### PR TITLE
Refactor the Document classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 script:
-  - bundle exec rake test:web
+  - bundle exec rake
 sudo: false
 rvm:
   - 2.3.1

--- a/app.rb
+++ b/app.rb
@@ -3,7 +3,7 @@ require 'everypolitician'
 
 require_relative 'lib/document/frontmatter'
 require_relative 'lib/document/markdown'
-require_relative 'lib/document/document'
+require_relative 'lib/document/markdown_with_frontmatter'
 
 set :datasource, ENV.fetch('DATASOURCE', 'https://github.com/everypolitician/everypolitician-data/raw/master/countries.json')
 set :index, EveryPolitician::Index.new(index_url: settings.datasource)
@@ -24,7 +24,7 @@ end
 
 get '/blog/' do
   @posts = Dir.glob("#{prose_dir('posts')}/*.md").map do |filename|
-    Document::Document.new(filename: filename, baseurl: '/blog/')
+    Document::MarkdownWithFrontmatter.new(filename: filename, baseurl: '/blog/')
   end.sort_by { |d| d.date }.reverse
   erb :posts
 end
@@ -34,6 +34,6 @@ get '/blog/:slug' do |slug|
   posts = Dir.glob("#{prose_dir('posts')}/#{date_glob}-#{slug}.md")
   raise Sinatra::NotFound if posts.length == 0
   raise "Multiple posts matched '#{slug}': #{posts}" if posts.length > 1
-  @post = Document::Document.new(filename: posts[0], baseurl: '/blog/')
+  @post = Document::MarkdownWithFrontmatter.new(filename: posts[0], baseurl: '/blog/')
   erb :post
 end

--- a/app.rb
+++ b/app.rb
@@ -1,7 +1,7 @@
 require 'sinatra'
 require 'everypolitician'
 
-require_relative 'lib/document/frontmatter'
+require_relative 'lib/document/frontmatter_parser'
 require_relative 'lib/document/markdown'
 require_relative 'lib/document/markdown_with_frontmatter'
 

--- a/app.rb
+++ b/app.rb
@@ -2,7 +2,7 @@ require 'sinatra'
 require 'everypolitician'
 
 require_relative 'lib/document/frontmatter_parser'
-require_relative 'lib/document/markdown'
+require_relative 'lib/document/markdown_parser'
 require_relative 'lib/document/markdown_with_frontmatter'
 
 set :datasource, ENV.fetch('DATASOURCE', 'https://github.com/everypolitician/everypolitician-data/raw/master/countries.json')

--- a/app.rb
+++ b/app.rb
@@ -1,8 +1,6 @@
 require 'sinatra'
 require 'everypolitician'
 
-require_relative 'lib/document/frontmatter_parser'
-require_relative 'lib/document/markdown_parser'
 require_relative 'lib/document/markdown_with_frontmatter'
 
 set :datasource, ENV.fetch('DATASOURCE', 'https://github.com/everypolitician/everypolitician-data/raw/master/countries.json')

--- a/lib/document/document.rb
+++ b/lib/document/document.rb
@@ -32,12 +32,16 @@ module Document
 
     attr_reader :filename, :baseurl
 
+    def filecontents
+      @contents ||= File.open(filename, 'r') { |f| f.read }
+    end
+
     def frontmatter
-      @frontmatter ||= Frontmatter.new(filename: filename)
+      @frontmatter ||= Frontmatter.new(filecontents: filecontents)
     end
 
     def markdown
-      @markdown ||= Markdown.new(filename: filename)
+      @markdown ||= Markdown.new(filecontents: filecontents)
     end
   end
 end

--- a/lib/document/frontmatter.rb
+++ b/lib/document/frontmatter.rb
@@ -3,8 +3,8 @@ require 'yaml'
 
 module Document
   class Frontmatter
-    def initialize(filename:)
-      @filename = filename
+    def initialize(filecontents:)
+      @filecontents = filecontents
     end
 
     def title
@@ -21,10 +21,10 @@ module Document
 
     private
 
-    attr_reader :filename
+    attr_reader :filecontents
 
     def parse
-      @hash_memo ||= YAML::load_file(filename) || {}
+      YAML::load(filecontents) || {}
     end
 
     def fetch(key, default_value = '')

--- a/lib/document/frontmatter_parser.rb
+++ b/lib/document/frontmatter_parser.rb
@@ -2,7 +2,7 @@
 require 'yaml'
 
 module Document
-  class Frontmatter
+  class FrontmatterParser
     def initialize(filecontents:)
       @filecontents = filecontents
     end

--- a/lib/document/markdown.rb
+++ b/lib/document/markdown.rb
@@ -8,12 +8,12 @@ module Document
     #     lib/jekyll/document.rb#L10
     YAML_FRONT_MATTER_REGEXP = %r!\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)!m
 
-    def initialize(filename:)
-      @filename = filename
+    def initialize(filecontents:)
+      @filecontents = filecontents
     end
 
     def raw
-      contents.sub(YAML_FRONT_MATTER_REGEXP, '')
+      filecontents.sub(YAML_FRONT_MATTER_REGEXP, '')
     end
 
     def as_html
@@ -22,20 +22,10 @@ module Document
 
     private
 
-    attr_reader :filename
-
-    def file
-      @file_memo ||= File.open(filename, 'r')
-    end
+    attr_reader :filecontents
 
     def parser
       @parser ||= RDiscount.new(raw)
-    end
-
-    def contents
-      @contents ||= file.read
-      file.close
-      @contents
     end
   end
 end

--- a/lib/document/markdown_parser.rb
+++ b/lib/document/markdown_parser.rb
@@ -2,7 +2,7 @@
 require 'rdiscount'
 
 module Document
-  class Markdown
+  class MarkdownParser
     # Regex from Jekyll
     # https://github.com/jekyll/jekyll/blob/fac041933c3e328ff73dc91faeaeb08182ae3c74/
     #     lib/jekyll/document.rb#L10

--- a/lib/document/markdown_with_frontmatter.rb
+++ b/lib/document/markdown_with_frontmatter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Document
-  class Document
+  class MarkdownWithFrontmatter
     def initialize(filename:, baseurl:)
       @filename = filename
       @baseurl = baseurl

--- a/lib/document/markdown_with_frontmatter.rb
+++ b/lib/document/markdown_with_frontmatter.rb
@@ -37,7 +37,7 @@ module Document
     end
 
     def frontmatter
-      @frontmatter ||= Frontmatter.new(filecontents: filecontents)
+      @frontmatter ||= FrontmatterParser.new(filecontents: filecontents)
     end
 
     def markdown

--- a/lib/document/markdown_with_frontmatter.rb
+++ b/lib/document/markdown_with_frontmatter.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+require_relative 'frontmatter_parser'
+require_relative 'markdown_parser'
+
 module Document
   class MarkdownWithFrontmatter
     def initialize(filename:, baseurl:)

--- a/lib/document/markdown_with_frontmatter.rb
+++ b/lib/document/markdown_with_frontmatter.rb
@@ -10,7 +10,7 @@ module Document
     end
 
     def date
-      Date.iso8601($1) if /^(\d{4}-\d{2}-\d{2})/ =~ File.basename(filename)
+      Date.iso8601($1) if /^(\d{4}-\d{2}-\d{2})/ =~ basename
     end
 
     def title
@@ -32,6 +32,10 @@ module Document
     private
 
     attr_reader :filename, :baseurl
+
+    def basename
+      File.basename(filename)
+    end
 
     def filecontents
       @contents ||= File.open(filename, 'r') { |f| f.read }

--- a/lib/document/markdown_with_frontmatter.rb
+++ b/lib/document/markdown_with_frontmatter.rb
@@ -41,7 +41,7 @@ module Document
     end
 
     def markdown
-      @markdown ||= Markdown.new(filecontents: filecontents)
+      @markdown ||= MarkdownParser.new(filecontents: filecontents)
     end
   end
 end

--- a/lib/document/markdown_with_frontmatter.rb
+++ b/lib/document/markdown_with_frontmatter.rb
@@ -7,10 +7,10 @@ module Document
     def initialize(filename:, baseurl:)
       @filename = filename
       @baseurl = baseurl
-      @date = nil
-      if /^(\d{4}-\d{2}-\d{2})/ =~ File.basename(filename)
-        @date = Date.iso8601($1)
-      end
+    end
+
+    def date
+      Date.iso8601($1) if /^(\d{4}-\d{2}-\d{2})/ =~ File.basename(filename)
     end
 
     def title
@@ -28,8 +28,6 @@ module Document
     def body
       markdown.as_html
     end
-
-    attr_reader :date
 
     private
 

--- a/tests/document/frontmatter.rb
+++ b/tests/document/frontmatter.rb
@@ -1,41 +1,42 @@
 # frozen_string_literal: true
 require 'test_helper'
 require_relative '../../lib/document/frontmatter'
+
 describe 'Document::Frontmatter' do
   describe 'when file has frontmatter' do
     it 'finds the title' do
       contents = '---
 title: A Title
 ---'
-      Document::Frontmatter.new(filecontents: contents).title.must_equal('A Title')
+      parser(contents).title.must_equal('A Title')
     end
 
     it 'returns an empty string if there is no title' do
       contents = '---
 foo: bar
 ---'
-      Document::Frontmatter.new(filecontents: contents).title.must_equal('')
+      parser(contents).title.must_equal('')
     end
 
     it 'finds the slug' do
       contents = '---
 slug: a-slug
 ---'
-      Document::Frontmatter.new(filecontents: contents).slug.must_equal('a-slug')
+      parser(contents).slug.must_equal('a-slug')
     end
 
     it 'knows if it is published' do
       contents = '---
 published: false
 ---'
-      Document::Frontmatter.new(filecontents: contents).published?.must_equal(false)
+      parser(contents).published?.must_equal(false)
     end
 
     it 'publishes by default if there is no published field' do
       contents = '---
 foo: bar
 ---'
-      Document::Frontmatter.new(filecontents: contents).published?.must_equal(true)
+      parser(contents).published?.must_equal(true)
     end
   end
 
@@ -45,7 +46,7 @@ foo: bar
 title: A Title
 ---
 # some markdown here'
-      Document::Frontmatter.new(filecontents: contents).title.must_equal('A Title')
+      parser(contents).title.must_equal('A Title')
     end
   end
 
@@ -53,14 +54,18 @@ title: A Title
     it 'sends an empty field' do
       contents = '---
 ---'
-      Document::Frontmatter.new(filecontents: contents).title.must_equal('')
+      parser(contents).title.must_equal('')
     end
   end
 
   describe 'when file is empty' do
     it 'does not break' do
       contents = ''
-      Document::Frontmatter.new(filecontents: contents).title.must_equal('')
+      parser(contents).title.must_equal('')
     end
+  end
+
+  def parser(contents)
+    Document::Frontmatter.new(filecontents: contents)
   end
 end

--- a/tests/document/frontmatter.rb
+++ b/tests/document/frontmatter.rb
@@ -1,67 +1,66 @@
 # frozen_string_literal: true
 require 'test_helper'
 require_relative '../../lib/document/frontmatter'
-
 describe 'Document::Frontmatter' do
   describe 'when file has frontmatter' do
     it 'finds the title' do
-      file = new_file('---
+      contents = '---
 title: A Title
----')
-      Document::Frontmatter.new(filename: file.path).title.must_equal('A Title')
+---'
+      Document::Frontmatter.new(filecontents: contents).title.must_equal('A Title')
     end
 
     it 'returns an empty string if there is no title' do
-      file = new_file('---
+      contents = '---
 foo: bar
----')
-      Document::Frontmatter.new(filename: file.path).title.must_equal('')
+---'
+      Document::Frontmatter.new(filecontents: contents).title.must_equal('')
     end
 
     it 'finds the slug' do
-      file = new_file('---
+      contents = '---
 slug: a-slug
----')
-      Document::Frontmatter.new(filename: file.path).slug.must_equal('a-slug')
+---'
+      Document::Frontmatter.new(filecontents: contents).slug.must_equal('a-slug')
     end
 
     it 'knows if it is published' do
-      file = new_file('---
+      contents = '---
 published: false
----')
-      Document::Frontmatter.new(filename: file.path).published?.must_equal(false)
+---'
+      Document::Frontmatter.new(filecontents: contents).published?.must_equal(false)
     end
 
     it 'publishes by default if there is no published field' do
-      file = new_file('---
+      contents = '---
 foo: bar
----')
-      Document::Frontmatter.new(filename: file.path).published?.must_equal(true)
+---'
+      Document::Frontmatter.new(filecontents: contents).published?.must_equal(true)
     end
   end
 
   describe 'when file has frontmatter and markdown' do
     it 'still finds the title' do
-      file = new_file('---
+      contents = '---
 title: A Title
 ---
-# some markdown here')
-      Document::Frontmatter.new(filename: file.path).title.must_equal('A Title')
+# some markdown here'
+      Document::Frontmatter.new(filecontents: contents).title.must_equal('A Title')
     end
   end
 
   describe 'when frontmatter is empty' do
     it 'sends an empty field' do
-      file = new_file('---
----')
-      Document::Frontmatter.new(filename: file.path).title.must_equal('')
+      contents = '---
+---'
+      Document::Frontmatter.new(filecontents: contents).title.must_equal('')
     end
   end
 
   describe 'when file is empty' do
     it 'does not break' do
-      file = new_file('')
-      Document::Frontmatter.new(filename: file.path).title.must_equal('')
+      contents = ''
+      Document::Frontmatter.new(filecontents: contents).title.must_equal('')
     end
   end
 end

--- a/tests/document/frontmatter_parser.rb
+++ b/tests/document/frontmatter_parser.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../lib/document/frontmatter'
+require_relative '../../lib/document/frontmatter_parser'
 
-describe 'Document::Frontmatter' do
+describe 'Document::FrontmatterParser' do
   describe 'when file has frontmatter' do
     it 'finds the title' do
       contents = '---
@@ -66,6 +66,6 @@ title: A Title
   end
 
   def parser(contents)
-    Document::Frontmatter.new(filecontents: contents)
+    Document::FrontmatterParser.new(filecontents: contents)
   end
 end

--- a/tests/document/markdown.rb
+++ b/tests/document/markdown.rb
@@ -5,40 +5,40 @@ require_relative '../../lib/document/markdown'
 describe 'Document::Markdown' do
   describe '#raw' do
     it 'detects an empty file' do
-      file = new_file('')
-      Document::Markdown.new(filename: file.path).raw.must_equal('')
+      contents = ''
+      Document::Markdown.new(filecontents: contents).raw.must_equal('')
     end
 
     it 'returns nothing if there is frontmatter but no markdown' do
-      file = new_file('---
+      contents = '---
 foo: bar
----')
-      Document::Markdown.new(filename: file.path).raw.must_equal('')
+---'
+      Document::Markdown.new(filecontents: contents).raw.must_equal('')
     end
 
     it 'returns only markdown if there is no frontmatter' do
-      file = new_file('# A markdown header')
-      markdown = Document::Markdown.new(filename: file.path)
+      contents = '# A markdown header'
+      markdown = Document::Markdown.new(filecontents: contents)
       markdown.raw.must_equal('# A markdown header')
     end
 
     it 'returns only markdown if it has a frontmatter' do
-      file = new_file('---
+      contents = '---
 foo: bar
 ---
-# A markdown header')
-      markdown = Document::Markdown.new(filename: file.path)
+# A markdown header'
+      markdown = Document::Markdown.new(filecontents: contents)
       markdown.raw.must_equal('# A markdown header')
     end
   end
 
   describe '#as_html' do
     it 'returns html from markdown' do
-      file = new_file('---
+      contents = '---
 foo: bar
 ---
-# A markdown header')
-      markdown = Document::Markdown.new(filename: file.path)
+# A markdown header'
+      markdown = Document::Markdown.new(filecontents: contents)
       markdown.as_html.strip.must_equal('<h1>A markdown header</h1>')
     end
   end

--- a/tests/document/markdown.rb
+++ b/tests/document/markdown.rb
@@ -6,20 +6,19 @@ describe 'Document::Markdown' do
   describe '#raw' do
     it 'detects an empty file' do
       contents = ''
-      Document::Markdown.new(filecontents: contents).raw.must_equal('')
+      parser(contents).raw.must_equal('')
     end
 
     it 'returns nothing if there is frontmatter but no markdown' do
       contents = '---
 foo: bar
 ---'
-      Document::Markdown.new(filecontents: contents).raw.must_equal('')
+      parser(contents).raw.must_equal('')
     end
 
     it 'returns only markdown if there is no frontmatter' do
       contents = '# A markdown header'
-      markdown = Document::Markdown.new(filecontents: contents)
-      markdown.raw.must_equal('# A markdown header')
+      parser(contents).raw.must_equal('# A markdown header')
     end
 
     it 'returns only markdown if it has a frontmatter' do
@@ -27,8 +26,7 @@ foo: bar
 foo: bar
 ---
 # A markdown header'
-      markdown = Document::Markdown.new(filecontents: contents)
-      markdown.raw.must_equal('# A markdown header')
+      parser(contents).raw.must_equal('# A markdown header')
     end
   end
 
@@ -38,8 +36,11 @@ foo: bar
 foo: bar
 ---
 # A markdown header'
-      markdown = Document::Markdown.new(filecontents: contents)
-      markdown.as_html.strip.must_equal('<h1>A markdown header</h1>')
+      parser(contents).as_html.strip.must_equal('<h1>A markdown header</h1>')
     end
+  end
+
+  def parser(contents)
+    Document::Markdown.new(filecontents: contents)
   end
 end

--- a/tests/document/markdown_parser.rb
+++ b/tests/document/markdown_parser.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../lib/document/markdown'
+require_relative '../../lib/document/markdown_parser'
 
-describe 'Document::Markdown' do
+describe 'Document::MarkdownParser' do
   describe '#raw' do
     it 'detects an empty file' do
       contents = ''
@@ -41,6 +41,6 @@ foo: bar
   end
 
   def parser(contents)
-    Document::Markdown.new(filecontents: contents)
+    Document::MarkdownParser.new(filecontents: contents)
   end
 end

--- a/tests/document/markdown_with_frontmatter.rb
+++ b/tests/document/markdown_with_frontmatter.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../lib/document/document'
+require_relative '../../lib/document/markdown_with_frontmatter'
 
-describe 'Document::Document' do
+describe 'Document::MarkdownWithFrontmatter' do
   let(:file) { new_file('---
 title: A Title
 slug: a-slug
 published: true
 ---
-# Hello World') }
-  let(:document) { Document::Document.new(filename: file.path, baseurl: '/events/') }
+# Hello World')
+  }
+  let(:document) { Document::MarkdownWithFrontmatter.new(
+    filename: file.path,
+    baseurl: '/events/')
+  }
 
   it 'has a title' do
     document.title.must_equal('A Title')

--- a/tests/document/markdown_with_frontmatter.rb
+++ b/tests/document/markdown_with_frontmatter.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 require_relative '../../lib/document/markdown_with_frontmatter'
 
 describe 'Document::MarkdownWithFrontmatter' do
-  let(:file) { new_file('---
+  let(:filename) { new_tempfile('---
 title: A Title
 slug: a-slug
 published: true
@@ -11,7 +11,7 @@ published: true
 # Hello World')
   }
   let(:document) { Document::MarkdownWithFrontmatter.new(
-    filename: file.path,
+    filename: filename,
     baseurl: '/events/')
   }
 
@@ -32,9 +32,9 @@ published: true
   end
 
   it 'has a date' do
-    file = new_file('', '1000-10-01-filename')
+    filename_with_date = new_tempfile('', '1000-10-01-filename')
     document = Document::MarkdownWithFrontmatter.new(
-      filename: file.path,
+      filename: filename_with_date,
       baseurl: '/events/'
     )
     document.date.year.must_equal(1000)

--- a/tests/document/markdown_with_frontmatter.rb
+++ b/tests/document/markdown_with_frontmatter.rb
@@ -30,4 +30,15 @@ published: true
   it 'has a body' do
     document.body.strip.must_equal('<h1>Hello World</h1>')
   end
+
+  it 'has a date' do
+    file = new_file('', '1000-10-01-filename')
+    document = Document::MarkdownWithFrontmatter.new(
+      filename: file.path,
+      baseurl: '/events/'
+    )
+    document.date.year.must_equal(1000)
+    document.date.month.must_equal(10)
+    document.date.day.must_equal(1)
+  end
 end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -15,11 +15,11 @@ module Minitest
       Sinatra::Application
     end
 
-    def new_file(contents, filename = 'foo')
-      file = Tempfile.new([filename, '.md'])
-      file.write(contents)
-      file.close
-      file
+    def new_tempfile(contents, filename = 'sye-tests')
+      Tempfile.open([filename, '.md']) do |f|
+        f.write(contents)
+        f.path
+      end
     end
   end
 end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -15,8 +15,8 @@ module Minitest
       Sinatra::Application
     end
 
-    def new_file(contents)
-      file = Tempfile.new(['foo', '.md'])
+    def new_file(contents, filename = 'foo')
+      file = Tempfile.new([filename, '.md'])
       file.write(contents)
       file.close
       file


### PR DESCRIPTION
The document classes needed a bit of attention as they were made in a bit of a rush.
This PR refactors some of the code, basically:

* Makes the markdown and frontmatter parsers take the contents of the file to parse as an argument in the constructor, instead of each of them opening the same file (plus the document class which was also opening it)! Now the file is opened once, in the document class, and its contents passed to Markdown and Frontmatter.

* Renames the document class to `MarkdownWithFrontmatter` as suggested by Mark, and also renames `Markdown` and `Frontmatter` to `MarkdownParser` and `FrontmatterParser`. Hopefully with this we have more of a DSL.

* The date class member was refactored into a method which allows to remove that logic from the constructor. Also, a test was added for it.

## Notes to merger
This PR should be merged after #2 