### PR TITLE
Update blog views

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
 script:
+  - bin/deploy
   - bundle exec rake
 sudo: false
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,5 @@ group :test do
   gem 'minitest'
   gem 'pry'
   gem 'rack-test'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     chunky_png (1.3.8)
     coderay (1.1.1)
     compass (1.0.3)
@@ -23,9 +25,12 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     everypolitician-popolo (0.8.0)
       require_all
     ffi (1.9.14)
+    hashdiff (0.3.0)
     method_source (0.8.2)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
@@ -36,6 +41,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    public_suffix (2.0.4)
     rack (1.6.5)
     rack-protection (1.5.3)
       rack
@@ -47,6 +53,7 @@ GEM
       ffi (>= 0.5.0)
     rdiscount (2.2.0.1)
     require_all (1.3.3)
+    safe_yaml (1.0.4)
     sass (3.4.22)
     sinatra (1.4.7)
       rack (~> 1.5)
@@ -54,6 +61,10 @@ GEM
       tilt (>= 1.3, < 3)
     slop (3.6.0)
     tilt (2.0.5)
+    webmock (2.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -68,6 +79,7 @@ DEPENDENCIES
   rake
   rdiscount
   sinatra
+  webmock
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,5 @@
-require 'sinatra'
 require 'everypolitician'
+require 'sinatra'
 
 require_relative 'lib/document/markdown_with_frontmatter'
 

--- a/app.rb
+++ b/app.rb
@@ -26,6 +26,7 @@ end
 
 get '/blog/:slug' do |slug|
   @page = Page::Post.new(directory: posts_dir, slug: slug)
+  raise Sinatra::NotFound if @page.none?
   raise "Multiple posts matched '#{slug}'" if @page.multiple?
   erb :post
 end

--- a/app.rb
+++ b/app.rb
@@ -26,5 +26,6 @@ end
 
 get '/blog/:slug' do |slug|
   @page = Page::Post.new(directory: posts_dir, slug: slug)
+  raise "Multiple posts matched '#{slug}'" if @page.multiple?
   erb :post
 end

--- a/app.rb
+++ b/app.rb
@@ -5,7 +5,6 @@ require_relative 'lib/document/markdown_with_frontmatter'
 
 set :datasource, ENV.fetch('DATASOURCE', 'https://github.com/everypolitician/everypolitician-data/raw/master/countries.json')
 set :index, EveryPolitician::Index.new(index_url: settings.datasource)
-set :country, settings.index.country('Nigeria')
 
 def prose_dir(directory)
   File.join(__dir__, 'prose', directory)
@@ -16,7 +15,7 @@ get '/' do
 end
 
 get '/places/' do
-  @country = settings.country
+  @country = settings.index.country('Nigeria')
   erb :places
 end
 

--- a/app.rb
+++ b/app.rb
@@ -4,6 +4,7 @@ require 'sinatra'
 require_relative 'lib/document/markdown_with_frontmatter'
 require_relative 'lib/helpers/constants_helper'
 require_relative 'lib/page/posts'
+require_relative 'lib/page/post'
 
 set :datasource, ENV.fetch('DATASOURCE', 'https://github.com/everypolitician/everypolitician-data/raw/master/countries.json')
 set :index, EveryPolitician::Index.new(index_url: settings.datasource)
@@ -24,10 +25,6 @@ get '/blog/' do
 end
 
 get '/blog/:slug' do |slug|
-  date_glob = '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
-  posts = Dir.glob("#{posts_dir}/#{date_glob}-#{slug}.md")
-  raise Sinatra::NotFound if posts.length == 0
-  raise "Multiple posts matched '#{slug}': #{posts}" if posts.length > 1
-  @post = Document::MarkdownWithFrontmatter.new(filename: posts[0], baseurl: '/blog/')
+  @page = Page::Post.new(directory: posts_dir, slug: slug)
   erb :post
 end

--- a/app.rb
+++ b/app.rb
@@ -3,6 +3,7 @@ require 'sinatra'
 
 require_relative 'lib/document/markdown_with_frontmatter'
 require_relative 'lib/helpers/constants_helper'
+require_relative 'lib/page/posts'
 
 set :datasource, ENV.fetch('DATASOURCE', 'https://github.com/everypolitician/everypolitician-data/raw/master/countries.json')
 set :index, EveryPolitician::Index.new(index_url: settings.datasource)
@@ -18,9 +19,7 @@ get '/places/' do
 end
 
 get '/blog/' do
-  @posts = Dir.glob("#{posts_dir}/*.md").map do |filename|
-    Document::MarkdownWithFrontmatter.new(filename: filename, baseurl: '/blog/')
-  end.sort_by { |d| d.date }.reverse
+  @page = Page::Posts.new(directory: posts_dir)
   erb :posts
 end
 

--- a/app.rb
+++ b/app.rb
@@ -2,13 +2,11 @@ require 'everypolitician'
 require 'sinatra'
 
 require_relative 'lib/document/markdown_with_frontmatter'
+require_relative 'lib/helpers/constants_helper'
 
 set :datasource, ENV.fetch('DATASOURCE', 'https://github.com/everypolitician/everypolitician-data/raw/master/countries.json')
 set :index, EveryPolitician::Index.new(index_url: settings.datasource)
-
-def prose_dir(directory)
-  File.join(__dir__, 'prose', directory)
-end
+set :content_dir, File.join(__dir__, 'prose')
 
 get '/' do
   erb :homepage
@@ -20,7 +18,7 @@ get '/places/' do
 end
 
 get '/blog/' do
-  @posts = Dir.glob("#{prose_dir('posts')}/*.md").map do |filename|
+  @posts = Dir.glob("#{posts_dir}/*.md").map do |filename|
     Document::MarkdownWithFrontmatter.new(filename: filename, baseurl: '/blog/')
   end.sort_by { |d| d.date }.reverse
   erb :posts
@@ -28,7 +26,7 @@ end
 
 get '/blog/:slug' do |slug|
   date_glob = '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
-  posts = Dir.glob("#{prose_dir('posts')}/#{date_glob}-#{slug}.md")
+  posts = Dir.glob("#{posts_dir}/#{date_glob}-#{slug}.md")
   raise Sinatra::NotFound if posts.length == 0
   raise "Multiple posts matched '#{slug}': #{posts}" if posts.length > 1
   @post = Document::MarkdownWithFrontmatter.new(filename: posts[0], baseurl: '/blog/')

--- a/lib/document/markdown_with_frontmatter.rb
+++ b/lib/document/markdown_with_frontmatter.rb
@@ -10,7 +10,7 @@ module Document
     end
 
     def date
-      Date.iso8601($1) if /^(\d{4}-\d{2}-\d{2})/ =~ basename
+      Date.iso8601($1) if DATE_PATTERN =~ basename
     end
 
     def title
@@ -18,7 +18,7 @@ module Document
     end
 
     def url
-      baseurl + frontmatter.slug
+      baseurl + slug
     end
 
     def published?
@@ -31,10 +31,24 @@ module Document
 
     private
 
+    DATE_PATTERN = /^(\d{4}-\d{2}-\d{2})/
     attr_reader :filename, :baseurl
 
     def basename
       File.basename(filename)
+    end
+
+    def extname
+      File.extname(filename)
+    end
+
+    def rawname
+      basename.gsub(DATE_PATTERN, '').gsub(extname, '')[1..-1]
+    end
+
+    def slug
+      slug = frontmatter.slug
+      slug.empty? ? rawname : slug
     end
 
     def filecontents

--- a/lib/helpers/constants_helper.rb
+++ b/lib/helpers/constants_helper.rb
@@ -1,0 +1,11 @@
+module ConstantsHelper
+  def content_dir
+    settings.content_dir
+  end
+
+  def posts_dir
+    "#{content_dir}/posts"
+  end
+end
+
+helpers ConstantsHelper

--- a/lib/page/post.rb
+++ b/lib/page/post.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require_relative '../document/markdown_with_frontmatter'
+
+module Page
+  class Post
+    BASEURL = '/blog/'
+
+    def initialize(directory:, slug:)
+      @directory = directory
+      @slug = slug
+    end
+
+    def title
+      post.title
+    end
+
+    def date
+      post.date.strftime("%B %-d, %Y")
+    end
+
+    def body
+      post.body
+    end
+
+    private
+
+    attr_reader :directory, :slug
+
+    def found
+      @found ||= Dir.glob(pattern)
+    end
+
+    def pattern
+      date_glob = '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+      "#{directory}/#{date_glob}-#{slug}.md"
+    end
+
+    def post
+      Document::MarkdownWithFrontmatter.new(filename: found.first, baseurl: 'BASEURL')
+    end
+  end
+end

--- a/lib/page/post.rb
+++ b/lib/page/post.rb
@@ -26,6 +26,10 @@ module Page
       found.size > 1
     end
 
+    def none?
+      found.empty?
+    end
+
     private
 
     attr_reader :directory, :slug

--- a/lib/page/post.rb
+++ b/lib/page/post.rb
@@ -22,6 +22,10 @@ module Page
       post.body
     end
 
+    def multiple?
+      found.size > 1
+    end
+
     private
 
     attr_reader :directory, :slug

--- a/lib/page/posts.rb
+++ b/lib/page/posts.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require_relative '../document/markdown_with_frontmatter'
+
+module Page
+  class Posts
+    BASEURL = '/blog/'
+
+    def initialize(directory:)
+      @directory = directory
+    end
+
+    def sorted_posts
+      posts.sort_by { |d| d.date }.reverse
+    end
+
+    def format_date(date)
+      date.strftime("%B %-d, %Y")
+    end
+
+    private
+
+    attr_reader :directory
+
+    def posts
+      filenames.map { |filename| create_post(filename) }
+    end
+
+    def filenames
+      @filenames ||= Dir.glob(pattern)
+    end
+
+    def pattern
+      date_glob = '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+      "#{directory}/#{date_glob}-*.md"
+    end
+
+    def create_post(filename)
+      Document::MarkdownWithFrontmatter.new(filename: filename, baseurl: BASEURL)
+    end
+  end
+end

--- a/tests/document/markdown_with_frontmatter.rb
+++ b/tests/document/markdown_with_frontmatter.rb
@@ -41,4 +41,14 @@ published: true
     document.date.month.must_equal(10)
     document.date.day.must_equal(1)
   end
+
+  describe 'when there is no slug field' do
+    it 'builds the url from the filename' do
+      document = Document::MarkdownWithFrontmatter.new(
+        filename: new_tempfile('', '2000-20-02-file-name'),
+        baseurl: '/somepath/'
+      )
+      document.url.must_include('/somepath/file-name')
+    end
+  end
 end

--- a/tests/document/markdown_with_frontmatter.rb
+++ b/tests/document/markdown_with_frontmatter.rb
@@ -3,15 +3,14 @@ require 'test_helper'
 require_relative '../../lib/document/markdown_with_frontmatter'
 
 describe 'Document::MarkdownWithFrontmatter' do
-  let(:filename) { new_tempfile('---
+  let(:contents) { '---
 title: A Title
 slug: a-slug
 published: true
 ---
-# Hello World')
-  }
+# Hello World' }
   let(:document) { Document::MarkdownWithFrontmatter.new(
-    filename: filename,
+    filename: new_tempfile(contents, '1000-10-01-file-name'),
     baseurl: '/events/')
   }
 
@@ -32,11 +31,6 @@ published: true
   end
 
   it 'has a date' do
-    filename_with_date = new_tempfile('', '1000-10-01-filename')
-    document = Document::MarkdownWithFrontmatter.new(
-      filename: filename_with_date,
-      baseurl: '/events/'
-    )
     document.date.year.must_equal(1000)
     document.date.month.must_equal(10)
     document.date.day.must_equal(1)

--- a/tests/fixtures/ep_data/75b7651/ep-popolo-v1.0.json
+++ b/tests/fixtures/ep_data/75b7651/ep-popolo-v1.0.json
@@ -1,0 +1,12606 @@
+{
+  "posts": [
+
+  ],
+  "persons": [
+    {
+      "id": "b2a7f72a-9ecf-4263-83f1-cb0f8783053c",
+      "identifiers": [
+        {
+          "identifier": "546",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/546.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/546.jpg"
+        }
+      ],
+      "name": "ABDUKADIR RAHIS",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/546"
+        }
+      ]
+    },
+    {
+      "id": "8ab0069f-7c0f-4fcb-8b93-486432b7520a",
+      "identifiers": [
+        {
+          "identifier": "581",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/581.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/581.jpg"
+        }
+      ],
+      "name": "ABDUL-MALIC ZUBAIRU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/581"
+        }
+      ]
+    },
+    {
+      "id": "764fce72-c12a-42ad-ba84-d899f81f7a77",
+      "identifiers": [
+        {
+          "identifier": "685",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ABDULAHI FARUK",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/685"
+        }
+      ]
+    },
+    {
+      "id": "9cac82e2-515f-492b-90f5-343530a48f0a",
+      "identifiers": [
+        {
+          "identifier": "733",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ABDULLAHI HASSAN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/733"
+        }
+      ]
+    },
+    {
+      "id": "1acd5fb5-c9ee-41e2-8236-8e7e64ba5207",
+      "identifiers": [
+        {
+          "identifier": "921",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ABDULLAHI MOHAMMED",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/921"
+        }
+      ]
+    },
+    {
+      "id": "dfeacf04-9bd5-4f12-8440-2cb91b58ac9a",
+      "identifiers": [
+        {
+          "identifier": "923",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ABDULMUMIN JIBRIN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/923"
+        }
+      ]
+    },
+    {
+      "id": "8643dbb1-57e4-4c5a-a34d-dcc76eb18a0c",
+      "identifiers": [
+        {
+          "identifier": "723",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ABDULRAZAK NAMDAS",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/723"
+        }
+      ]
+    },
+    {
+      "id": "b62f18fc-dd29-4b02-a5f7-95a42f956543",
+      "identifiers": [
+        {
+          "identifier": "932",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ABDUSSAMAD DASUKI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/932"
+        }
+      ]
+    },
+    {
+      "id": "50cb2a99-49a0-4ea7-b5a5-65a0bd7ede30",
+      "identifiers": [
+        {
+          "identifier": "598",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ABUBAKAR AMUDA-KANNIKE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/598"
+        }
+      ]
+    },
+    {
+      "id": "58a2855c-7b99-4837-b234-deed1fc2404a",
+      "identifiers": [
+        {
+          "identifier": "586",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/586.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/586.jpg"
+        }
+      ],
+      "name": "ABUBAKAR DAHIRU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/586"
+        }
+      ]
+    },
+    {
+      "id": "d1b39c93-9087-4da4-adc4-e1ae99b35fc3",
+      "identifiers": [
+        {
+          "identifier": "656",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ABUBAKAR LADO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/656"
+        }
+      ]
+    },
+    {
+      "id": "5198eacc-97f8-4eb1-9ad9-1895cb5cb979",
+      "identifiers": [
+        {
+          "identifier": "642",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ABUBAKAR LAWAL",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/642"
+        }
+      ]
+    },
+    {
+      "id": "543f5de3-208e-40fb-8925-a3717d098ab0",
+      "identifiers": [
+        {
+          "identifier": "504",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ACHARU OCHIJENU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/504"
+        }
+      ]
+    },
+    {
+      "id": "dee1b701-c30c-4161-815a-54dc12048c41",
+      "identifiers": [
+        {
+          "identifier": "900",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ADAMU GURAI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/900"
+        }
+      ]
+    },
+    {
+      "id": "d0ca0091-8bde-4f07-aa4c-ad6c7f2506ea",
+      "identifiers": [
+        {
+          "identifier": "797",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ADAMU JAGABA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/797"
+        }
+      ]
+    },
+    {
+      "id": "c8f995d8-29b6-43d2-b2cb-77a12a68b588",
+      "identifiers": [
+        {
+          "identifier": "903",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ADAMU KAMALE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/903"
+        }
+      ]
+    },
+    {
+      "id": "a4683308-694e-4907-8eca-a6a968d9f3b8",
+      "identifiers": [
+        {
+          "identifier": "687",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ADAMU MUHAMMADU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/687"
+        }
+      ]
+    },
+    {
+      "id": "85a8d87b-5fe7-4c70-b1d7-512f8dba2178",
+      "identifiers": [
+        {
+          "identifier": "788",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ADAMU SALIHU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/788"
+        }
+      ]
+    },
+    {
+      "id": "b4771d4f-81fb-47ef-9631-9f8520b391ad",
+      "identifiers": [
+        {
+          "identifier": "674",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ADEBUTU OLADIPUPO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/674"
+        }
+      ]
+    },
+    {
+      "id": "8ecd73b9-0119-4f2a-9514-cf441b8246a2",
+      "identifiers": [
+        {
+          "identifier": "795",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ADEDAPO LAM-ADESINA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/795"
+        }
+      ]
+    },
+    {
+      "id": "dbbb2782-d52b-4594-8150-d98f73ad776e",
+      "identifiers": [
+        {
+          "identifier": "703",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ADEKOYA ADESSEGUN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/703"
+        }
+      ]
+    },
+    {
+      "id": "e1cda19f-f81d-4d7e-bfcf-5a5134cef83e",
+      "identifiers": [
+        {
+          "identifier": "623",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ADEKUNLE AKINLADE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/623"
+        }
+      ]
+    },
+    {
+      "id": "299c9fe3-3f1a-4a45-a1ea-d239a3968240",
+      "identifiers": [
+        {
+          "identifier": "782",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ADEYEMI ADEPOJU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/782"
+        }
+      ]
+    },
+    {
+      "id": "77e887ac-e9d6-46e6-8005-3b868b191617",
+      "identifiers": [
+        {
+          "identifier": "917",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/917.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/917.jpg"
+        }
+      ],
+      "name": "ADO ALHASSAN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/917"
+        }
+      ]
+    },
+    {
+      "id": "06356066-e59d-4182-b700-35120278bfdc",
+      "identifiers": [
+        {
+          "identifier": "553",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/553.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/553.jpg"
+        }
+      ],
+      "name": "ADO MUSA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/553"
+        }
+      ]
+    },
+    {
+      "id": "4aa3a1f8-6788-4acd-ab49-7108b92b187a",
+      "identifiers": [
+        {
+          "identifier": "680",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AGBEDI YEITIEMONE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/680"
+        }
+      ]
+    },
+    {
+      "id": "3f38fade-7505-4a43-b5d3-1d8d1afad279",
+      "identifiers": [
+        {
+          "identifier": "913",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AHMAD BABBA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/913"
+        }
+      ]
+    },
+    {
+      "id": "cacf9de6-c729-4ea1-904c-2ce0515940b8",
+      "identifiers": [
+        {
+          "identifier": "865",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AHMED ABU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/865"
+        }
+      ]
+    },
+    {
+      "id": "27b4d513-0f89-4e90-bc17-cc6f4c6f4789",
+      "identifiers": [
+        {
+          "identifier": "460",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/460.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/460.jpg"
+        }
+      ],
+      "name": "AHMED RUFAI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/460"
+        }
+      ]
+    },
+    {
+      "id": "ecad542f-6975-4a15-a31f-e2a8fbf041b4",
+      "identifiers": [
+        {
+          "identifier": "587",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/587.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/587.jpg"
+        }
+      ],
+      "name": "AHMED YERIMA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/587"
+        }
+      ]
+    },
+    {
+      "id": "71228aab-a8fa-4592-a7e8-f512b77f3c67",
+      "identifiers": [
+        {
+          "identifier": "696",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AINA THADDEUS",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/696"
+        }
+      ]
+    },
+    {
+      "id": "717fe4f9-c75a-475e-a549-84d845a34ab8",
+      "identifiers": [
+        {
+          "identifier": "579",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/579.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/579.jpg"
+        }
+      ],
+      "name": "AISHATU DUKKU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/579"
+        }
+      ]
+    },
+    {
+      "id": "a038a9a0-3752-40cd-80ab-0cb42be9c973",
+      "identifiers": [
+        {
+          "identifier": "898",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AISOWTEREN PATRICK",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/898"
+        }
+      ]
+    },
+    {
+      "id": "159dcd2b-8991-481c-bea3-797503de0f03",
+      "identifiers": [
+        {
+          "identifier": "773",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AJA SAMSON",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/773"
+        }
+      ]
+    },
+    {
+      "id": "090cdc38-e999-4530-af1f-f1b7ca7e4e01",
+      "identifiers": [
+        {
+          "identifier": "861",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AJANAH KABIR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/861"
+        }
+      ]
+    },
+    {
+      "id": "360ff59a-7382-4154-8a30-69f7f13912e6",
+      "identifiers": [
+        {
+          "identifier": "560",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/560.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/560.jpg"
+        }
+      ],
+      "name": "AJAYI ADEYIMKA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/560"
+        }
+      ]
+    },
+    {
+      "id": "3d2f6c9a-781b-42c6-8a3a-e6240efa9b4a",
+      "identifiers": [
+        {
+          "identifier": "363",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/363.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/363.jpg"
+        }
+      ],
+      "name": "AJAYI AYANTUNJI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/363"
+        }
+      ]
+    },
+    {
+      "id": "078f3198-ad87-45dd-8f6f-fa419eb79316",
+      "identifiers": [
+        {
+          "identifier": "799",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AJIBOLA FAMUREWA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/799"
+        }
+      ]
+    },
+    {
+      "id": "8d17036d-0d51-4fb3-82eb-d5c9f2e2b9e5",
+      "identifiers": [
+        {
+          "identifier": "754",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/754.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/754.jpg"
+        }
+      ],
+      "name": "AJISAFE OLOWOOKERE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/754"
+        }
+      ]
+    },
+    {
+      "id": "ade0005f-dccf-49dd-9f41-fefe8885beba",
+      "identifiers": [
+        {
+          "identifier": "790",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AKINJO VICTOR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/790"
+        }
+      ]
+    },
+    {
+      "id": "44fafa9a-f1f8-484b-8580-11f1ec116d39",
+      "identifiers": [
+        {
+          "identifier": "791",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AKINLAJA JOSEPH",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/791"
+        }
+      ]
+    },
+    {
+      "id": "ebe932ac-37bf-4d9d-8b48-d8541a7dbeec",
+      "identifiers": [
+        {
+          "identifier": "342",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/342.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/342.jpg"
+        }
+      ],
+      "name": "AKINLOYE BABAJIDE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/342"
+        }
+      ]
+    },
+    {
+      "id": "9b34c9ba-428f-4c08-9e05-716de04fcb06",
+      "identifiers": [
+        {
+          "identifier": "722",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AKINTOLA TAIWO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/722"
+        }
+      ]
+    },
+    {
+      "id": "ed21de44-634c-469b-aeb4-6310664dfdad",
+      "identifiers": [
+        {
+          "identifier": "743",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ALABI MOJEED",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/743"
+        }
+      ]
+    },
+    {
+      "id": "a526c57d-09d5-4230-97fd-f1cf98b359dc",
+      "identifiers": [
+        {
+          "identifier": "746",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/746.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/746.jpg"
+        }
+      ],
+      "name": "ALAGBAOSO JERRY",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/746"
+        }
+      ]
+    },
+    {
+      "id": "18dd9ba1-d20d-4eb6-89f0-b3db84c05246",
+      "identifiers": [
+        {
+          "identifier": "934",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ALBERT ADEOGUN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/934"
+        }
+      ]
+    },
+    {
+      "id": "3a8e8cdd-4467-4ff0-b61c-f786228424ab",
+      "identifiers": [
+        {
+          "identifier": "558",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/558.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/558.jpg"
+        }
+      ],
+      "name": "ALIYU AHMAN-PATEGI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/558"
+        }
+      ]
+    },
+    {
+      "id": "36aa99d5-6235-45b0-b831-58967b2555ed",
+      "identifiers": [
+        {
+          "identifier": "732",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ALIYU DANLADI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/732"
+        }
+      ]
+    },
+    {
+      "id": "5417f0ae-48a3-4e36-8d4b-820b75dfc976",
+      "identifiers": [
+        {
+          "identifier": "700",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ALIYU MADAKI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/700"
+        }
+      ]
+    },
+    {
+      "id": "3b78b18c-75cd-486f-905b-ee1291ff95c5",
+      "identifiers": [
+        {
+          "identifier": "563",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/563.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/563.jpg"
+        }
+      ],
+      "name": "AMINU ASHIRU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/563"
+        }
+      ]
+    },
+    {
+      "id": "bf2e026d-c295-496f-ac19-b0897e5f8e0b",
+      "identifiers": [
+        {
+          "identifier": "702",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AMINU ISA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/702"
+        }
+      ]
+    },
+    {
+      "id": "fb8aa21b-861f-489c-a935-87faa8c081f9",
+      "identifiers": [
+        {
+          "identifier": "920",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AMINU SHAGARI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/920"
+        }
+      ]
+    },
+    {
+      "id": "e4537751-d3a8-4805-b8c3-642f0fd7c5fb",
+      "identifiers": [
+        {
+          "identifier": "730",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AMIRUDDIN TUKUR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/730"
+        }
+      ]
+    },
+    {
+      "id": "ba539602-2401-4974-9ed9-1a5003028b39",
+      "identifiers": [
+        {
+          "identifier": "594",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/594.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/594.jpg"
+        }
+      ],
+      "name": "ANAYO NNEBE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/594"
+        }
+      ]
+    },
+    {
+      "id": "35cc2522-e0d7-4e82-8619-2635bc60fd88",
+      "identifiers": [
+        {
+          "identifier": "692",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ASABE BASHIR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/692"
+        }
+      ]
+    },
+    {
+      "id": "e8f3081e-2f66-408f-bc0b-7bb9f4d93ba7",
+      "identifiers": [
+        {
+          "identifier": "836",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AWAJI-INOMBEK AIANTE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/836"
+        }
+      ]
+    },
+    {
+      "id": "a037d5e6-cc05-4484-a1e4-87047c62a6b7",
+      "identifiers": [
+        {
+          "identifier": "576",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/576.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/576.jpg"
+        }
+      ],
+      "name": "AYEOLA ABAYOMI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/576"
+        }
+      ]
+    },
+    {
+      "id": "b0e939a5-5889-4b76-b39d-21d1e21c937e",
+      "identifiers": [
+        {
+          "identifier": "192",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/192.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/192.jpg"
+        }
+      ],
+      "name": "AYI EKPEYONG",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/192"
+        }
+      ]
+    },
+    {
+      "id": "e31fdcad-208b-4cf8-9b7f-a4194f53cd98",
+      "identifiers": [
+        {
+          "identifier": "662",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AYO OMIDIRAN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/662"
+        }
+      ]
+    },
+    {
+      "id": "75824414-7ee6-48d5-bfe5-03e809eb3c7a",
+      "identifiers": [
+        {
+          "identifier": "649",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "AYUBA BADAMASI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/649"
+        }
+      ]
+    },
+    {
+      "id": "bd3ce3b6-9eb9-46a1-baf2-503e6f6a4858",
+      "identifiers": [
+        {
+          "identifier": "85",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/85.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/85.jpg"
+        }
+      ],
+      "name": "AZUBOGU IFEANYI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/85"
+        }
+      ]
+    },
+    {
+      "id": "b1cb36c5-bc2d-4230-b5c4-f3f958c20d55",
+      "identifiers": [
+        {
+          "identifier": "778",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Abdullahi Garba",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/778"
+        }
+      ]
+    },
+    {
+      "id": "6706efee-7156-488a-95c4-4dd10b544c7a",
+      "identifiers": [
+        {
+          "identifier": "569",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/569.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/569.jpg"
+        }
+      ],
+      "name": "Abdullahi Mahmud",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/569"
+        }
+      ]
+    },
+    {
+      "id": "8b910dbc-22e9-4408-8dcf-98276b530ad3",
+      "identifiers": [
+        {
+          "identifier": "950",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Adabah Christian",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/950"
+        }
+      ]
+    },
+    {
+      "id": "78726e95-961f-461d-9bd1-ca226e30be4d",
+      "identifiers": [
+        {
+          "identifier": "915",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Adewale Oluwatayo",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/915"
+        }
+      ]
+    },
+    {
+      "id": "868498bd-2a23-4477-96b9-17bf0dbf96ae",
+      "identifiers": [
+        {
+          "identifier": "535",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/535.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/535.jpg"
+        }
+      ],
+      "name": "Agom Jarigbe",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/535"
+        }
+      ]
+    },
+    {
+      "id": "790d799a-a330-416c-92dd-76b08676fc2c",
+      "identifiers": [
+        {
+          "identifier": "747",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/747.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/747.jpg"
+        }
+      ],
+      "name": "Akinyele Awodumila",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/747"
+        }
+      ]
+    },
+    {
+      "id": "0cfa657a-9ba3-4889-a30a-9c9c1040b9cb",
+      "identifiers": [
+        {
+          "identifier": "960",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Angulu Zakari",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/960"
+        }
+      ]
+    },
+    {
+      "id": "f57fe0a1-478c-4ec4-b89a-9c7e18c89b43",
+      "identifiers": [
+        {
+          "identifier": "562",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/562.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/562.jpg"
+        }
+      ],
+      "name": "Ayodeji Joseph",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/562"
+        }
+      ]
+    },
+    {
+      "id": "bfacc136-b4e0-4021-9c71-5ab1dc45dd74",
+      "identifiers": [
+        {
+          "identifier": "711",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "BABANGIDA IBRAHIM",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/711"
+        }
+      ]
+    },
+    {
+      "id": "5bca4ac7-190e-4cf1-a1a9-7c0735f4d764",
+      "identifiers": [
+        {
+          "identifier": "751",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "BABATUNDE KOLAWOLE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/751"
+        }
+      ]
+    },
+    {
+      "id": "60ac3d18-9946-41e9-a7cf-6a5d35b281ec",
+      "identifiers": [
+        {
+          "identifier": "632",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "BADERINWA BAMIDELE WHITE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/632"
+        }
+      ]
+    },
+    {
+      "id": "add7f959-73ba-4afc-b236-19a98e9cdb8b",
+      "identifiers": [
+        {
+          "identifier": "613",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "BALA YUSUF",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/613"
+        }
+      ]
+    },
+    {
+      "id": "d782983c-2663-48e3-b24e-6da13ff04566",
+      "identifiers": [
+        {
+          "identifier": "957",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "BALARABE ABDULLAHI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/957"
+        }
+      ]
+    },
+    {
+      "id": "99b80f19-88d3-4d3e-9464-d26d12adbc87",
+      "identifiers": [
+        {
+          "identifier": "931",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "BASHIR BABALE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/931"
+        }
+      ]
+    },
+    {
+      "id": "fbe2b76b-4ee1-4e2b-9bcf-8f9dbb7a8dbf",
+      "identifiers": [
+        {
+          "identifier": "796",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "BASSEY EWAH",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/796"
+        }
+      ]
+    },
+    {
+      "id": "25e4ad12-dcda-4fcc-ab3e-00c24dd3a711",
+      "identifiers": [
+        {
+          "identifier": "664",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "BELLO ABDULLAHI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/664"
+        }
+      ]
+    },
+    {
+      "id": "24a57e06-1019-4ed5-a6a9-99af12871b17",
+      "identifiers": [
+        {
+          "identifier": "853",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "BELLO SANI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/853"
+        }
+      ]
+    },
+    {
+      "id": "59ca73d9-1f43-46c4-9069-498c5cfeed0a",
+      "identifiers": [
+        {
+          "identifier": "544",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/544.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/544.jpg"
+        }
+      ],
+      "name": "BENI LAR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/544"
+        }
+      ]
+    },
+    {
+      "id": "6e8bd3ec-95ca-4df1-992d-024998cacba9",
+      "identifiers": [
+        {
+          "identifier": "539",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/539.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/539.jpg"
+        }
+      ],
+      "name": "BINTA BELLO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/539"
+        }
+      ]
+    },
+    {
+      "id": "7b93348e-4294-43a1-a6b2-5f32e478ad38",
+      "identifiers": [
+        {
+          "identifier": "801",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "BOLAJI AYINLA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/801"
+        }
+      ]
+    },
+    {
+      "id": "7d679377-c418-4ed0-89c3-f2992a32aa35",
+      "identifiers": [
+        {
+          "identifier": "896",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "BROWN ONYERE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/896"
+        }
+      ]
+    },
+    {
+      "id": "3acdf153-8e52-4c6a-854c-7a24869dd1b6",
+      "identifiers": [
+        {
+          "identifier": "786",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "BULUS SOLOMON",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/786"
+        }
+      ]
+    },
+    {
+      "id": "902ca577-525c-46bb-8677-718d0e32ded5",
+      "identifiers": [
+        {
+          "identifier": "567",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "BUSAYO OKE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/567"
+        }
+      ]
+    },
+    {
+      "id": "3cb4be54-0692-41f3-9fde-aef403474774",
+      "identifiers": [
+        {
+          "identifier": "609",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "CHIDOKA OBINNA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/609"
+        }
+      ]
+    },
+    {
+      "id": "b17b20ef-a8a0-481b-abba-8a9ceedaed1e",
+      "identifiers": [
+        {
+          "identifier": "571",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "CHUKWUEMEKA ANOHU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/571"
+        }
+      ]
+    },
+    {
+      "id": "e48fa637-1ddc-45e4-acaa-21a14127a330",
+      "identifiers": [
+        {
+          "identifier": "636",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "CHUKWUKA ONYEMA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/636"
+        }
+      ]
+    },
+    {
+      "id": "515d2b39-e318-47ac-992f-39b3c44acc56",
+      "identifiers": [
+        {
+          "identifier": "659",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "CHUKWUKERE AUSTINE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/659"
+        }
+      ]
+    },
+    {
+      "id": "2112408c-3908-409b-826a-52fa59654163",
+      "identifiers": [
+        {
+          "identifier": "951",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Chukwuma Nwazunku",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/951"
+        }
+      ]
+    },
+    {
+      "id": "eb96273d-62bb-4a48-8615-ae257b378389",
+      "identifiers": [
+        {
+          "identifier": "845",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "DA'U MAGAJI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/845"
+        }
+      ]
+    },
+    {
+      "id": "9d4283cd-7e90-4c59-a428-346c95bbe0a6",
+      "identifiers": [
+        {
+          "identifier": "603",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/603.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/603.jpg"
+        }
+      ],
+      "name": "DANBURAM NUHU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/603"
+        }
+      ]
+    },
+    {
+      "id": "4d2d6956-a86e-44e7-a8a7-1d4fa4e4b1a0",
+      "identifiers": [
+        {
+          "identifier": "580",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/580.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/580.jpg"
+        }
+      ],
+      "name": "DAUDA KAKO ARE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/580"
+        }
+      ]
+    },
+    {
+      "id": "e58346b8-fd97-4bb1-b24a-84f9cb4bb27c",
+      "identifiers": [
+        {
+          "identifier": "638",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "DAVEMATICS OMBUGADU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/638"
+        }
+      ]
+    },
+    {
+      "id": "00f8089e-cc28-4433-90fa-48852600a92b",
+      "identifiers": [
+        {
+          "identifier": "538",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/538.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/538.jpg"
+        }
+      ],
+      "name": "DEKOR DUMNAMENE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/538"
+        }
+      ]
+    },
+    {
+      "id": "a1fde7e8-6b68-4e69-9b87-f6d12b26cf88",
+      "identifiers": [
+        {
+          "identifier": "534",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/534.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/534.jpg"
+        }
+      ],
+      "name": "DENNIS AMADI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/534"
+        }
+      ]
+    },
+    {
+      "id": "d3557568-295b-48c2-8d9f-7d6b0753a48a",
+      "identifiers": [
+        {
+          "identifier": "554",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/554.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/554.jpg"
+        }
+      ],
+      "name": "DOGARA YAKUBU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/554"
+        }
+      ]
+    },
+    {
+      "id": "cfbd55d3-3ce6-48e8-bfbc-bfc2b57e4f59",
+      "identifiers": [
+        {
+          "identifier": "719",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "DOUYE DIRI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/719"
+        }
+      ]
+    },
+    {
+      "id": "692c14c1-07cd-4bc7-bb09-0ade6b2b2f57",
+      "identifiers": [
+        {
+          "identifier": "958",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Danladi Baido",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/958"
+        }
+      ]
+    },
+    {
+      "id": "c559cabf-04e8-468f-bc84-c3d52daf0e69",
+      "identifiers": [
+        {
+          "identifier": "605",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/605.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/605.jpg"
+        }
+      ],
+      "name": "Darlington Nwokocha",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/605"
+        }
+      ]
+    },
+    {
+      "id": "a5a3bc2d-d074-4d77-8112-604ac7630c77",
+      "identifiers": [
+        {
+          "identifier": "635",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Dennis Agbo",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/635"
+        }
+      ]
+    },
+    {
+      "id": "411de638-0045-4de9-afd1-ebba29059b0f",
+      "identifiers": [
+        {
+          "identifier": "524",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/524.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/524.jpg"
+        }
+      ],
+      "name": "EAMMANUEL EKON",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/524"
+        }
+      ]
+    },
+    {
+      "id": "87f8dbd5-975c-4a06-b45b-cb1eec546ef1",
+      "identifiers": [
+        {
+          "identifier": "673",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "EBENYI KINGSLEY",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/673"
+        }
+      ]
+    },
+    {
+      "id": "02f6ec41-6711-434d-9bab-1e4143954edb",
+      "identifiers": [
+        {
+          "identifier": "755",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/755.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/755.jpg"
+        }
+      ],
+      "name": "EDERIN IDISI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/755"
+        }
+      ]
+    },
+    {
+      "id": "d7d9a7f3-972a-4ceb-9c97-a8787b86a673",
+      "identifiers": [
+        {
+          "identifier": "653",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "EDIM ETA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/653"
+        }
+      ]
+    },
+    {
+      "id": "7446df85-7895-4c1e-8431-28b8cf83f523",
+      "identifiers": [
+        {
+          "identifier": "615",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "EDWIN ANAYO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/615"
+        }
+      ]
+    },
+    {
+      "id": "e708ad4d-7700-4557-a9bf-d832c0c3893a",
+      "identifiers": [
+        {
+          "identifier": "829",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "EFFIONG DANIEL",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/829"
+        }
+      ]
+    },
+    {
+      "id": "ee50c7f9-787f-46eb-9c17-2d1b0d0dac56",
+      "identifiers": [
+        {
+          "identifier": "694",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "EGWU EMMANUEL",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/694"
+        }
+      ]
+    },
+    {
+      "id": "7a964ca1-67eb-43e9-8986-f2823bef710f",
+      "identifiers": [
+        {
+          "identifier": "631",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "EMERENGWA BONIFACE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/631"
+        }
+      ]
+    },
+    {
+      "id": "31b8d277-22d5-48f2-a896-cb603866d54d",
+      "identifiers": [
+        {
+          "identifier": "840",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "EMMANUEL UKOETE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/840"
+        }
+      ]
+    },
+    {
+      "id": "74b1390d-39d3-4ce1-9ef4-8f7e7641d0df",
+      "identifiers": [
+        {
+          "identifier": "710",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ENITAN BADRU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/710"
+        }
+      ]
+    },
+    {
+      "id": "eed0c790-156d-499e-9745-1dfcfee22bb9",
+      "identifiers": [
+        {
+          "identifier": "518",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/518.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/518.jpg"
+        }
+      ],
+      "name": "EVELYN OMAVOWAN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/518"
+        }
+      ]
+    },
+    {
+      "id": "9ab7d672-3488-4ce7-83df-d85603c0b1d8",
+      "identifiers": [
+        {
+          "identifier": "949",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Emeka Idu",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/949"
+        }
+      ]
+    },
+    {
+      "id": "8dd0112a-1805-44b8-9b7a-4c6a6faa5b70",
+      "identifiers": [
+        {
+          "identifier": "709",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Emmanuel Akpan",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/709"
+        }
+      ]
+    },
+    {
+      "id": "2042f878-8ec3-4d2e-a7ac-d5cba38fdd56",
+      "identifiers": [
+        {
+          "identifier": "785",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Eucharia Okwunna",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/785"
+        }
+      ]
+    },
+    {
+      "id": "d1380eb2-87ec-46da-99df-27b2223e2a04",
+      "identifiers": [
+        {
+          "identifier": "787",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "FAKEYE OLUFEMI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/787"
+        }
+      ]
+    },
+    {
+      "id": "0116052b-c1a1-4053-89b2-a255e56f976d",
+      "identifiers": [
+        {
+          "identifier": "882",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "FALEKE ABIODUN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/882"
+        }
+      ]
+    },
+    {
+      "id": "a1906a92-c207-444e-83c5-221f635d1c6d",
+      "identifiers": [
+        {
+          "identifier": "628",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "FARUK MUHAMMADU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/628"
+        }
+      ]
+    },
+    {
+      "id": "fbbb9c94-8873-458c-8998-06dcfe3302f5",
+      "identifiers": [
+        {
+          "identifier": "930",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "FIJABI AKINADE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/930"
+        }
+      ]
+    },
+    {
+      "id": "b32bbfd7-7e44-45e3-b1e1-fb5cff750021",
+      "identifiers": [
+        {
+          "identifier": "670",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "FRANCIS UDUYOK",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/670"
+        }
+      ]
+    },
+    {
+      "id": "f02cddda-fddf-4cf8-8fc5-b36ee0fdd895",
+      "identifiers": [
+        {
+          "identifier": "639",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "GABRIEL ONYENWIFE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/639"
+        }
+      ]
+    },
+    {
+      "id": "35e448ea-2064-4c69-b7cc-9528a877a248",
+      "identifiers": [
+        {
+          "identifier": "793",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "GAFARU AKINTAYO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/793"
+        }
+      ]
+    },
+    {
+      "id": "3cb8bc47-9681-409a-a602-f54c2be08b52",
+      "identifiers": [
+        {
+          "identifier": "738",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "GARBA AHMED",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/738"
+        }
+      ]
+    },
+    {
+      "id": "ee784851-7a07-45d3-8314-b7d63bbd49aa",
+      "identifiers": [
+        {
+          "identifier": "537",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/537.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/537.jpg"
+        }
+      ],
+      "name": "GARBA MOHAMMED",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/537"
+        }
+      ]
+    },
+    {
+      "id": "ba282346-4ec2-4712-9d47-d463d46da0f9",
+      "identifiers": [
+        {
+          "identifier": "686",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "GARBA MUHAMMAD",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/686"
+        }
+      ]
+    },
+    {
+      "id": "ec3ad0af-b8f7-4f12-8358-278ef53e6fc2",
+      "identifiers": [
+        {
+          "identifier": "775",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "GARBA UMAR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/775"
+        }
+      ]
+    },
+    {
+      "id": "e62ad765-bebf-4952-9814-629be886ceea",
+      "identifiers": [
+        {
+          "identifier": "741",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "GAZA GBEFWI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/741"
+        }
+      ]
+    },
+    {
+      "id": "97262ad4-9373-4d3b-bef8-e194f734b671",
+      "identifiers": [
+        {
+          "identifier": "884",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "GOGO TAMUNO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/884"
+        }
+      ]
+    },
+    {
+      "id": "85152454-f6ec-4853-af8b-80b43f39ae11",
+      "identifiers": [
+        {
+          "identifier": "620",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "GONI BUKAR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/620"
+        }
+      ]
+    },
+    {
+      "id": "5c7cf5cd-eb34-4689-8c23-03f185e8628b",
+      "identifiers": [
+        {
+          "identifier": "509",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "GOODLUGK OPIAH",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/509"
+        }
+      ]
+    },
+    {
+      "id": "86de3065-7b55-47cd-8dab-8e85bb87fa0a",
+      "identifiers": [
+        {
+          "identifier": "510",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "GOODLUGK OPIAH",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/510"
+        }
+      ]
+    },
+    {
+      "id": "875408c1-8bb0-4b66-9efb-defdeef28f47",
+      "identifiers": [
+        {
+          "identifier": "505",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "GOODLUGK OPIAH",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/505"
+        }
+      ]
+    },
+    {
+      "id": "3e4fe02e-cdf8-4c5e-b88d-355cb886fb56",
+      "identifiers": [
+        {
+          "identifier": "924",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Gumau Yahaya",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/924"
+        }
+      ]
+    },
+    {
+      "id": "8ff5f0af-eaec-4e24-8896-eb41afbb9bd8",
+      "identifiers": [
+        {
+          "identifier": "725",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "HAMMAN-JULDE GARBA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/725"
+        }
+      ]
+    },
+    {
+      "id": "a13b0d31-cad2-49fa-9173-ee030984aca3",
+      "identifiers": [
+        {
+          "identifier": "736",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "HASSAN ABUBAKAR III",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/736"
+        }
+      ]
+    },
+    {
+      "id": "f77669c1-8dbe-4747-aa68-f8c84dcd303d",
+      "identifiers": [
+        {
+          "identifier": "513",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "HASSAN ADAMU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/513"
+        }
+      ]
+    },
+    {
+      "id": "b77bf509-47ad-4a86-9188-401e18312e42",
+      "identifiers": [
+        {
+          "identifier": "868",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "HASSAN SALEH",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/868"
+        }
+      ]
+    },
+    {
+      "id": "19333d94-5d10-4cb4-b94a-f919d6e090fa",
+      "identifiers": [
+        {
+          "identifier": "678",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "HENRY ARCHIBONG",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/678"
+        }
+      ]
+    },
+    {
+      "id": "e5360427-1eee-4606-ada6-89ca337d3780",
+      "identifiers": [
+        {
+          "identifier": "665",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "HENRY NWAWUBA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/665"
+        }
+      ]
+    },
+    {
+      "id": "284c5ab4-af02-4a34-9e3d-23f8f53964a0",
+      "identifiers": [
+        {
+          "identifier": "551",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "HERMAN HEMBE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/551"
+        }
+      ]
+    },
+    {
+      "id": "36f13d81-0781-45e7-b5de-0d5a71a9a69c",
+      "identifiers": [
+        {
+          "identifier": "556",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/556.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/556.jpg"
+        }
+      ],
+      "name": "Hassan Omale",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/556"
+        }
+      ]
+    },
+    {
+      "id": "0baf46e2-4521-4400-96f7-75137e68c6cb",
+      "identifiers": [
+        {
+          "identifier": "625",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Husaini Suleiman",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/625"
+        }
+      ]
+    },
+    {
+      "id": "40ac5b78-a4f2-45e3-b380-1d7ff585257e",
+      "identifiers": [
+        {
+          "identifier": "690",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "IBORO EKANEM",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/690"
+        }
+      ]
+    },
+    {
+      "id": "7bd2a315-5a9f-495b-a766-d534c429a0da",
+      "identifiers": [
+        {
+          "identifier": "691",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "IBRAHIM ABDULLAHI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/691"
+        }
+      ]
+    },
+    {
+      "id": "1f2fdde9-40ee-4fa3-956f-039b8c07448d",
+      "identifiers": [
+        {
+          "identifier": "728",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "IBRAHIM DANMAZARI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/728"
+        }
+      ]
+    },
+    {
+      "id": "ec925d92-5d97-477c-8b2a-c49064e7ffdc",
+      "identifiers": [
+        {
+          "identifier": "828",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "IDAGBO OCHIGLEGOR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/828"
+        }
+      ]
+    },
+    {
+      "id": "54898789-b7ed-4933-ad91-f26aae2cef42",
+      "identifiers": [
+        {
+          "identifier": "568",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/568.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/568.jpg"
+        }
+      ],
+      "name": "IDUMA IGARIWEY",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/568"
+        }
+      ]
+    },
+    {
+      "id": "bc3c9923-3157-4fbd-afe0-a0203e3f20d9",
+      "identifiers": [
+        {
+          "identifier": "777",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "IKANI OKOLO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/777"
+        }
+      ]
+    },
+    {
+      "id": "ff16e23f-3be0-4a89-a263-4d974d9c3f24",
+      "identifiers": [
+        {
+          "identifier": "909",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "IOREMBER WAYO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/909"
+        }
+      ]
+    },
+    {
+      "id": "94c7f532-97bf-411b-ba64-7a4cc612b97b",
+      "identifiers": [
+        {
+          "identifier": "590",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/590.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/590.jpg"
+        }
+      ],
+      "name": "IROM MICHAEL",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/590"
+        }
+      ]
+    },
+    {
+      "id": "d4e2312b-c244-4cf8-be5e-e58325580b5a",
+      "identifiers": [
+        {
+          "identifier": "899",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ISA MOHAMMED",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/899"
+        }
+      ]
+    },
+    {
+      "id": "b9bd9f0c-cee1-4451-b7b8-3845f5c72f8c",
+      "identifiers": [
+        {
+          "identifier": "717",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ISA SALIHU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/717"
+        }
+      ]
+    },
+    {
+      "id": "356c08ec-a215-4f99-904a-3640b4cdf98a",
+      "identifiers": [
+        {
+          "identifier": "565",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/565.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/565.jpg"
+        }
+      ],
+      "name": "ISAH MURTALA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/565"
+        }
+      ]
+    },
+    {
+      "id": "746673b7-5fb2-4446-83ba-5f63b97028f1",
+      "identifiers": [
+        {
+          "identifier": "871",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Ibrahim Baba",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/871"
+        }
+      ]
+    },
+    {
+      "id": "e214e2b1-4555-4b24-8e0e-20756b28c34b",
+      "identifiers": [
+        {
+          "identifier": "643",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Ibrahim Isiaka",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/643"
+        }
+      ]
+    },
+    {
+      "id": "ae393303-feda-4be9-be1d-f3d95fc8b05e",
+      "identifiers": [
+        {
+          "identifier": "566",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/566.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/566.jpg"
+        }
+      ],
+      "name": "Ismaila Gadaka",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/566"
+        }
+      ]
+    },
+    {
+      "id": "fd172c3e-4a15-498f-96e6-71a6573759cc",
+      "identifiers": [
+        {
+          "identifier": "601",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/601.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/601.jpg"
+        }
+      ],
+      "name": "Istifanus Gyang",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/601"
+        }
+      ]
+    },
+    {
+      "id": "a3c1d5ff-1271-484f-978a-11668e10b2fe",
+      "identifiers": [
+        {
+          "identifier": "527",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/527.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/527.jpg"
+        }
+      ],
+      "name": "JACOBSON BARINEKA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/527"
+        }
+      ]
+    },
+    {
+      "id": "d879dab2-dbcf-41ce-a457-17b2552a4946",
+      "identifiers": [
+        {
+          "identifier": "529",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/529.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/529.jpg"
+        }
+      ],
+      "name": "JEPHTHAH FOINGHA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/529"
+        }
+      ]
+    },
+    {
+      "id": "75d9a145-030a-48cb-875e-789db11e6b63",
+      "identifiers": [
+        {
+          "identifier": "573",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/573.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/573.jpg"
+        }
+      ],
+      "name": "JIBRIN SANTUMARI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/573"
+        }
+      ]
+    },
+    {
+      "id": "79d811f8-36c2-4d9c-8cb2-c360f746c209",
+      "identifiers": [
+        {
+          "identifier": "588",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/588.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/588.jpg"
+        }
+      ],
+      "name": "JIBRIN SATUMARI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/588"
+        }
+      ]
+    },
+    {
+      "id": "11b0606e-4b96-4228-9ee4-c78b653283c0",
+      "identifiers": [
+        {
+          "identifier": "648",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "JIMOH ABDUL",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/648"
+        }
+      ]
+    },
+    {
+      "id": "0c38ed75-9f5f-4821-998b-7d1537c761bd",
+      "identifiers": [
+        {
+          "identifier": "624",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "JIMOH OJUGBELE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/624"
+        }
+      ]
+    },
+    {
+      "id": "40b6599d-8fcc-493d-aa1a-426581d49a40",
+      "identifiers": [
+        {
+          "identifier": "541",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "JOHN DYEGH",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/541"
+        }
+      ]
+    },
+    {
+      "id": "02f60e2e-b2eb-49b1-ad43-efbc4809077d",
+      "identifiers": [
+        {
+          "identifier": "739",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "JOHNSON EHIOZUWA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/739"
+        }
+      ]
+    },
+    {
+      "id": "73129c99-b11d-43d2-bdff-687197a629d7",
+      "identifiers": [
+        {
+          "identifier": "611",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "JONES ONYERERI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/611"
+        }
+      ]
+    },
+    {
+      "id": "7d66426a-7fb1-4fb5-b111-4d8752365242",
+      "identifiers": [
+        {
+          "identifier": "699",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "JOSEPH BAMGBOSE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/699"
+        }
+      ]
+    },
+    {
+      "id": "182dbeaa-91bb-4138-854a-e78f4cb44eaa",
+      "identifiers": [
+        {
+          "identifier": "927",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "JOSEPH EDIONWELE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/927"
+        }
+      ]
+    },
+    {
+      "id": "c9662b95-206c-4a9c-aa6a-5dda5c8e6aa7",
+      "identifiers": [
+        {
+          "identifier": "748",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/748.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/748.jpg"
+        }
+      ],
+      "name": "Jika Haliru",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/748"
+        }
+      ]
+    },
+    {
+      "id": "62874761-fd85-4dc5-a6bc-579b4f908086",
+      "identifiers": [
+        {
+          "identifier": "595",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/595.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/595.jpg"
+        }
+      ],
+      "name": "Johnbull Shekarau",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/595"
+        }
+      ]
+    },
+    {
+      "id": "3e672fe3-54fd-4fe6-89d5-0bc6a34b0afc",
+      "identifiers": [
+        {
+          "identifier": "676",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "KABIR SHAIBU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/676"
+        }
+      ]
+    },
+    {
+      "id": "f8be60de-258a-46a2-97d6-f8014421f6d6",
+      "identifiers": [
+        {
+          "identifier": "939",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "KABIRU ACHIDA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/939"
+        }
+      ]
+    },
+    {
+      "id": "29dfc79f-bd7c-49ef-a31b-913faabe8e4e",
+      "identifiers": [
+        {
+          "identifier": "794",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "KAYODE OLADELE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/794"
+        }
+      ]
+    },
+    {
+      "id": "b97f173d-2163-4f8a-9632-c857511ed427",
+      "identifiers": [
+        {
+          "identifier": "839",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "KENNETH CHIKERE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/839"
+        }
+      ]
+    },
+    {
+      "id": "329dc28f-bc10-4fc3-b769-61d17e077393",
+      "identifiers": [
+        {
+          "identifier": "608",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "KHADIJA BUKAR .A.",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/608"
+        }
+      ]
+    },
+    {
+      "id": "21ff1ae5-be2c-4c4c-93e9-d629a478a402",
+      "identifiers": [
+        {
+          "identifier": "729",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "KHAMISU AHM AHMED",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/729"
+        }
+      ]
+    },
+    {
+      "id": "b0057850-1a94-4576-aa0f-ed300209bb12",
+      "identifiers": [
+        {
+          "identifier": "646",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "KWAMOTI LAORI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/646"
+        }
+      ]
+    },
+    {
+      "id": "3438649a-0572-4d86-b47c-42b2bdcbd46a",
+      "identifiers": [
+        {
+          "identifier": "779",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "KWEWUM SHAWULU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/779"
+        }
+      ]
+    },
+    {
+      "id": "22c21b1b-5e7b-4d81-b849-7a82aebfda26",
+      "identifiers": [
+        {
+          "identifier": "501",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Kehinde Agboola",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/501"
+        }
+      ]
+    },
+    {
+      "id": "7d66d561-a926-41a3-9c6c-e72dad7eea98",
+      "identifiers": [
+        {
+          "identifier": "959",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Kurmi Gashaka",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/959"
+        }
+      ]
+    },
+    {
+      "id": "d467a019-de86-4406-a5ee-bb82ada812c5",
+      "identifiers": [
+        {
+          "identifier": "260",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/260.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/260.jpg"
+        }
+      ],
+      "name": "LAWAL B/TUDU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/260"
+        }
+      ]
+    },
+    {
+      "id": "ed60d392-ebe6-49f6-8174-10eb29dbb216",
+      "identifiers": [
+        {
+          "identifier": "564",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/564.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/564.jpg"
+        }
+      ],
+      "name": "LAWALI HASSAN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/564"
+        }
+      ]
+    },
+    {
+      "id": "54790a50-af87-4d4d-ab8d-0798351c0d41",
+      "identifiers": [
+        {
+          "identifier": "515",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/515.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/515.jpg"
+        }
+      ],
+      "name": "LAZARUS OGBEE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/515"
+        }
+      ]
+    },
+    {
+      "id": "e99f6599-47cc-4025-9551-58f90d0e455c",
+      "identifiers": [
+        {
+          "identifier": "570",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/570.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/570.jpg"
+        }
+      ],
+      "name": "MAHHUD MAINA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/570"
+        }
+      ]
+    },
+    {
+      "id": "003e0736-add0-4997-9444-94fac606bb95",
+      "identifiers": [
+        {
+          "identifier": "616",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MALLAM GANA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/616"
+        }
+      ]
+    },
+    {
+      "id": "98615618-8f3a-4f5a-899a-9dd1275d9114",
+      "identifiers": [
+        {
+          "identifier": "701",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MALLE AMINU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/701"
+        }
+      ]
+    },
+    {
+      "id": "93e50fab-06e9-4cf0-b24d-1af1141a06a1",
+      "identifiers": [
+        {
+          "identifier": "626",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MARK GBILLAH",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/626"
+        }
+      ]
+    },
+    {
+      "id": "8e65e183-9e14-4029-b68b-4fa8a35d6179",
+      "identifiers": [
+        {
+          "identifier": "688",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MAYOWA AKINFOLARIN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/688"
+        }
+      ]
+    },
+    {
+      "id": "b4e56469-45dd-4cfd-a258-8234f0f46e2b",
+      "identifiers": [
+        {
+          "identifier": "663",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MOHAMMED GARBA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/663"
+        }
+      ]
+    },
+    {
+      "id": "46fddce6-2c5e-4b70-8eb4-843501b059b7",
+      "identifiers": [
+        {
+          "identifier": "789",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MOHAMMED MAHMUD",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/789"
+        }
+      ]
+    },
+    {
+      "id": "a918818a-4004-4668-bacf-7805da576a0e",
+      "identifiers": [
+        {
+          "identifier": "720",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MOHAMMED MONGUNO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/720"
+        }
+      ]
+    },
+    {
+      "id": "cf6981b7-c365-40ae-b2c7-9c1deaa081c1",
+      "identifiers": [
+        {
+          "identifier": "784",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MOHAMMED ONAWO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/784"
+        }
+      ]
+    },
+    {
+      "id": "c2178d8a-fe28-4b7d-b291-de813d5612c8",
+      "identifiers": [
+        {
+          "identifier": "555",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/555.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/555.jpg"
+        }
+      ],
+      "name": "MOHAMMED SANDA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/555"
+        }
+      ]
+    },
+    {
+      "id": "e8415bea-7bb4-4075-9458-ea4b0d3d1b11",
+      "identifiers": [
+        {
+          "identifier": "713",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MOHAMMED ZAKARI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/713"
+        }
+      ]
+    },
+    {
+      "id": "deac6723-504e-48ae-b116-5b319fe8ae54",
+      "identifiers": [
+        {
+          "identifier": "724",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MUHAMMAD ABDU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/724"
+        }
+      ]
+    },
+    {
+      "id": "b7d77f59-9d90-4d4a-8911-b096c921dc30",
+      "identifiers": [
+        {
+          "identifier": "585",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/585.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/585.jpg"
+        }
+      ],
+      "name": "MUHAMMAD ABUBAKAR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/585"
+        }
+      ]
+    },
+    {
+      "id": "f9c4b3ab-5844-48d0-9a99-d550dddbdf86",
+      "identifiers": [
+        {
+          "identifier": "549",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/549.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/549.jpg"
+        }
+      ],
+      "name": "MUHAMMAD BOYI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/549"
+        }
+      ]
+    },
+    {
+      "id": "dcffcccf-4ca8-4fcb-8be4-27f7b60e4148",
+      "identifiers": [
+        {
+          "identifier": "804",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MUHAMMAD JEGA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/804"
+        }
+      ]
+    },
+    {
+      "id": "90f3b0fb-54e4-4e37-a65b-81beffd10257",
+      "identifiers": [
+        {
+          "identifier": "749",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/749.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/749.jpg"
+        }
+      ],
+      "name": "MUHAMMAD MUSA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/749"
+        }
+      ]
+    },
+    {
+      "id": "c306f5a2-7830-4a0f-a217-03e27b096579",
+      "identifiers": [
+        {
+          "identifier": "657",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MUHAMMAD USMAN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/657"
+        }
+      ]
+    },
+    {
+      "id": "fb99f755-dd6b-4192-b503-fbafe5053ea4",
+      "identifiers": [
+        {
+          "identifier": "693",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MUHAMMADU MUHTARI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/693"
+        }
+      ]
+    },
+    {
+      "id": "d1122514-8591-4a96-863c-1826fbea9bc8",
+      "identifiers": [
+        {
+          "identifier": "596",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/596.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/596.jpg"
+        }
+      ],
+      "name": "MUHAMMED ALI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/596"
+        }
+      ]
+    },
+    {
+      "id": "8a0483b2-37d2-4abf-9ac1-24bf46fb34ec",
+      "identifiers": [
+        {
+          "identifier": "681",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MUHAMMED GUDAJI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/681"
+        }
+      ]
+    },
+    {
+      "id": "8cc24ea0-7960-424e-b6c7-2f886057b775",
+      "identifiers": [
+        {
+          "identifier": "637",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MUHAMMED IDIRISU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/637"
+        }
+      ]
+    },
+    {
+      "id": "74a6dad8-d6c5-4322-8f25-35c757bebb95",
+      "identifiers": [
+        {
+          "identifier": "672",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MUKAILA KASSIM",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/672"
+        }
+      ]
+    },
+    {
+      "id": "77f0b5b9-f9c9-41fd-b742-1d4db1bc8b81",
+      "identifiers": [
+        {
+          "identifier": "918",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MUNIR DANAGUNDI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/918"
+        }
+      ]
+    },
+    {
+      "id": "557d08dc-0bc1-4129-b082-6ac8b938978a",
+      "identifiers": [
+        {
+          "identifier": "545",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/545.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/545.jpg"
+        }
+      ],
+      "name": "MUNTARI DADNDUTSE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/545"
+        }
+      ]
+    },
+    {
+      "id": "e0864697-871a-4fb3-bbdc-7c04219bb496",
+      "identifiers": [
+        {
+          "identifier": "574",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/574.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/574.jpg"
+        }
+      ],
+      "name": "MUSA SARKIN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/574"
+        }
+      ]
+    },
+    {
+      "id": "cf843d3a-89ef-4b1c-b286-ae49c5038b72",
+      "identifiers": [
+        {
+          "identifier": "593",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/593.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/593.jpg"
+        }
+      ],
+      "name": "MUSTAPHA BALA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/593"
+        }
+      ]
+    },
+    {
+      "id": "e35cd9c4-a48f-4158-ba49-f3637b273e27",
+      "identifiers": [
+        {
+          "identifier": "627",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "MUTIU SHADIMU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/627"
+        }
+      ]
+    },
+    {
+      "id": "4aeb2a50-a77d-42d2-b687-dc295090d2af",
+      "identifiers": [
+        {
+          "identifier": "953",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Marshal Sunday",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/953"
+        }
+      ]
+    },
+    {
+      "id": "8d4197d8-4fd0-47f6-8489-64b9e9575ede",
+      "identifiers": [
+        {
+          "identifier": "607",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/607.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/607.jpg"
+        }
+      ],
+      "name": "Mohammed Sani",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/607"
+        }
+      ]
+    },
+    {
+      "id": "8010d5b9-a35e-4b8b-bbf9-74cdd1507c4b",
+      "identifiers": [
+        {
+          "identifier": "933",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "NASIRU BABALLE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/933"
+        }
+      ]
+    },
+    {
+      "id": "c349a15f-1885-4ebd-accd-5e000230ea23",
+      "identifiers": [
+        {
+          "identifier": "682",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "NASIRU SULE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/682"
+        }
+      ]
+    },
+    {
+      "id": "857c85ec-3dba-49ed-89c8-543fc7cf0050",
+      "identifiers": [
+        {
+          "identifier": "543",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/543.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/543.jpg"
+        }
+      ],
+      "name": "NASSIR ALI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/543"
+        }
+      ]
+    },
+    {
+      "id": "18e353f3-f57f-4646-bcd6-603cdda084c2",
+      "identifiers": [
+        {
+          "identifier": "599",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/599.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/599.jpg"
+        }
+      ],
+      "name": "NGORO AGIBE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/599"
+        }
+      ]
+    },
+    {
+      "id": "726225dd-a03a-43b6-879a-414076ea6d27",
+      "identifiers": [
+        {
+          "identifier": "848",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "NICHOLAS SHEHU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/848"
+        }
+      ]
+    },
+    {
+      "id": "395c7580-4078-44c5-98cd-445a371e1ffe",
+      "identifiers": [
+        {
+          "identifier": "697",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "NSE EKPENYONG",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/697"
+        }
+      ]
+    },
+    {
+      "id": "a06bff4f-5aba-4727-9c04-434569f7b234",
+      "identifiers": [
+        {
+          "identifier": "306",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/306.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/306.jpg"
+        }
+      ],
+      "name": "NSIEGBE IBIBA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/306"
+        }
+      ]
+    },
+    {
+      "id": "1fd79189-2d7d-4822-9839-37a3b6d1b16c",
+      "identifiers": [
+        {
+          "identifier": "798",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "NWOKOLO VICTOR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/798"
+        }
+      ]
+    },
+    {
+      "id": "821f87b4-905e-4d12-96f6-f453b5b6fbc5",
+      "identifiers": [
+        {
+          "identifier": "906",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Nkem Uzoma",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/906"
+        }
+      ]
+    },
+    {
+      "id": "0d39a31a-e14e-4141-af64-446f3db43247",
+      "identifiers": [
+        {
+          "identifier": "847",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Nnenna Elendu",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/847"
+        }
+      ]
+    },
+    {
+      "id": "a910a5c7-163d-473d-a8ae-c14f3d637908",
+      "identifiers": [
+        {
+          "identifier": "761",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/761.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/761.jpg"
+        }
+      ],
+      "name": "O.PALLY IRIASE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/761"
+        }
+      ]
+    },
+    {
+      "id": "94fca274-b7f8-4809-a2f4-6566d08ecf63",
+      "identifiers": [
+        {
+          "identifier": "911",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ODENEYE OLUSEGUN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/911"
+        }
+      ]
+    },
+    {
+      "id": "350bdf87-adf7-4c43-89b0-788d2dd71776",
+      "identifiers": [
+        {
+          "identifier": "705",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OFONGO HENRY",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/705"
+        }
+      ]
+    },
+    {
+      "id": "83096a24-9560-4584-af40-d4140f2bb72c",
+      "identifiers": [
+        {
+          "identifier": "618",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OGBEIDE-IHAMA OMOREGIE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/618"
+        }
+      ]
+    },
+    {
+      "id": "4ef095c9-3402-4491-afce-59be3ad36187",
+      "identifiers": [
+        {
+          "identifier": "689",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OGHENE EMMANUEL",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/689"
+        }
+      ]
+    },
+    {
+      "id": "9732b1be-0b73-4d5b-9106-ae55e5a55eb2",
+      "identifiers": [
+        {
+          "identifier": "905",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/905.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/905.jpg"
+        }
+      ],
+      "name": "OGOR OKUWEH",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/905"
+        }
+      ]
+    },
+    {
+      "id": "f8c1f144-b33e-4f31-b094-f7f7cb9d2b55",
+      "identifiers": [
+        {
+          "identifier": "792",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OGUNWUYI SEGUN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/792"
+        }
+      ]
+    },
+    {
+      "id": "260593f3-76a9-4df0-999a-25cc14cd066b",
+      "identifiers": [
+        {
+          "identifier": "765",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OHIOZOJEH AKPATASON",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/765"
+        }
+      ]
+    },
+    {
+      "id": "284631bd-2803-4e50-906d-846a52923a32",
+      "identifiers": [
+        {
+          "identifier": "880",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OKAFOR JOHN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/880"
+        }
+      ]
+    },
+    {
+      "id": "2ed2a5b2-882f-499d-9962-2ffc9a9e4555",
+      "identifiers": [
+        {
+          "identifier": "916",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OLAJIDE OLATUBOSUN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/916"
+        }
+      ]
+    },
+    {
+      "id": "d3fae412-fb8b-4c59-8426-10a1c3f862fd",
+      "identifiers": [
+        {
+          "identifier": "862",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OLAMIDE ONI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/862"
+        }
+      ]
+    },
+    {
+      "id": "9d9b0610-b5f6-4f85-b6cf-d779a2aeeefe",
+      "identifiers": [
+        {
+          "identifier": "610",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OLARINOYE OLAYONU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/610"
+        }
+      ]
+    },
+    {
+      "id": "559e1aad-6916-4cae-9893-c3a742157fc9",
+      "identifiers": [
+        {
+          "identifier": "633",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OLATUNJI SHOYINKA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/633"
+        }
+      ]
+    },
+    {
+      "id": "965f94df-c963-486d-9437-a0d5e2a24e88",
+      "identifiers": [
+        {
+          "identifier": "704",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OLUFEMI ADEBANJO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/704"
+        }
+      ]
+    },
+    {
+      "id": "765d47ff-a659-4faa-9fc7-d641fee30ac5",
+      "identifiers": [
+        {
+          "identifier": "803",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/803.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/803.jpg"
+        }
+      ],
+      "name": "OLUFEMI GBAJABIAMILA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/803"
+        }
+      ]
+    },
+    {
+      "id": "dfb34e8f-f293-48a5-a492-e5591a474170",
+      "identifiers": [
+        {
+          "identifier": "938",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OLUFUNKE ADEDOYIN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/938"
+        }
+      ]
+    },
+    {
+      "id": "421c73dc-b657-454e-93dc-80a02640a6e9",
+      "identifiers": [
+        {
+          "identifier": "936",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OLUGBENGA AYODE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/936"
+        }
+      ]
+    },
+    {
+      "id": "b4c80409-374c-4429-8f08-a2a60bfa3c17",
+      "identifiers": [
+        {
+          "identifier": "752",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OLUSEGUN ODEBUNMI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/752"
+        }
+      ]
+    },
+    {
+      "id": "94f050f0-bda4-4a83-8913-db7940d66411",
+      "identifiers": [
+        {
+          "identifier": "805",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OLUSUNBO SAMSON",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/805"
+        }
+      ]
+    },
+    {
+      "id": "c14f9e8b-fa61-47fd-bea8-de476895373a",
+      "identifiers": [
+        {
+          "identifier": "698",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OLUWAROTIMI AGUNSOYE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/698"
+        }
+      ]
+    },
+    {
+      "id": "1a3d477f-10fe-4727-9212-d312e03bd55f",
+      "identifiers": [
+        {
+          "identifier": "802",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OMAR TATA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/802"
+        }
+      ]
+    },
+    {
+      "id": "ce5bb010-0ada-40a2-9313-4f9e1d0824af",
+      "identifiers": [
+        {
+          "identifier": "651",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OMOSEDE IGBINEDION",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/651"
+        }
+      ]
+    },
+    {
+      "id": "beda968f-381d-47cb-b1a3-07806fe627d5",
+      "identifiers": [
+        {
+          "identifier": "707",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ONINUBUARIRI OBINNA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/707"
+        }
+      ]
+    },
+    {
+      "id": "9edd9f06-4880-49fe-89c7-68c473abb384",
+      "identifiers": [
+        {
+          "identifier": "612",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ONWANA MUSA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/612"
+        }
+      ]
+    },
+    {
+      "id": "b7a2ac57-9d18-4e5d-a177-e41a99fc83a2",
+      "identifiers": [
+        {
+          "identifier": "756",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/756.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/756.jpg"
+        }
+      ],
+      "name": "ONYEJEOCHA NKIRUKA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/756"
+        }
+      ]
+    },
+    {
+      "id": "cc0c8ee4-5f23-4e20-8e71-9f9341f5e6cf",
+      "identifiers": [
+        {
+          "identifier": "575",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/575.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/575.jpg"
+        }
+      ],
+      "name": "ONYEMAECHI MRAKPOR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/575"
+        }
+      ]
+    },
+    {
+      "id": "2f8a506d-ea53-4126-bc71-1b5deec22941",
+      "identifiers": [
+        {
+          "identifier": "316",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/316.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/316.jpg"
+        }
+      ],
+      "name": "ONYEWUCHI EZENWA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/316"
+        }
+      ]
+    },
+    {
+      "id": "d761bcb4-8021-4b38-b46b-e2c4d1d9cddc",
+      "identifiers": [
+        {
+          "identifier": "859",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ORKER-JEV YISA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/859"
+        }
+      ]
+    },
+    {
+      "id": "f2556830-38db-4585-a8b6-7b511a9320e0",
+      "identifiers": [
+        {
+          "identifier": "800",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OSSAI OSSAI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/800"
+        }
+      ]
+    },
+    {
+      "id": "65580dd7-a319-41b4-8e48-c88e50f5bcae",
+      "identifiers": [
+        {
+          "identifier": "727",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OWOIDIGHE EKPOATTAI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/727"
+        }
+      ]
+    },
+    {
+      "id": "387498db-b8e3-4110-8dfe-8952999c126d",
+      "identifiers": [
+        {
+          "identifier": "677",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "OYEWOLE DIYA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/677"
+        }
+      ]
+    },
+    {
+      "id": "01fa4a69-45f0-42e2-812d-1a168b9356b4",
+      "identifiers": [
+        {
+          "identifier": "629",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Okechukwu Eze",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/629"
+        }
+      ]
+    },
+    {
+      "id": "c7e9c2f7-02b2-43e9-a57d-42f54c7e01c7",
+      "identifiers": [
+        {
+          "identifier": "864",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Okon Michael",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/864"
+        }
+      ]
+    },
+    {
+      "id": "e848ce55-5b26-4ec1-9cf2-09889f0775d6",
+      "identifiers": [
+        {
+          "identifier": "552",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/552.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/552.jpg"
+        }
+      ],
+      "name": "Olabode Ayorinde",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/552"
+        }
+      ]
+    },
+    {
+      "id": "5df2ecb5-be44-435e-864c-e5df712f9006",
+      "identifiers": [
+        {
+          "identifier": "521",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Olemija Stephen",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/521"
+        }
+      ]
+    },
+    {
+      "id": "50ec61a9-dca5-456a-8430-73b7fd89616f",
+      "identifiers": [
+        {
+          "identifier": "644",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "PHILIP AHMAD",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/644"
+        }
+      ]
+    },
+    {
+      "id": "ed9e7d80-fafb-4d0a-93f9-a73adfd765db",
+      "identifiers": [
+        {
+          "identifier": "577",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/577.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/577.jpg"
+        }
+      ],
+      "name": "PHILIP SHAIBU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/577"
+        }
+      ]
+    },
+    {
+      "id": "2d5472ed-c775-4af9-9277-87c97ed667b4",
+      "identifiers": [
+        {
+          "identifier": "824",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "PRESTIGE OSSY",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/824"
+        }
+      ]
+    },
+    {
+      "id": "767961bb-6ba5-46a8-a640-3f14220519db",
+      "identifiers": [
+        {
+          "identifier": "956",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "PWAJOK GYANG",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/956"
+        }
+      ]
+    },
+    {
+      "id": "fe1cd7cb-8c45-4886-a6ab-b93d9659979b",
+      "identifiers": [
+        {
+          "identifier": "721",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Peter Madubueze",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/721"
+        }
+      ]
+    },
+    {
+      "id": "4dded367-aad0-426b-a20e-a84d16f78f64",
+      "identifiers": [
+        {
+          "identifier": "750",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/750.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/750.jpg"
+        }
+      ],
+      "name": "RAZAK ATUNWA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/750"
+        }
+      ]
+    },
+    {
+      "id": "296f1852-72c5-4b9e-94e4-b923ff9e309d",
+      "identifiers": [
+        {
+          "identifier": "597",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/597.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/597.jpg"
+        }
+      ],
+      "name": "RITA ORJI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/597"
+        }
+      ]
+    },
+    {
+      "id": "13690167-45a0-48c1-97f2-724e65341972",
+      "identifiers": [
+        {
+          "identifier": "572",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/572.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/572.jpg"
+        }
+      ],
+      "name": "Rabiu Garba",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/572"
+        }
+      ]
+    },
+    {
+      "id": "de5ac455-7e74-4648-816d-03de6b3b97e5",
+      "identifiers": [
+        {
+          "identifier": "550",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/550.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/550.jpg"
+        }
+      ],
+      "name": "SAADU NABUNKAN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/550"
+        }
+      ]
+    },
+    {
+      "id": "92dbd640-9b33-4732-bf85-d82c1a756326",
+      "identifiers": [
+        {
+          "identifier": "907",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SADIQ IBRAHIM",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/907"
+        }
+      ]
+    },
+    {
+      "id": "dcb0a859-5def-46d2-ab8e-22f110c9db62",
+      "identifiers": [
+        {
+          "identifier": "757",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SALISU KOKO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/757"
+        }
+      ]
+    },
+    {
+      "id": "594f85ac-20a5-4758-bd2a-d8b28fe2d808",
+      "identifiers": [
+        {
+          "identifier": "583",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/583.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/583.jpg"
+        }
+      ],
+      "name": "SAMAILA SULEIMAN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/583"
+        }
+      ]
+    },
+    {
+      "id": "fcdd186a-3e82-4d05-8f02-32b4b30dd6f5",
+      "identifiers": [
+        {
+          "identifier": "706",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SAMUEL IKON",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/706"
+        }
+      ]
+    },
+    {
+      "id": "e0167e52-a98b-44db-a385-e3c5b33c2969",
+      "identifiers": [
+        {
+          "identifier": "737",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SAMUEL ONUIGBO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/737"
+        }
+      ]
+    },
+    {
+      "id": "86250b8a-201b-4d62-9c93-d8f7ab7b4911",
+      "identifiers": [
+        {
+          "identifier": "641",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SAMUEL WILLIAM",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/641"
+        }
+      ]
+    },
+    {
+      "id": "b72e517d-600f-4421-8c18-76263d959a66",
+      "identifiers": [
+        {
+          "identifier": "622",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SANI AMINU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/622"
+        }
+      ]
+    },
+    {
+      "id": "5ff2f8a2-7e20-4083-a740-b686a369bf86",
+      "identifiers": [
+        {
+          "identifier": "437",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/437.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/437.jpg"
+        }
+      ],
+      "name": "SANI DAURA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/437"
+        }
+      ]
+    },
+    {
+      "id": "13c712a7-44ab-4034-bbb8-30079b745cdf",
+      "identifiers": [
+        {
+          "identifier": "764",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SANI SAIDU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/764"
+        }
+      ]
+    },
+    {
+      "id": "763b937d-40c9-4510-baca-f5dafd339965",
+      "identifiers": [
+        {
+          "identifier": "614",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SANI UMAR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/614"
+        }
+      ]
+    },
+    {
+      "id": "9ca6ab56-a7e0-4616-9e21-bed883d3e20c",
+      "identifiers": [
+        {
+          "identifier": "557",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SEGUN ADEKOLA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/557"
+        }
+      ]
+    },
+    {
+      "id": "e01dd914-0d13-4db4-bb54-a5a88b93a5be",
+      "identifiers": [
+        {
+          "identifier": "661",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SERGIUS OGUN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/661"
+        }
+      ]
+    },
+    {
+      "id": "5b7c85fc-e64f-49ba-b198-f2d7738dcf9e",
+      "identifiers": [
+        {
+          "identifier": "578",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/578.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/578.jpg"
+        }
+      ],
+      "name": "SHEHU ALIYU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/578"
+        }
+      ]
+    },
+    {
+      "id": "4c485a8d-f8c5-4287-8935-d4fd39f1b3f1",
+      "identifiers": [
+        {
+          "identifier": "654",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SHEHU SALEH",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/654"
+        }
+      ]
+    },
+    {
+      "id": "e6bd93db-b6ce-466f-97b2-c5c42f208872",
+      "identifiers": [
+        {
+          "identifier": "640",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SIMON ARABO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/640"
+        }
+      ]
+    },
+    {
+      "id": "a64a8a2e-8638-41aa-9a8b-b336ec53934f",
+      "identifiers": [
+        {
+          "identifier": "846",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SODAGUNO FESTUS-OMONI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/846"
+        }
+      ]
+    },
+    {
+      "id": "c4bac33d-10b8-419c-8f1e-4a472dfcf103",
+      "identifiers": [
+        {
+          "identifier": "679",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SOPULUCHUKWU EZEONWUKA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/679"
+        }
+      ]
+    },
+    {
+      "id": "5d985d83-c5e0-46ee-9e61-04594717a3b0",
+      "identifiers": [
+        {
+          "identifier": "867",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "STELLA NGWU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/867"
+        }
+      ]
+    },
+    {
+      "id": "d26a7682-d75e-49e1-b44d-582374e86951",
+      "identifiers": [
+        {
+          "identifier": "606",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SULAIMAN ROMO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/606"
+        }
+      ]
+    },
+    {
+      "id": "6849db26-474d-46f1-8bc1-6c29e542d364",
+      "identifiers": [
+        {
+          "identifier": "650",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SULEIMAN AMINU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/650"
+        }
+      ]
+    },
+    {
+      "id": "0baa5a03-b1e0-4e66-b3f9-daee8bacb87d",
+      "identifiers": [
+        {
+          "identifier": "857",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SUNDAY KARIMI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/857"
+        }
+      ]
+    },
+    {
+      "id": "305500ed-340a-4ae1-83d3-68ead88a893c",
+      "identifiers": [
+        {
+          "identifier": "658",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/658.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/658.jpg"
+        }
+      ],
+      "name": "SUNDAY OLADIMEJI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/658"
+        }
+      ]
+    },
+    {
+      "id": "ea083b8f-f370-484e-bb84-63541cd0cc1c",
+      "identifiers": [
+        {
+          "identifier": "763",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "SYLVESTER OGBAGA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/763"
+        }
+      ]
+    },
+    {
+      "id": "2f3453b5-6567-4460-91f2-b388d1ab9099",
+      "identifiers": [
+        {
+          "identifier": "634",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Shehu Musa",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/634"
+        }
+      ]
+    },
+    {
+      "id": "e47293a7-720a-4ea0-b61f-e16c80ffb511",
+      "identifiers": [
+        {
+          "identifier": "503",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/503.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/503.jpg"
+        }
+      ],
+      "name": "Shuaibu Abdulraman",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/503"
+        }
+      ]
+    },
+    {
+      "id": "bfab36c0-a199-42da-a005-94e31066d2be",
+      "identifiers": [
+        {
+          "identifier": "886",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Solomon Adaelu",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/886"
+        }
+      ]
+    },
+    {
+      "id": "9c636dc2-431e-4ec9-8337-2211f6cf547e",
+      "identifiers": [
+        {
+          "identifier": "559",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/559.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/559.jpg"
+        }
+      ],
+      "name": "Solomon Ahwinahwi",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/559"
+        }
+      ]
+    },
+    {
+      "id": "a435ef24-0197-44e6-8dbd-8fe1c87206e1",
+      "identifiers": [
+        {
+          "identifier": "645",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "TAJUDEEN ABBAS",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/645"
+        }
+      ]
+    },
+    {
+      "id": "24548ea1-20ce-44bb-8995-5ea4d27a21c5",
+      "identifiers": [
+        {
+          "identifier": "619",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "TAJUDEEN OBASA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/619"
+        }
+      ]
+    },
+    {
+      "id": "b393127e-a630-43d9-8fba-0eb0f37a0e6d",
+      "identifiers": [
+        {
+          "identifier": "708",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "TAOFEEK ADARANIJO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/708"
+        }
+      ]
+    },
+    {
+      "id": "52cec1d0-75a5-44c0-acfb-038a7f4cd5a0",
+      "identifiers": [
+        {
+          "identifier": "669",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "TARKIGHIN DICKSON",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/669"
+        }
+      ]
+    },
+    {
+      "id": "5002acd7-8dd6-48ac-814f-c4c57a92e40a",
+      "identifiers": [
+        {
+          "identifier": "928",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "TEMITOPE OLATOYE",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/928"
+        }
+      ]
+    },
+    {
+      "id": "007d807d-2f2d-4a2e-829f-1fd5109bb7de",
+      "identifiers": [
+        {
+          "identifier": "684",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "TIJJANI ABDUL KADIR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/684"
+        }
+      ]
+    },
+    {
+      "id": "f0eb90f1-c40e-49e4-9def-75bda049c788",
+      "identifiers": [
+        {
+          "identifier": "726",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "TIMOTHY GOLU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/726"
+        }
+      ]
+    },
+    {
+      "id": "13e149bf-bc57-4c7d-b5ee-3111daca51c6",
+      "identifiers": [
+        {
+          "identifier": "660",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "TOBY OKECHUKWU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/660"
+        }
+      ]
+    },
+    {
+      "id": "1e32d025-0def-4efc-96c8-0d00d87de51e",
+      "identifiers": [
+        {
+          "identifier": "548",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/548.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/548.jpg"
+        }
+      ],
+      "name": "Tasir Raji",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/548"
+        }
+      ]
+    },
+    {
+      "id": "954eaef9-c9c4-40a6-be39-25339065e6ff",
+      "identifiers": [
+        {
+          "identifier": "955",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Tony Nwulu",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/955"
+        }
+      ]
+    },
+    {
+      "id": "9815f746-7531-4529-bdfb-1f3ba6e954bf",
+      "identifiers": [
+        {
+          "identifier": "833",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "UCHECHIRUN NNAM-OBI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/833"
+        }
+      ]
+    },
+    {
+      "id": "d9936274-8b09-43dd-8289-2bdc96c0dfe0",
+      "identifiers": [
+        {
+          "identifier": "671",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "UJAM CHUKWUEMEKA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/671"
+        }
+      ]
+    },
+    {
+      "id": "10414161-787c-4423-a6f3-bf0547665d19",
+      "identifiers": [
+        {
+          "identifier": "874",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/874.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/874.jpg"
+        }
+      ],
+      "name": "UMAR JIBRIL",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/874"
+        }
+      ]
+    },
+    {
+      "id": "ab2e3960-7d0f-45b9-825f-35c533ebf857",
+      "identifiers": [
+        {
+          "identifier": "667",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "UMAR MUHAMMED",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/667"
+        }
+      ]
+    },
+    {
+      "id": "380aa4f9-c947-40af-815c-dbb9267340ac",
+      "identifiers": [
+        {
+          "identifier": "851",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/851.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/851.jpg"
+        }
+      ],
+      "name": "UMAR YAKUBU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/851"
+        }
+      ]
+    },
+    {
+      "id": "5007b010-495c-4eba-937b-35c97001910f",
+      "identifiers": [
+        {
+          "identifier": "856",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "UMARU MOHAMMED",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/856"
+        }
+      ]
+    },
+    {
+      "id": "87fa5f5d-ea7d-4499-b032-5001192ceb68",
+      "identifiers": [
+        {
+          "identifier": "561",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/561.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/561.jpg"
+        }
+      ],
+      "name": "USMAN IBRAHIM",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/561"
+        }
+      ]
+    },
+    {
+      "id": "a7d48bda-e47d-4807-a9e6-07a790800d41",
+      "identifiers": [
+        {
+          "identifier": "683",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "USMAN SHEHU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/683"
+        }
+      ]
+    },
+    {
+      "id": "0276a03a-323f-40ff-8e3f-d66f9c54bd0b",
+      "identifiers": [
+        {
+          "identifier": "591",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/591.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/591.jpg"
+        }
+      ],
+      "name": "USMAN SHIDDI",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/591"
+        }
+      ]
+    },
+    {
+      "id": "af34db4e-cd4c-40aa-8197-b7a7dc45847b",
+      "identifiers": [
+        {
+          "identifier": "952",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Ugwuegede Ikechukwu",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/952"
+        }
+      ]
+    },
+    {
+      "id": "c460c61f-bdaf-40f5-b64f-2039604367a5",
+      "identifiers": [
+        {
+          "identifier": "547",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/547.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/547.jpg"
+        }
+      ],
+      "name": "Uko Nkole",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/547"
+        }
+      ]
+    },
+    {
+      "id": "651299a7-ecb5-465a-8262-4cbe728ea85f",
+      "identifiers": [
+        {
+          "identifier": "954",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Uthman Munir",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/954"
+        }
+      ]
+    },
+    {
+      "id": "c2c2e02a-5840-496f-98ac-98671cdbdce6",
+      "identifiers": [
+        {
+          "identifier": "735",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "YAHAYA CHADO",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/735"
+        }
+      ]
+    },
+    {
+      "id": "dd79529c-471d-4943-b3fa-6b5a36018b75",
+      "identifiers": [
+        {
+          "identifier": "582",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "YAKUB BALOGUN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/582"
+        }
+      ]
+    },
+    {
+      "id": "e87ae72e-3445-49f6-9650-9499d7ea69ae",
+      "identifiers": [
+        {
+          "identifier": "854",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "YAYAHA SULEIMAN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/854"
+        }
+      ]
+    },
+    {
+      "id": "3d90055e-7223-4978-89c8-07685eb4b283",
+      "identifiers": [
+        {
+          "identifier": "542",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/542.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/542.jpg"
+        }
+      ],
+      "name": "YUNUSA ABUBAKAR",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/542"
+        }
+      ]
+    },
+    {
+      "id": "1da348a6-3c05-498c-b1b9-74ecb747be49",
+      "identifiers": [
+        {
+          "identifier": "668",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "YUSUF BUBA",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/668"
+        }
+      ]
+    },
+    {
+      "id": "70ab94b6-2262-4f7b-bc5f-16cf475bfcac",
+      "identifiers": [
+        {
+          "identifier": "367",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/367.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/367.jpg"
+        }
+      ],
+      "name": "YUSUF LASUN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/367"
+        }
+      ]
+    },
+    {
+      "id": "d9b26731-6e74-4896-bedc-e924590fbe13",
+      "identifiers": [
+        {
+          "identifier": "602",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "YUSUF SAIDU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/602"
+        }
+      ]
+    },
+    {
+      "id": "42fdabc8-9bbb-4d09-b7db-261a3b61b5a6",
+      "identifiers": [
+        {
+          "identifier": "617",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "YUSUF TAJUDEEN",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/617"
+        }
+      ]
+    },
+    {
+      "id": "77c0dd7a-dae7-461e-aa98-02dee6a79221",
+      "identifiers": [
+        {
+          "identifier": "540",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/540.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/540.jpg"
+        }
+      ],
+      "name": "ZAKARI SALISU",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/540"
+        }
+      ]
+    },
+    {
+      "id": "949c67a8-063e-408e-98c4-dd2294c953d5",
+      "identifiers": [
+        {
+          "identifier": "860",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "Zaphaniah Jisalo",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/860"
+        }
+      ]
+    },
+    {
+      "id": "f9e6d731-c734-4986-bc94-7f3e749d3270",
+      "identifiers": [
+        {
+          "identifier": "835",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "abiodun awoleye",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/835"
+        }
+      ]
+    },
+    {
+      "id": "631c3523-c284-469d-8fdf-e30d147ee88a",
+      "identifiers": [
+        {
+          "identifier": "893",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "abiodun olasupo",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/893"
+        }
+      ]
+    },
+    {
+      "id": "51c8fe3f-5e57-4e49-a373-fc9820a8802c",
+      "identifiers": [
+        {
+          "identifier": "770",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "abubakar adamu",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/770"
+        }
+      ]
+    },
+    {
+      "id": "5930bf13-221b-4b11-90ae-154cabd61af8",
+      "identifiers": [
+        {
+          "identifier": "855",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "akeem adeyemi",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/855"
+        }
+      ]
+    },
+    {
+      "id": "d5d7e6d0-c824-4790-b455-12c5f5b38a30",
+      "identifiers": [
+        {
+          "identifier": "902",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ali isa",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/902"
+        }
+      ]
+    },
+    {
+      "id": "9cb0fa3f-13da-4444-b571-a38a4e0c4524",
+      "identifiers": [
+        {
+          "identifier": "897",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "aliyu muktar",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/897"
+        }
+      ]
+    },
+    {
+      "id": "bc85343e-b96f-48a2-b2ff-2127f061a7c9",
+      "identifiers": [
+        {
+          "identifier": "772",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "awulu adaji",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/772"
+        }
+      ]
+    },
+    {
+      "id": "e5c64ded-fbca-42d0-903e-44618f4964bf",
+      "identifiers": [
+        {
+          "identifier": "825",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "babajinmi benson",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/825"
+        }
+      ]
+    },
+    {
+      "id": "fce6b6d3-4f57-42c0-bfdd-710d41a5d089",
+      "identifiers": [
+        {
+          "identifier": "908",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "barambu kawuwa",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/908"
+        }
+      ]
+    },
+    {
+      "id": "299f6b83-cbf8-4780-845d-35477e6b9f3c",
+      "identifiers": [
+        {
+          "identifier": "675",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "betty apiafi",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/675"
+        }
+      ]
+    },
+    {
+      "id": "6e824b24-29b3-43c1-aae9-15d556e014b9",
+      "identifiers": [
+        {
+          "identifier": "731",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "chime oji",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/731"
+        }
+      ]
+    },
+    {
+      "id": "de9be2db-dc90-4d40-a967-e906ce7c2f99",
+      "identifiers": [
+        {
+          "identifier": "826",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "d boma",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/826"
+        }
+      ]
+    },
+    {
+      "id": "72be377a-ef68-44ab-a563-1958e4c74096",
+      "identifiers": [
+        {
+          "identifier": "875",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "d. muhammad",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/875"
+        }
+      ]
+    },
+    {
+      "id": "f82c9e9c-24d5-47e8-a490-7a84cb4ac57c",
+      "identifiers": [
+        {
+          "identifier": "837",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "daniel reyenieju",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/837"
+        }
+      ]
+    },
+    {
+      "id": "ff5b5a16-9243-4cc0-83fc-b4c97f44ce63",
+      "identifiers": [
+        {
+          "identifier": "901",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "eke bede",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/901"
+        }
+      ]
+    },
+    {
+      "id": "c30c00dc-f1c5-44f6-b42b-99be55b03589",
+      "identifiers": [
+        {
+          "identifier": "753",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/753.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/753.jpg"
+        }
+      ],
+      "name": "fulata abubakar",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/753"
+        }
+      ]
+    },
+    {
+      "id": "bd330f95-c1b8-4ae3-af52-61e2878f249c",
+      "identifiers": [
+        {
+          "identifier": "925",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "galadima zakariya'u",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/925"
+        }
+      ]
+    },
+    {
+      "id": "da20ea9b-54e7-4caa-a508-5f425ac7b11a",
+      "identifiers": [
+        {
+          "identifier": "926",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "garba sabo",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/926"
+        }
+      ]
+    },
+    {
+      "id": "946deeec-db1f-46b5-9769-f894f5a2b870",
+      "identifiers": [
+        {
+          "identifier": "872",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "hassan yuguda",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/872"
+        }
+      ]
+    },
+    {
+      "id": "4473b1c4-0423-46c9-bef0-57f768caa0f0",
+      "identifiers": [
+        {
+          "identifier": "621",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "husaini abubakar",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/621"
+        }
+      ]
+    },
+    {
+      "id": "6d39bb96-cdc2-4677-8164-4a4fc291bc3a",
+      "identifiers": [
+        {
+          "identifier": "766",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "idris Ahmed",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/766"
+        }
+      ]
+    },
+    {
+      "id": "3e9657f4-f662-4a2c-b9d3-630df6be49e4",
+      "identifiers": [
+        {
+          "identifier": "762",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "igbokwe raphael",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/762"
+        }
+      ]
+    },
+    {
+      "id": "648d4da1-86eb-4941-9104-7c7d2dc1ce63",
+      "identifiers": [
+        {
+          "identifier": "919",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "isah ibrahim",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/919"
+        }
+      ]
+    },
+    {
+      "id": "26b2faba-5957-49a2-a6d2-3645b0a0812e",
+      "identifiers": [
+        {
+          "identifier": "831",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "jerome eke",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/831"
+        }
+      ]
+    },
+    {
+      "id": "477b8b61-168f-47c1-b7c3-5b42c8e9453e",
+      "identifiers": [
+        {
+          "identifier": "850",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "julius pondi",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/850"
+        }
+      ]
+    },
+    {
+      "id": "ae8b4742-16db-410b-b05d-be813c2ef8cd",
+      "identifiers": [
+        {
+          "identifier": "666",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "linus okorie,fca",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/666"
+        }
+      ]
+    },
+    {
+      "id": "68ad0d36-e750-4486-83b0-f887cc360c78",
+      "identifiers": [
+        {
+          "identifier": "878",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "lucas gideon",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/878"
+        }
+      ]
+    },
+    {
+      "id": "eaa0affc-dfca-424b-9470-50faa560ab5d",
+      "identifiers": [
+        {
+          "identifier": "904",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "memga Emmanuel",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/904"
+        }
+      ]
+    },
+    {
+      "id": "a3e06cab-34c9-4180-9ad3-2433bfb8ec03",
+      "identifiers": [
+        {
+          "identifier": "830",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "michael omobgehin",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/830"
+        }
+      ]
+    },
+    {
+      "id": "debf0004-e243-4def-9040-43b63b658d5e",
+      "identifiers": [
+        {
+          "identifier": "881",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "mohammed danlami",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/881"
+        }
+      ]
+    },
+    {
+      "id": "bda297aa-6f98-4210-929d-c4814740dece",
+      "identifiers": [
+        {
+          "identifier": "843",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "muhd lawal",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/843"
+        }
+      ]
+    },
+    {
+      "id": "7b2e15e0-94c3-4758-9ac8-316a8469e89e",
+      "identifiers": [
+        {
+          "identifier": "841",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "nicholas mutu",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/841"
+        }
+      ]
+    },
+    {
+      "id": "55b39b1f-0922-4fb7-ac62-a4563282916e",
+      "identifiers": [
+        {
+          "identifier": "768",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "ochepo adamu",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/768"
+        }
+      ]
+    },
+    {
+      "id": "640b41f9-1e8c-41b4-8e73-ac6c95b6c8bf",
+      "identifiers": [
+        {
+          "identifier": "760",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "olatubosun oladele",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/760"
+        }
+      ]
+    },
+    {
+      "id": "1134b7bc-a663-415b-8340-0d688aa77e2f",
+      "identifiers": [
+        {
+          "identifier": "895",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "sani Mohammed",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/895"
+        }
+      ]
+    },
+    {
+      "id": "a8bbe0eb-610d-4aaf-a783-1d39e14549c9",
+      "identifiers": [
+        {
+          "identifier": "910",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "shriff mohammed",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/910"
+        }
+      ]
+    },
+    {
+      "id": "976be656-6c2d-461c-9b27-23ae8f307341",
+      "identifiers": [
+        {
+          "identifier": "922",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "sidi yakubu",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/922"
+        }
+      ]
+    },
+    {
+      "id": "26d3efdc-7eb1-475e-9201-c3616d1a8953",
+      "identifiers": [
+        {
+          "identifier": "914",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.nass.gov.ng/images/mps/avatar.jpg",
+      "images": [
+        {
+          "url": "http://www.nass.gov.ng/images/mps/avatar.jpg"
+        }
+      ],
+      "name": "suleiman salisu",
+      "sources": [
+        {
+          "url": "http://www.nass.gov.ng/mp/profile/914"
+        }
+      ]
+    }
+  ],
+  "organizations": [
+    {
+      "classification": "party",
+      "id": "A",
+      "name": "ACCORD"
+    },
+    {
+      "classification": "party",
+      "id": "APC",
+      "identifiers": [
+        {
+          "identifier": "Q4729266",
+          "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.apc.com.ng/"
+        }
+      ],
+      "name": "All Progressives Congress",
+      "other_names": [
+        {
+          "lang": "en",
+          "name": "All Progressives Congress",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ar",
+          "name": "مؤتمر الجميع التقدميين النيجيري",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "Congresso di Tutti i Progressisti",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "All Progressives Congress",
+          "note": "multilingual"
+        }
+      ]
+    },
+    {
+      "classification": "party",
+      "id": "APGA",
+      "name": "All Progressives Grand Alliance"
+    },
+    {
+      "classification": "party",
+      "id": "LP",
+      "name": "Labour Party"
+    },
+    {
+      "classification": "legislature",
+      "id": "legislature",
+      "identifiers": [
+        {
+          "identifier": "Q2635070",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "National Assembly",
+      "seats": 360
+    },
+    {
+      "classification": "party",
+      "id": "PDP",
+      "identifiers": [
+        {
+          "identifier": "Q1551163",
+          "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.peoplesdemocraticparty.net/"
+        }
+      ],
+      "name": "Peoples Democratic Party",
+      "other_names": [
+        {
+          "lang": "pt",
+          "name": "Partido Democrático Popular",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "People’s Democratic Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "pl",
+          "name": "Ludowa Partia Demokratyczna",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ig",
+          "name": "People's Democratic Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Parti démocratique populaire",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Partido Democrático Popular",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "People's Democratic Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "yo",
+          "name": "Ẹgbẹ́ Olóṣèlúaráìlú àwọn Aráàlù",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ms",
+          "name": "People's Democratic Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sv",
+          "name": "People’s Democratic Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "Partito democratico del popolo",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nb",
+          "name": "People's Democratic Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ar",
+          "name": "حزب الشعب الديمقراطي",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "Demokratikus Néppárt",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ru",
+          "name": "Народная демократическая партия",
+          "note": "multilingual"
+        },
+        {
+          "lang": "eo",
+          "name": "Popola Demokratia Partio",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Democratische Volkspartij",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sr",
+          "name": "Народна демократска странка",
+          "note": "multilingual"
+        }
+      ]
+    },
+    {
+      "classification": "party",
+      "id": "SDP",
+      "name": "Social Democratic Party"
+    }
+  ],
+  "meta": {
+    "sources": [
+      "http://www.nass.gov.ng/"
+    ]
+  },
+  "memberships": [
+    {
+      "area_id": "area/kukawa/mobbar/abadam/guzamalai,_borno_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "003e0736-add0-4997-9444-94fac606bb95",
+      "role": "member"
+    },
+    {
+      "area_id": "area/dawakin-tofa/tofa/rimin_gado,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "007d807d-2f2d-4a2e-829f-1fd5109bb7de",
+      "role": "member"
+    },
+    {
+      "area_id": "area/khana/gokana,_rivers_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "00f8089e-cc28-4433-90fa-48852600a92b",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ikeja,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "0116052b-c1a1-4053-89b2-a255e56f976d",
+      "role": "member"
+    },
+    {
+      "area_id": "area/anaocha/njikoka/dunukofia,_anambra_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "01fa4a69-45f0-42e2-812d-1a168b9356b4",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ibi/wukari,_taraba_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APGA",
+      "organization_id": "legislature",
+      "person_id": "0276a03a-323f-40ff-8e3f-d66f9c54bd0b",
+      "role": "member"
+    },
+    {
+      "area_id": "area/egor/ikpoba-okha,_edo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "02f60e2e-b2eb-49b1-ad43-efbc4809077d",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ethiope,_delta_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "02f6ec41-6711-434d-9bab-1e4143954edb",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gezawa/gabasawa,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "06356066-e59d-4182-b700-35120278bfdc",
+      "role": "member"
+    },
+    {
+      "area_id": "area/atakunmosa_east/_atakunmosa_west/ilesha_east/,_osun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "078f3198-ad87-45dd-8f6f-fa419eb79316",
+      "role": "member"
+    },
+    {
+      "area_id": "area/adavi/okehi,_kogi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "090cdc38-e999-4530-af1f-f1b7ca7e4e01",
+      "role": "member"
+    },
+    {
+      "area_id": "area/yagba_east/yagba_west/mopa-muro,_kogi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "0baa5a03-b1e0-4e66-b3f9-daee8bacb87d",
+      "role": "member"
+    },
+    {
+      "area_id": "area/arewa/dandi,_kebbi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "0baf46e2-4521-4400-96f7-75137e68c6cb",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ado-odo/ota,_ogun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "0c38ed75-9f5f-4821-998b-7d1537c761bd",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kuje/abaji/gwagwalada/kwali,_federal_capital_territory_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "0cfa657a-9ba3-4889-a30a-9c9c1040b9cb",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bende,_abia_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "0d39a31a-e14e-4141-af64-446f3db43247",
+      "role": "member"
+    },
+    {
+      "area_id": "area/lokoja/kogi/kk,_kogi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "10414161-787c-4423-a6f3-bf0547665d19",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gumel/maigatari/sule_tankarkar/gagarawa,_jigawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "1134b7bc-a663-415b-8340-0d688aa77e2f",
+      "role": "member"
+    },
+    {
+      "area_id": "area/lagos_mainland,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "11b0606e-4b96-4228-9ee4-c78b653283c0",
+      "role": "member"
+    },
+    {
+      "area_id": "area/mallam_madori/kaugama,_jigawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "13690167-45a0-48c1-97f2-724e65341972",
+      "role": "member"
+    },
+    {
+      "area_id": "area/daura/sandamu/maiadua,_katsina_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "13c712a7-44ab-4034-bbb8-30079b745cdf",
+      "role": "member"
+    },
+    {
+      "area_id": "area/aninri/agwu/oji-uzo,_enugu_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "13e149bf-bc57-4c7d-b5ee-3111daca51c6",
+      "role": "member"
+    },
+    {
+      "area_id": "area/oju/obi,_benue_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "159dcd2b-8991-481c-bea3-797503de0f03",
+      "role": "member"
+    },
+    {
+      "area_id": "area/esan_central/west/igueben,_edo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "182dbeaa-91bb-4138-854a-e78f4cb44eaa",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ife_central/east/north/south,_osun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "18dd9ba1-d20d-4eb6-89f0-b3db84c05246",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ikom/boki,_cross_river_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "18e353f3-f57f-4646-bcd6-603cdda084c2",
+      "role": "member"
+    },
+    {
+      "area_id": "area/itu/ibiono_ibom,_akwa_ibom_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "19333d94-5d10-4cb4-b94a-f919d6e090fa",
+      "role": "member"
+    },
+    {
+      "area_id": "area/zaki,_bauchi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "1a3d477f-10fe-4727-9212-d312e03bd55f",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kware/wamakko,_sokoto_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "1acd5fb5-c9ee-41e2-8236-8e7e64ba5207",
+      "role": "member"
+    },
+    {
+      "area_id": "area/hong/gombi,_adamawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "1da348a6-3c05-498c-b1b9-74ecb747be49",
+      "role": "member"
+    },
+    {
+      "area_id": "area/epe,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "1e32d025-0def-4efc-96c8-0d00d87de51e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/musawa/matazu,_katsina_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "1f2fdde9-40ee-4fa3-956f-039b8c07448d",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ika,_delta_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "1fd79189-2d7d-4822-9839-37a3b6d1b16c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/aguta,_anambra_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "2042f878-8ec3-4d2e-a7ac-d5cba38fdd56",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ohaukwu/ebonyi,_ebonyi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "2112408c-3908-409b-826a-52fa59654163",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gombe,kwami_&funakaye,_gombe_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "21ff1ae5-be2c-4c4c-93e9-d629a478a402",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ikole/oye,_ekiti_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "22c21b1b-5e7b-4d81-b849-7a82aebfda26",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ojo,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "24548ea1-20ce-44bb-8995-5ea4d27a21c5",
+      "role": "member"
+    },
+    {
+      "area_id": "area/mashi/dvisi,_katsina_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "24a57e06-1019-4ed5-a6a9-99af12871b17",
+      "role": "member"
+    },
+    {
+      "area_id": "area/okene/ogori-magogo,_kogi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "25e4ad12-dcda-4fcc-ab3e-00c24dd3a711",
+      "role": "member"
+    },
+    {
+      "area_id": "area/akoko-edo,_edo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "260593f3-76a9-4df0-999a-25cc14cd066b",
+      "role": "member"
+    },
+    {
+      "area_id": "area/etche/omuma,_rivers_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "26b2faba-5957-49a2-a6d2-3645b0a0812e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kaita/jibia,_katsina_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "26d3efdc-7eb1-475e-9201-c3616d1a8953",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kaduna_south,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "27b4d513-0f89-4e90-bc17-cc6f4c6f4789",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ehimembano/ihitte_uboma/obowo,_imo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "284631bd-2803-4e50-906d-846a52923a32",
+      "role": "member"
+    },
+    {
+      "area_id": "area/vandeikya/konshisha,_benue_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "284c5ab4-af02-4a34-9e3d-23f8f53964a0",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ajeromi-ifelodun,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "296f1852-72c5-4b9e-94e4-b923ff9e309d",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ibarapa_east/ido,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "299c9fe3-3f1a-4a45-a1ea-d239a3968240",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ahoada-east/abua/odual,_rivers_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "299f6b83-cbf8-4780-845d-35477e6b9f3c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/imeko_afon/egbado_north,_ogun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "29dfc79f-bd7c-49ef-a31b-913faabe8e4e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/aba_north/south,_abia_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APGA",
+      "organization_id": "legislature",
+      "person_id": "2d5472ed-c775-4af9-9277-87c97ed667b4",
+      "role": "member"
+    },
+    {
+      "area_id": "area/atisbo/saki_east/saki_west,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "2ed2a5b2-882f-499d-9962-2ffc9a9e4555",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bauchi,_bauchi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "2f3453b5-6567-4460-91f2-b388d1ab9099",
+      "role": "member"
+    },
+    {
+      "area_id": "area/owerri_municipal/owerri_north/west,_imo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APGA",
+      "organization_id": "legislature",
+      "person_id": "2f8a506d-ea53-4126-bc71-1b5deec22941",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ekiti_central,_ekiti_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "305500ed-340a-4ae1-83d3-68ead88a893c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ukanafun/orukanam,_akwa_ibom_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "31b8d277-22d5-48f2-a896-cb603866d54d",
+      "role": "member"
+    },
+    {
+      "area_id": "area/damaturu/gujba/gulani/tarmuwa,_yobe_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "329dc28f-bc10-4fc3-b769-61d17e077393",
+      "role": "member"
+    },
+    {
+      "area_id": "area/donga/ussa/takum/special_area,_taraba_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "3438649a-0572-4d86-b47c-42b2bdcbd46a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/southern_ijaw,_bayelsa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "350bdf87-adf7-4c43-89b0-788d2dd71776",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kankara/sabuwa/faskari,_katsina_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "356c08ec-a215-4f99-904a-3640b4cdf98a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/damboa/gwoza/chibok,_borno_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "35cc2522-e0d7-4e82-8619-2635bc60fd88",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ayedire/iwo/ola-oluwa,_osun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "35e448ea-2064-4c69-b7cc-9528a877a248",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ife_federal_constituency,_osun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "360ff59a-7382-4154-8a30-69f7f13912e6",
+      "role": "member"
+    },
+    {
+      "area_id": "area/zuru/fakai/sakaba/d/wasagu,_kebbi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "36aa99d5-6235-45b0-b831-58967b2555ed",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ankpa/omala/olamaboro,_kogi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "36f13d81-0781-45e7-b5de-0d5a71a9a69c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/chikum/kajuru,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "380aa4f9-c947-40af-815c-dbb9267340ac",
+      "role": "member"
+    },
+    {
+      "area_id": "area/somolu,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "387498db-b8e3-4110-8dfe-8952999c126d",
+      "role": "member"
+    },
+    {
+      "area_id": "area/oron/mbo/okobo/urueoffong/oruko/udung-uko,_akwa_ibom_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "395c7580-4078-44c5-98cd-445a371e1ffe",
+      "role": "member"
+    },
+    {
+      "area_id": "area/edu/moro/patigi,_kwara_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "3a8e8cdd-4467-4ff0-b61c-f786228424ab",
+      "role": "member"
+    },
+    {
+      "area_id": "area/mangu/bokkos,_plateau_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "3acdf153-8e52-4c6a-854c-7a24869dd1b6",
+      "role": "member"
+    },
+    {
+      "area_id": "area/mani/bindawa,_katsina_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "3b78b18c-75cd-486f-905b-ee1291ff95c5",
+      "role": "member"
+    },
+    {
+      "area_id": "area/idemili_north/south,_anambra_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "3cb4be54-0692-41f3-9fde-aef403474774",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bichi,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "3cb8bc47-9681-409a-a602-f54c2be08b52",
+      "role": "member"
+    },
+    {
+      "area_id": "area/odo-otin/ifelodun/boripe,_osun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "3d2f6c9a-781b-42c6-8a3a-e6240efa9b4a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/yamaltu-deba,_gombe_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "3d90055e-7223-4978-89c8-07685eb4b283",
+      "role": "member"
+    },
+    {
+      "area_id": "area/toro,_bauchi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "3e4fe02e-cdf8-4c5e-b88d-355cb886fb56",
+      "role": "member"
+    },
+    {
+      "area_id": "area/rimi/charanchi/batagarawa,_katsina_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "3e672fe3-54fd-4fe6-89d5-0bc6a34b0afc",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ahiazu_mbaise/ezinihitte,_imo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "3e9657f4-f662-4a2c-b9d3-630df6be49e4",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kankia/ingawa/kusada,_katsina_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "3f38fade-7505-4a43-b5d3-1d8d1afad279",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ikono/_ini,_akwa_ibom_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "40ac5b78-a4f2-45e3-b380-1d7ff585257e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gboko/tarka,_benue_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "40b6599d-8fcc-493d-aa1a-426581d49a40",
+      "role": "member"
+    },
+    {
+      "area_id": "area/abak/etim_ekpo/ika,_akwa_ibom_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "411de638-0045-4de9-afd1-ebba29059b0f",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ibarapa_central/ibarapa_north,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "421c73dc-b657-454e-93dc-80a02640a6e9",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kabba/bunu/ijumu,_kogi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "42fdabc8-9bbb-4d09-b7db-261a3b61b5a6",
+      "role": "member"
+    },
+    {
+      "area_id": "area/zurmi/shinkafi,_zamfara_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "4473b1c4-0423-46c9-bef0-57f768caa0f0",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ondo_east/ondo_west,_ondo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "44fafa9a-f1f8-484b-8580-11f1ec116d39",
+      "role": "member"
+    },
+    {
+      "area_id": "area/agaie/lapai,_niger_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "46fddce6-2c5e-4b70-8eb4-843501b059b7",
+      "role": "member"
+    },
+    {
+      "area_id": "area/burutu,_delta_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "477b8b61-168f-47c1-b7c3-5b42c8e9453e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/sagbama/ekeremor,_bayelsa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "4aa3a1f8-6788-4acd-ab49-7108b92b187a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/zangon_kataf/jaba,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "4aeb2a50-a77d-42d2-b687-dc295090d2af",
+      "role": "member"
+    },
+    {
+      "area_id": "area/magama/rijau,_niger_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "4c485a8d-f8c5-4287-8935-d4fd39f1b3f1",
+      "role": "member"
+    },
+    {
+      "area_id": "area/mushin_i,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "A",
+      "organization_id": "legislature",
+      "person_id": "4d2d6956-a86e-44e7-a8a7-1d4fa4e4b1a0",
+      "role": "member"
+    },
+    {
+      "area_id": "area/asa/ilorin_west,_kwara_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "4dded367-aad0-426b-a20e-a84d16f78f64",
+      "role": "member"
+    },
+    {
+      "area_id": "area/amuwo_odofin,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "4ef095c9-3402-4491-afce-59be3ad36187",
+      "role": "member"
+    },
+    {
+      "area_id": "area/lagelu/akinyele,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "5002acd7-8dd6-48ac-814f-c4c57a92e40a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/chanchaga,_niger_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "5007b010-495c-4eba-937b-35c97001910f",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ilorin_east/south,_kwara_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "50cb2a99-49a0-4ea7-b5a5-65a0bd7ede30",
+      "role": "member"
+    },
+    {
+      "area_id": "area/guyuk/shelleng,_adamawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "50ec61a9-dca5-456a-8430-73b7fd89616f",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ideato_north_/south,_imo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "515d2b39-e318-47ac-992f-39b3c44acc56",
+      "role": "member"
+    },
+    {
+      "area_id": "area/yola_north/yola_south/girei,_adamawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "5198eacc-97f8-4eb1-9ad9-1895cb5cb979",
+      "role": "member"
+    },
+    {
+      "area_id": "area/shiroro/rafi/munya,_niger_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "51c8fe3f-5e57-4e49-a373-fc9820a8802c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/makurdi/guma,_benue_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "52cec1d0-75a5-44c0-acfb-038a7f4cd5a0",
+      "role": "member"
+    },
+    {
+      "area_id": "area/dala,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "5417f0ae-48a3-4e36-8d4b-820b75dfc976",
+      "role": "member"
+    },
+    {
+      "area_id": "area/,_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "543f5de3-208e-40fb-8925-a3717d098ab0",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ikwo/ezza_south,_ebonyi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "54790a50-af87-4d4d-ab8d-0798351c0d41",
+      "role": "member"
+    },
+    {
+      "area_id": "area/afikpo_north/afikpo_south,_ebonyi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "54898789-b7ed-4933-ad91-f26aae2cef42",
+      "role": "member"
+    },
+    {
+      "area_id": "area/funtua/dandume,_katsina_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "557d08dc-0bc1-4129-b082-6ac8b938978a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/surulere_ii,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "559e1aad-6916-4cae-9893-c3a742157fc9",
+      "role": "member"
+    },
+    {
+      "area_id": "area/apa/agatu,_benue_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "55b39b1f-0922-4fb7-ac62-a4563282916e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/lafia/obi,_nassarawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "58a2855c-7b99-4837-b234-deed1fc2404a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/afijio/oyo_east/oyo_west/_atiba,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "5930bf13-221b-4b11-90ae-154cabd61af8",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kaduna_north,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "594f85ac-20a5-4758-bd2a-d8b28fe2d808",
+      "role": "member"
+    },
+    {
+      "area_id": "area/langtang_north/south,_plateau_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "59ca73d9-1f43-46c4-9069-498c5cfeed0a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bodinga/dange-shuni/tureta,_sokoto_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "5b7c85fc-e64f-49ba-b198-f2d7738dcf9e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/akoko_south_east/south_west,_ondo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "5bca4ac7-190e-4cf1-a1a9-7c0735f4d764",
+      "role": "member"
+    },
+    {
+      "area_id": "area/,_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "5c7cf5cd-eb34-4689-8c23-03f185e8628b",
+      "role": "member"
+    },
+    {
+      "area_id": "area/igbo-etiti/uzo-uwani,_enugu_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "5d985d83-c5e0-46ee-9e61-04594717a3b0",
+      "role": "member"
+    },
+    {
+      "area_id": "area/akoko_north_east/west,_ondo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "5df2ecb5-be44-435e-864c-e5df712f9006",
+      "role": "member"
+    },
+    {
+      "area_id": "area/baure/zango,_katsina_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "5ff2f8a2-7e20-4083-a740-b686a369bf86",
+      "role": "member"
+    },
+    {
+      "area_id": "area/idanre/ifedore,_ondo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "60ac3d18-9946-41e9-a7cf-6a5d35b281ec",
+      "role": "member"
+    },
+    {
+      "area_id": "area/mikang/quan.pan/shendam,_plateau_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "62874761-fd85-4dc5-a6bc-579b4f908086",
+      "role": "member"
+    },
+    {
+      "area_id": "area/iseyin/itesiwaju/kajola/iwajowa,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "631c3523-c284-469d-8fdf-e30d147ee88a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/olurunsogo/oorelope,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "640b41f9-1e8c-41b4-8e73-ac6c95b6c8bf",
+      "role": "member"
+    },
+    {
+      "area_id": "area/tsafe/gusau,_zamfara_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "648d4da1-86eb-4941-9104-7c7d2dc1ce63",
+      "role": "member"
+    },
+    {
+      "area_id": "area/argungu/augie,_kebbi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "651299a7-ecb5-465a-8262-4cbe728ea85f",
+      "role": "member"
+    },
+    {
+      "area_id": "area/eket/onna/esit_eket/ibeno,_akwa_ibom_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "65580dd7-a319-41b4-8e48-c88e50f5bcae",
+      "role": "member"
+    },
+    {
+      "area_id": "area/alabasu/gaya/ajingi,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "6706efee-7156-488a-95c4-4dd10b544c7a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/fagge,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "6849db26-474d-46f1-8bc1-6c29e542d364",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kaura,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "68ad0d36-e750-4486-83b0-f887cc360c78",
+      "role": "member"
+    },
+    {
+      "area_id": "area/lau/k/lamido/ardo-kola,_taraba_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "692c14c1-07cd-4bc7-bb09-0ade6b2b2f57",
+      "role": "member"
+    },
+    {
+      "area_id": "area/wase,_plateau_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "6d39bb96-cdc2-4677-8164-4a4fc291bc3a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/enugu_north/south,_enugu_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "6e824b24-29b3-43c1-aae9-15d556e014b9",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kaltungo/shongom,_gombe_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "6e8bd3ec-95ca-4df1-992d-024998cacba9",
+      "role": "member"
+    },
+    {
+      "area_id": "area/irepodun/olurunda/osogbo/orolu,_osun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "70ab94b6-2262-4f7b-bc5f-16cf475bfcac",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ido/osi,_moba/ilejeme,_ekiti_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "71228aab-a8fa-4592-a7e8-f512b77f3c67",
+      "role": "member"
+    },
+    {
+      "area_id": "area/dukku_/_nafada,_gombe_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "717fe4f9-c75a-475e-a549-84d845a34ab8",
+      "role": "member"
+    },
+    {
+      "area_id": "area/jemaa/sanga,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "726225dd-a03a-43b6-879a-414076ea6d27",
+      "role": "member"
+    },
+    {
+      "area_id": "area/yauri/shanga/ngaski,_kebbi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "72be377a-ef68-44ab-a563-1958e4c74096",
+      "role": "member"
+    },
+    {
+      "area_id": "area/isu/njaba/nkwerre/nwangele,_imo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "73129c99-b11d-43d2-bdff-687197a629d7",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ezza_north/ishielu,_ebonyi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "7446df85-7895-4c1e-8431-28b8cf83f523",
+      "role": "member"
+    },
+    {
+      "area_id": "area/katagum,_bauchi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "746673b7-5fb2-4446-83ba-5f63b97028f1",
+      "role": "member"
+    },
+    {
+      "area_id": "area/abeokuta_north/_obafemi-_owode/odeda,_ogun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "74a6dad8-d6c5-4322-8f25-35c757bebb95",
+      "role": "member"
+    },
+    {
+      "area_id": "area/lagos_island_i,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "74b1390d-39d3-4ce1-9ef4-8f7e7641d0df",
+      "role": "member"
+    },
+    {
+      "area_id": "area/dambatta/makoda,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "75824414-7ee6-48d5-bfe5-03e809eb3c7a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/askira-uba/hawul,_borno_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "75d9a145-030a-48cb-875e-789db11e6b63",
+      "role": "member"
+    },
+    {
+      "area_id": "area/tsanyawa/kunchi,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "763b937d-40c9-4510-baca-f5dafd339965",
+      "role": "member"
+    },
+    {
+      "area_id": "area/b/kebbi/kalgo/bunza,_kebbi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "764fce72-c12a-42ad-ba84-d899f81f7a77",
+      "role": "member"
+    },
+    {
+      "area_id": "area/surulere_i,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "765d47ff-a659-4faa-9fc7-d641fee30ac5",
+      "role": "member"
+    },
+    {
+      "area_id": "area/jos_south/east,_plateau_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "767961bb-6ba5-46a8-a640-3f14220519db",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ningi/warji,_bauchi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "77c0dd7a-dae7-461e-aa98-02dee6a79221",
+      "role": "member"
+    },
+    {
+      "area_id": "area/tudun-wada/doguwa,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "77e887ac-e9d6-46e6-8005-3b868b191617",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kumbosto,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "77f0b5b9-f9c9-41fd-b742-1d4db1bc8b81",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ifako-ijaiye,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "78726e95-961f-461d-9bd1-ca226e30be4d",
+      "role": "member"
+    },
+    {
+      "area_id": "area/emure/gbonyin/ekiti_east,_ekiti_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "790d799a-a330-416c-92dd-76b08676fc2c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/jos_south/east,_plateau_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "79d811f8-36c2-4d9c-8cb2-c360f746c209",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ikwerre/_emohua,_rivers_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "7a964ca1-67eb-43e9-8986-f2823bef710f",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bomadi/patani,_delta_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "7b2e15e0-94c3-4758-9ac8-316a8469e89e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/mushin_ii,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "7b93348e-4294-43a1-a6b2-5f32e478ad38",
+      "role": "member"
+    },
+    {
+      "area_id": "area/dutse/kiyawa,_jigawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "7bd2a315-5a9f-495b-a766-d534c429a0da",
+      "role": "member"
+    },
+    {
+      "area_id": "area/badagry,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "7d66426a-7fb1-4fb5-b111-4d8752365242",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gashaka/kurmi/sardauna,_taraba_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "7d66d561-a926-41a3-9c6c-e72dad7eea98",
+      "role": "member"
+    },
+    {
+      "area_id": "area/degema/bonny,_rivers_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "7d679377-c418-4ed0-89c3-f2992a32aa35",
+      "role": "member"
+    },
+    {
+      "area_id": "area/tarauni,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "8010d5b9-a35e-4b8b-bbf9-74cdd1507c4b",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ukwa_east/ukwa_west,_abia_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "821f87b4-905e-4d12-96f6-f453b5b6fbc5",
+      "role": "member"
+    },
+    {
+      "area_id": "area/oredo,_edo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "83096a24-9560-4584-af40-d4140f2bb72c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bursari/geidam/yunusari,_yobe_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "85152454-f6ec-4853-af8b-80b43f39ae11",
+      "role": "member"
+    },
+    {
+      "area_id": "area/nassarawa,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "857c85ec-3dba-49ed-89c8-543fc7cf0050",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bosso/paikoro,_niger_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "85a8d87b-5fe7-4c70-b1d7-512f8dba2178",
+      "role": "member"
+    },
+    {
+      "area_id": "area/abeokuta_south,_ogun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "86250b8a-201b-4d62-9c93-d8f7ab7b4911",
+      "role": "member"
+    },
+    {
+      "area_id": "area/jada/ganye/mayo_belwa/toungo,_adamawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "8643dbb1-57e4-4c5a-a34d-dcc76eb18a0c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ogoja/yala,_cross_river_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "868498bd-2a23-4477-96b9-17bf0dbf96ae",
+      "role": "member"
+    },
+    {
+      "area_id": "area/,_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "86de3065-7b55-47cd-8dab-8e85bb87fa0a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/,_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "875408c1-8bb0-4b66-9efb-defdeef28f47",
+      "role": "member"
+    },
+    {
+      "area_id": "area/enugu_east/isi-uzo,_enugu_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "87f8dbd5-975c-4a06-b45b-cb1eec546ef1",
+      "role": "member"
+    },
+    {
+      "area_id": "area/hadejia/kafin_hausa/auyo,_jigawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "87fa5f5d-ea7d-4499-b032-5001192ceb68",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kazaure/roni/gwiwa/yankwashi,_jigawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "8a0483b2-37d2-4abf-9ac1-24bf46fb34ec",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bungudu/maru,_zamfara_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "8ab0069f-7c0f-4fcb-8b93-486432b7520a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ado/obadigbo/opkokwu,_benue_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "8b910dbc-22e9-4408-8dcf-98276b530ad3",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ajaokuta,_kogi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "8cc24ea0-7960-424e-b6c7-2f886057b775",
+      "role": "member"
+    },
+    {
+      "area_id": "area/akure_north/south,_ondo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "8d17036d-0d51-4fb3-82eb-d5c9f2e2b9e5",
+      "role": "member"
+    },
+    {
+      "area_id": "area/rano/bunkure/kibiya,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "8d4197d8-4fd0-47f6-8489-64b9e9575ede",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ikot_ekpene/_essien_udim/_obot_akara,_akwa_ibom_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "8dd0112a-1805-44b8-9b7a-4c6a6faa5b70",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ileoluji-okeibo/odigbo,_ondo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "8e65e183-9e14-4029-b68b-4fa8a35d6179",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ibadan_north-_east/south-_east,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "8ecd73b9-0119-4f2a-9514-cf441b8246a2",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bali/gassol,_taraba_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "8ff5f0af-eaec-4e24-8896-eb41afbb9bd8",
+      "role": "member"
+    },
+    {
+      "area_id": "area/obokon/oriade,_osun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "902ca577-525c-46bb-8677-718d0e32ded5",
+      "role": "member"
+    },
+    {
+      "area_id": "area/soba,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "90f3b0fb-54e4-4e37-a65b-81beffd10257",
+      "role": "member"
+    },
+    {
+      "area_id": "area/fufore/song,_adamawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "92dbd640-9b33-4732-bf85-d82c1a756326",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gwer_east/gwer_west,_benue_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "93e50fab-06e9-4cf0-b24d-1af1141a06a1",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gwaram,_jigawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "946deeec-db1f-46b5-9769-f894f5a2b870",
+      "role": "member"
+    },
+    {
+      "area_id": "area/amac/bwari,_federal_capital_territory_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "949c67a8-063e-408e-98c4-dd2294c953d5",
+      "role": "member"
+    },
+    {
+      "area_id": "area/obubra/etung,_cross_river_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "94c7f532-97bf-411b-ba64-7a4cc612b97b",
+      "role": "member"
+    },
+    {
+      "area_id": "area/oluyole_local_govt.,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "94f050f0-bda4-4a83-8913-db7940d66411",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ijebu_ode/odogbolu/ijebu_north_east,_ogun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "94fca274-b7f8-4809-a2f4-6566d08ecf63",
+      "role": "member"
+    },
+    {
+      "area_id": "area/oshodi-isolo_ii,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "954eaef9-c9c4-40a6-be39-25339065e6ff",
+      "role": "member"
+    },
+    {
+      "area_id": "area/alimosho,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "965f94df-c963-486d-9437-a0d5e2a24e88",
+      "role": "member"
+    },
+    {
+      "area_id": "area/okrika/ogu-bolo,_rivers_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "97262ad4-9373-4d3b-bef8-e194f734b671",
+      "role": "member"
+    },
+    {
+      "area_id": "area/isoko_north/south,_delta_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "9732b1be-0b73-4d5b-9106-ae55e5a55eb2",
+      "role": "member"
+    },
+    {
+      "area_id": "area/machina/nguru/karasuwa/yusufari,_yobe_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "976be656-6c2d-461c-9b27-23ae8f307341",
+      "role": "member"
+    },
+    {
+      "area_id": "area/obio/akpor,_rivers_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "9815f746-7531-4529-bdfb-1f3ba6e954bf",
+      "role": "member"
+    },
+    {
+      "area_id": "area/jalingo/yorro/zing,_taraba_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "98615618-8f3a-4f5a-899a-9dd1275d9114",
+      "role": "member"
+    },
+    {
+      "area_id": "area/minjibir/ungogo,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "99b80f19-88d3-4d3e-9464-d26d12adbc87",
+      "role": "member"
+    },
+    {
+      "area_id": "area/onitsha_north/south,_anambra_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "9ab7d672-3488-4ce7-83df-d85603c0b1d8",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ona-ara/egbeda,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "9b34c9ba-428f-4c08-9e05-716de04fcb06",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ughelli_north/south/udu,_delta_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "9c636dc2-431e-4ec9-8337-2211f6cf547e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ekiti_south_west/ikere/ise/orun,_ekiti_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "9ca6ab56-a7e0-4616-9e21-bed883d3e20c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bagudo/suru,_kebbi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "9cac82e2-515f-492b-90f5-343530a48f0a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/biu/bayo/shani/kwaya_kusar,_borno_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "9cb0fa3f-13da-4444-b571-a38a4e0c4524",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kano_municipal,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "9d4283cd-7e90-4c59-a428-346c95bbe0a6",
+      "role": "member"
+    },
+    {
+      "area_id": "area/offa/oyun/ifelodun,_kwara_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "9d9b0610-b5f6-4f85-b6cf-d779a2aeeefe",
+      "role": "member"
+    },
+    {
+      "area_id": "area/nasarawa/toto,_nassarawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "9edd9f06-4880-49fe-89c7-68c473abb384",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ibeju-lekki,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "a037d5e6-cc05-4484-a1e4-87047c62a6b7",
+      "role": "member"
+    },
+    {
+      "area_id": "area/orhionmwon/uhunmwode,_edo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "a038a9a0-3752-40cd-80ab-0cb42be9c973",
+      "role": "member"
+    },
+    {
+      "area_id": "area/port_harcourt_2,_rivers_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "a06bff4f-5aba-4727-9c04-434569f7b234",
+      "role": "member"
+    },
+    {
+      "area_id": "area/sokoto_north/sokoto_south,_sokoto_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "a13b0d31-cad2-49fa-9173-ee030984aca3",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bida/gbako/katcha,_niger_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "a1906a92-c207-444e-83c5-221f635d1c6d",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ezeagu/udi,_enugu_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "a1fde7e8-6b68-4e69-9b87-f6d12b26cf88",
+      "role": "member"
+    },
+    {
+      "area_id": "area/tai/eleme/oyigbo,_rivers_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "a3c1d5ff-1271-484f-978a-11668e10b2fe",
+      "role": "member"
+    },
+    {
+      "area_id": "area/okitipupa/irele,_ondo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "a3e06cab-34c9-4180-9ad3-2433bfb8ec03",
+      "role": "member"
+    },
+    {
+      "area_id": "area/zaria_federal,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "a435ef24-0197-44e6-8dbd-8fe1c87206e1",
+      "role": "member"
+    },
+    {
+      "area_id": "area/babura/garki,_jigawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "a4683308-694e-4907-8eca-a6a968d9f3b8",
+      "role": "member"
+    },
+    {
+      "area_id": "area/orlu/oru_east/orsu,_imo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "a526c57d-09d5-4230-97fd-f1cf98b359dc",
+      "role": "member"
+    },
+    {
+      "area_id": "area/igboeze_north/udenu,_enugu_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "a5a3bc2d-d074-4d77-8112-604ac7630c77",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ogbia,_bayelsa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "a64a8a2e-8638-41aa-9a8b-b336ec53934f",
+      "role": "member"
+    },
+    {
+      "area_id": "area/karaye/rogo,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "a7d48bda-e47d-4807-a9e6-07a790800d41",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bama/ngala/kalabalge,_borno_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "a8bbe0eb-610d-4aaf-a783-1d39e14549c9",
+      "role": "member"
+    },
+    {
+      "area_id": "area/owan_west/east,_edo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "a910a5c7-163d-473d-a8ae-c14f3d637908",
+      "role": "member"
+    },
+    {
+      "area_id": "area/jere,_borno_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "a918818a-4004-4668-bacf-7805da576a0e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/agwara/borgu,_niger_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "ab2e3960-7d0f-45b9-825f-35c533ebf857",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ikara/kubau,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "add7f959-73ba-4afc-b236-19a98e9cdb8b",
+      "role": "member"
+    },
+    {
+      "area_id": "area/eseodo/ilaje,_ondo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "ade0005f-dccf-49dd-9f41-fefe8885beba",
+      "role": "member"
+    },
+    {
+      "area_id": "area/fika/fune,_yobe_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "ae393303-feda-4be9-be1d-f3d95fc8b05e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ohaukwu/ebonyi,_ebonyi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "ae8b4742-16db-410b-b05d-be813c2ef8cd",
+      "role": "member"
+    },
+    {
+      "area_id": "area/nsukka/igbo-eze_south,_enugu_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "af34db4e-cd4c-40aa-8197-b7a7dc45847b",
+      "role": "member"
+    },
+    {
+      "area_id": "area/demsa/numan/lamurde,_adamawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "SDP",
+      "organization_id": "legislature",
+      "person_id": "b0057850-1a94-4576-aa0f-ed300209bb12",
+      "role": "member"
+    },
+    {
+      "area_id": "area/akpabuyo/bakassi/calabar_south,_cross_river_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "b0e939a5-5889-4b76-b39d-21d1e21c937e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ihiala,_anambra_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "b17b20ef-a8a0-481b-abba-8a9ceedaed1e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kontagora/wushishi/mariga/masheg,_niger_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "b1cb36c5-bc2d-4230-b5c4-f3f958c20d55",
+      "role": "member"
+    },
+    {
+      "area_id": "area/maiduguri_(metropolitan),_borno_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "b2a7f72a-9ecf-4263-83f1-cb0f8783053c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ikot_abasi/mkpat_enin/eastern_obolo,_akwa_ibom_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "b32bbfd7-7e44-45e3-b1e1-fb5cff750021",
+      "role": "member"
+    },
+    {
+      "area_id": "area/agege,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "b393127e-a630-43d9-8fba-0eb0f37a0e6d",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ikenne/shagamu/remo_north,_ogun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "b4771d4f-81fb-47ef-9631-9f8520b391ad",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ogo-oluwa,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "b4c80409-374c-4429-8f08-a2a60bfa3c17",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gamawa,_bauchi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "b4e56469-45dd-4cfd-a258-8234f0f46e2b",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kebbe/tambuwal,_sokoto_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "b62f18fc-dd29-4b02-a5f7-95a42f956543",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kaura_namoda/birnin_magaji,_zamfara_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "b72e517d-600f-4421-8c18-76263d959a66",
+      "role": "member"
+    },
+    {
+      "area_id": "area/eti-osa,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "b77bf509-47ad-4a86-9188-401e18312e42",
+      "role": "member"
+    },
+    {
+      "area_id": "area/isuikwato/umunneochi,_abia_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "b7a2ac57-9d18-4e5d-a177-e41a99fc83a2",
+      "role": "member"
+    },
+    {
+      "area_id": "area/igabi,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "b7d77f59-9d90-4d4a-8911-b096c921dc30",
+      "role": "member"
+    },
+    {
+      "area_id": "area/port_harcourt_1,_rivers_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "b97f173d-2163-4f8a-9632-c857511ed427",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gudu/tangaza,_sokoto_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "b9bd9f0c-cee1-4451-b7b8-3845f5c72f8c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/sabon_gari,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "ba282346-4ec2-4712-9d47-d463d46da0f9",
+      "role": "member"
+    },
+    {
+      "area_id": "area/awka_north/south,_anambra_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "ba539602-2401-4974-9ed9-1a5003028b39",
+      "role": "member"
+    },
+    {
+      "area_id": "area/dekina/bassa,_kogi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "bc3c9923-3157-4fbd-afe0-a0203e3f20d9",
+      "role": "member"
+    },
+    {
+      "area_id": "area/otukpo/ohimini,_benue_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "bc85343e-b96f-48a2-b2ff-2127f061a7c9",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bade/jakusko,_yobe_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "bd330f95-c1b8-4ae3-af52-61e2878f249c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/nnewi_north/south/ekwusigo,_anambra_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "bd3ce3b6-9eb9-46a1-baf2-503e6f6a4858",
+      "role": "member"
+    },
+    {
+      "area_id": "area/lere,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "bda297aa-6f98-4210-929d-c4814740dece",
+      "role": "member"
+    },
+    {
+      "area_id": "area/isiala_mbano/okigwe/onuimo,_imo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "beda968f-381d-47cb-b1a3-07806fe627d5",
+      "role": "member"
+    },
+    {
+      "area_id": "area/isa-sabon-birni,_sokoto_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "bf2e026d-c295-496f-ac19-b0897e5f8e0b",
+      "role": "member"
+    },
+    {
+      "area_id": "area/obingwa/osisioma/ugbunagbo,_abia_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "bfab36c0-a199-42da-a005-94e31066d2be",
+      "role": "member"
+    },
+    {
+      "area_id": "area/malumfashi/kafur,_katsina_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "bfacc136-b4e0-4021-9c71-5ab1dc45dd74",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kosofe,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "c14f9e8b-fa61-47fd-bea8-de476895373a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kaga/gubio/magumeri,_borno_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "c2178d8a-fe28-4b7d-b291-de813d5612c8",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bakura/maradun,_zamfara_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "c2c2e02a-5840-496f-98ac-98671cdbdce6",
+      "role": "member"
+    },
+    {
+      "area_id": "area/makarfi/kudan,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "c306f5a2-7830-4a0f-a217-03e27b096579",
+      "role": "member"
+    },
+    {
+      "area_id": "area/birniwa/guri/kiri-kasamma,_jigawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "c30c00dc-f1c5-44f6-b42b-99be55b03589",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gwarzo/ikabo,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "c349a15f-1885-4ebd-accd-5e000230ea23",
+      "role": "member"
+    },
+    {
+      "area_id": "area/arochukwu/ohafia,_abia_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "c460c61f-bdaf-40f5-b64f-2039604367a5",
+      "role": "member"
+    },
+    {
+      "area_id": "area/orumba_north/south,_anambra_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "c4bac33d-10b8-419c-8f1e-4a472dfcf103",
+      "role": "member"
+    },
+    {
+      "area_id": "area/isiala_ngwa_north/south,_abia_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "c559cabf-04e8-468f-bc84-c3d52daf0e69",
+      "role": "member"
+    },
+    {
+      "area_id": "area/uyo/uruan/nsit_ata/ibeskip_asutan,_akwa_ibom_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "c7e9c2f7-02b2-43e9-a57d-42f54c7e01c7",
+      "role": "member"
+    },
+    {
+      "area_id": "area/michika/madagali,_adamawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "c8f995d8-29b6-43d2-b2cb-77a12a68b588",
+      "role": "member"
+    },
+    {
+      "area_id": "area/darazo/gunjuwa,_bauchi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "c9662b95-206c-4a9c-aa6a-5dda5c8e6aa7",
+      "role": "member"
+    },
+    {
+      "area_id": "area/lavun/mokwa/edati,_niger_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "cacf9de6-c729-4ea1-904c-2ce0515940b8",
+      "role": "member"
+    },
+    {
+      "area_id": "area/aniocha_north/aniocha_south/_oshimili_n_&_s,_delta_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "cc0c8ee4-5f23-4e20-8e71-9f9341f5e6cf",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ovia_south/west-ovia_north/east,_edo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "ce5bb010-0ada-40a2-9313-4f9e1d0824af",
+      "role": "member"
+    },
+    {
+      "area_id": "area/awe/doma/keana,_nassarawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "cf6981b7-c365-40ae-b2c7-9c1deaa081c1",
+      "role": "member"
+    },
+    {
+      "area_id": "area/dawakin_kudu/warawa,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "cf843d3a-89ef-4b1c-b286-ae49c5038b72",
+      "role": "member"
+    },
+    {
+      "area_id": "area/yenagoa/kolokuna/opokuma,_bayelsa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "cfbd55d3-3ce6-48e8-bfbc-bfc2b57e4f59",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kachia/kagarko,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "d0ca0091-8bde-4f07-aa4c-ad6c7f2506ea",
+      "role": "member"
+    },
+    {
+      "area_id": "area/wudil/garko,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "d1122514-8591-4a96-863c-1826fbea9bc8",
+      "role": "member"
+    },
+    {
+      "area_id": "area/boluwaduro/ifedayo/illa,_osun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "d1380eb2-87ec-46da-99df-27b2223e2a04",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gurara/suleja/tafa,_niger_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "d1b39c93-9087-4da4-adc4-e1ae99b35fc3",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bagwai/shanono,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "d26a7682-d75e-49e1-b44d-582374e86951",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bogoro/dass/tafawa_balewa,_bauchi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "d3557568-295b-48c2-8d9f-7d6b0753a48a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ijero/ekiti_west/efon,_ekiti_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "d3fae412-fb8b-4c59-8426-10a1c3f862fd",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gummi/bukkuyum,_zamfara_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "d467a019-de86-4406-a5ee-bb82ada812c5",
+      "role": "member"
+    },
+    {
+      "area_id": "area/jama’are/itas-gadau,_bauchi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "d4e2312b-c244-4cf8-be5e-e58325580b5a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/balanga/billiri,_gombe_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "d5d7e6d0-c824-4790-b455-12c5f5b38a30",
+      "role": "member"
+    },
+    {
+      "area_id": "area/buruku,_benue_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "d761bcb4-8021-4b38-b46b-e2c4d1d9cddc",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gwadabawa_/_illela,_sokoto_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "d782983c-2663-48e3-b24e-6da13ff04566",
+      "role": "member"
+    },
+    {
+      "area_id": "area/calabar_munincipal/odukpani,_cross_river_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "d7d9a7f3-972a-4ceb-9c97-a8787b86a673",
+      "role": "member"
+    },
+    {
+      "area_id": "area/brass/nembe,_bayelsa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "d879dab2-dbcf-41ce-a457-17b2552a4946",
+      "role": "member"
+    },
+    {
+      "area_id": "area/nkanu_east/nkanu_west,_enugu_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "d9936274-8b09-43dd-8289-2bdc96c0dfe0",
+      "role": "member"
+    },
+    {
+      "area_id": "area/jahun/miga,_jigawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "d9b26731-6e74-4896-bedc-e924590fbe13",
+      "role": "member"
+    },
+    {
+      "area_id": "area/nangere/potiskum,_yobe_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "da20ea9b-54e7-4caa-a508-5f425ac7b11a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ijebu_north/ijebu_east/ogun_waterside,_ogun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "dbbb2782-d52b-4594-8150-d98f73ad776e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/maiyama/koko/besse,_kebbi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "dcb0a859-5def-46d2-ab8e-22f110c9db62",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gwandu/aliero/jega,_kebbi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "dcffcccf-4ca8-4fcb-8be4-27f7b60e4148",
+      "role": "member"
+    },
+    {
+      "area_id": "area/lagos_island_ii,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "dd79529c-471d-4943-b3fa-6b5a36018b75",
+      "role": "member"
+    },
+    {
+      "area_id": "area/binji/silame,_sokoto_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "de5ac455-7e74-4648-816d-03de6b3b97e5",
+      "role": "member"
+    },
+    {
+      "area_id": "area/asalga/akulga,_rivers_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "de9be2db-dc90-4d40-a967-e906ce7c2f99",
+      "role": "member"
+    },
+    {
+      "area_id": "area/alkaleri/kirfi,_bauchi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "deac6723-504e-48ae-b116-5b319fe8ae54",
+      "role": "member"
+    },
+    {
+      "area_id": "area/dutsin-ma/kurfi,_katsina_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "debf0004-e243-4def-9040-43b63b658d5e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/shira/giade,_bauchi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "dee1b701-c30c-4161-815a-54dc12048c41",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ekiti/isin/irepodun/oke-ero,_kwara_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "dfb34e8f-f293-48a5-a492-e5591a474170",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bebeji/kiru,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "dfeacf04-9bd5-4f12-8440-2cb91b58ac9a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ikwuano/umuahia_north/south,_abia_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "e0167e52-a98b-44db-a385-e3c5b33c2969",
+      "role": "member"
+    },
+    {
+      "area_id": "area/esan_north-east/esan_south-_east,_edo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "e01dd914-0d13-4db4-bb54-a5a88b93a5be",
+      "role": "member"
+    },
+    {
+      "area_id": "area/goronyo/gada,_sokoto_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "e0864697-871a-4fb3-bbdc-7c04219bb496",
+      "role": "member"
+    },
+    {
+      "area_id": "area/egbado_south_and_ipokia,_ogun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "e1cda19f-f81d-4d7e-bfcf-5a5134cef83e",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ifo/ewekoro,_ogun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "e214e2b1-4555-4b24-8e0e-20756b28c34b",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ayedaade/irewole/isokan,_osun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "e31fdcad-208b-4cf8-9b7f-a4194f53cd98",
+      "role": "member"
+    },
+    {
+      "area_id": "area/oshodi-isolo_i,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "e35cd9c4-a48f-4158-ba49-f3637b273e27",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bakori/danja,_katsina_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "e4537751-d3a8-4805-b8c3-642f0fd7c5fb",
+      "role": "member"
+    },
+    {
+      "area_id": "area/mubi_n/mu_s/maiha,_adamawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "e47293a7-720a-4ea0-b61f-e16c80ffb511",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ogbaru,_anambra_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "e48fa637-1ddc-45e4-acaa-21a14127a330",
+      "role": "member"
+    },
+    {
+      "area_id": "area/mbaitolu/ikeduru,_imo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "e5360427-1eee-4606-ada6-89ca337d3780",
+      "role": "member"
+    },
+    {
+      "area_id": "area/akwanga/nasarawa_eggon/wamba,_nassarawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "e58346b8-fd97-4bb1-b24a-84f9cb4bb27c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ikorodu,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "e5c64ded-fbca-42d0-903e-44618f4964bf",
+      "role": "member"
+    },
+    {
+      "area_id": "area/keffi/karu/kokona,_nassarawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "e62ad765-bebf-4952-9814-629be886ceea",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kauru,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "e6bd93db-b6ce-466f-97b2-c5c42f208872",
+      "role": "member"
+    },
+    {
+      "area_id": "area/akpabuyo/bakassi/calabar_south,_cross_river_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "e708ad4d-7700-4557-a9bf-d832c0c3893a",
+      "role": "member"
+    },
+    {
+      "area_id": "area/baruten/kaiama,_kwara_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "e8415bea-7bb4-4075-9458-ea4b0d3d1b11",
+      "role": "member"
+    },
+    {
+      "area_id": "area/owo/ose,_ondo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "e848ce55-5b26-4ec1-9cf2-09889f0775d6",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bassa/jos_north,_plateau_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "e87ae72e-3445-49f6-9650-9499d7ea69ae",
+      "role": "member"
+    },
+    {
+      "area_id": "area/andoni/opobo/nkoro,_rivers_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "e8f3081e-2f66-408f-bc0b-7bb9f4d93ba7",
+      "role": "member"
+    },
+    {
+      "area_id": "area/dikwa/mafaf/konduga,_borno_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "e99f6599-47cc-4025-9551-58f90d0e455c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/abakaliki/izzi,_ebonyi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "ea083b8f-f370-484e-bb84-63541cd0cc1c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/katsina-ala/ukum/logo,_benue_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "eaa0affc-dfca-424b-9470-50faa560ab5d",
+      "role": "member"
+    },
+    {
+      "area_id": "area/birnin-kudu/buji,_jigawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "eb96273d-62bb-4a48-8615-ae257b378389",
+      "role": "member"
+    },
+    {
+      "area_id": "area/eti-osa,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "ebe932ac-37bf-4d9d-8b48-d8541a7dbeec",
+      "role": "member"
+    },
+    {
+      "area_id": "area/sumaila/takai,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "ec3ad0af-b8f7-4f12-8358-278ef53e6fc2",
+      "role": "member"
+    },
+    {
+      "area_id": "area/bekwarra/obudu/obanliku,_cross_river_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "ec925d92-5d97-477c-8b2a-c49064e7ffdc",
+      "role": "member"
+    },
+    {
+      "area_id": "area/misau/dambam,_bauchi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "ecad542f-6975-4a15-a31f-e2a8fbf041b4",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ede_north,south/egbedero/ejigbo,_osun_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "ed21de44-634c-469b-aeb4-6310664dfdad",
+      "role": "member"
+    },
+    {
+      "area_id": "area/anka/mafara,_zamfara_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "ed60d392-ebe6-49f6-8174-10eb29dbb216",
+      "role": "member"
+    },
+    {
+      "area_id": "area/etsako_east/west/central,_edo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "ed9e7d80-fafb-4d0a-93f9-a73adfd765db",
+      "role": "member"
+    },
+    {
+      "area_id": "area/idah/ibaji/igalamela/ofu,_kogi_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "ee50c7f9-787f-46eb-9c17-2d1b0d0dac56",
+      "role": "member"
+    },
+    {
+      "area_id": "area/gwale,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "ee784851-7a07-45d3-8314-b7d63bbd49aa",
+      "role": "member"
+    },
+    {
+      "area_id": "area/opke/sapele/uvwie,_delta_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "eed0c790-156d-499e-9745-1dfcfee22bb9",
+      "role": "member"
+    },
+    {
+      "area_id": "area/oyi/ayamelum,_anambra_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APGA",
+      "organization_id": "legislature",
+      "person_id": "f02cddda-fddf-4cf8-8fc5-b36ee0fdd895",
+      "role": "member"
+    },
+    {
+      "area_id": "area/pankshin/kanke/kanam,_plateau_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "f0eb90f1-c40e-49e4-9def-75bda049c788",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ndokwa/ukwani,_delta_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "f2556830-38db-4585-a8b6-7b511a9320e0",
+      "role": "member"
+    },
+    {
+      "area_id": "area/apapa,_lagos_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "f57fe0a1-478c-4ec4-b89a-9c7e18c89b43",
+      "role": "member"
+    },
+    {
+      "area_id": "area/birnin-gwari/giwa,_kaduna_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "f77669c1-8dbe-4747-aa68-f8c84dcd303d",
+      "role": "member"
+    },
+    {
+      "area_id": "area/warri,_delta_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "f82c9e9c-24d5-47e8-a490-7a84cb4ac57c",
+      "role": "member"
+    },
+    {
+      "area_id": "area/wurno/rabah,_sokoto_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "f8be60de-258a-46a2-97d6-f8014421f6d6",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ogbomosho/north/south/orire,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "LP",
+      "organization_id": "legislature",
+      "person_id": "f8c1f144-b33e-4f31-b094-f7f7cb9d2b55",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ringim/taura,_jigawa_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APGA",
+      "organization_id": "legislature",
+      "person_id": "f9c4b3ab-5844-48d0-9a99-d550dddbdf86",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ibadan_north,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "f9e6d731-c734-4986-bc94-7f3e749d3270",
+      "role": "member"
+    },
+    {
+      "area_id": "area/shagari/yabo,_sokoto_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "fb8aa21b-861f-489c-a935-87faa8c081f9",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kura/madobi/garun_malam,_kano_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "fb99f755-dd6b-4192-b503-fbafe5053ea4",
+      "role": "member"
+    },
+    {
+      "area_id": "area/ibadan_north_west/south_west,_oyo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "fbbb9c94-8873-458c-8998-06dcfe3302f5",
+      "role": "member"
+    },
+    {
+      "area_id": "area/yakurr/abi,_cross_river_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "fbe2b76b-4ee1-4e2b-9bcf-8f9dbb7a8dbf",
+      "role": "member"
+    },
+    {
+      "area_id": "area/etinan/nsit_ibom/nsit_ubium,_akwa_ibom_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "fcdd186a-3e82-4d05-8f02-32b4b30dd6f5",
+      "role": "member"
+    },
+    {
+      "area_id": "area/akko,_gombe_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "fce6b6d3-4f57-42c0-bfdd-710d41a5d089",
+      "role": "member"
+    },
+    {
+      "area_id": "area/barkin_ladi/riyom,_plateau_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "fd172c3e-4a15-498f-96e6-71a6573759cc",
+      "role": "member"
+    },
+    {
+      "area_id": "area/anambra_east/west,_anambra_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "fe1cd7cb-8c45-4886-a6ab-b93d9659979b",
+      "role": "member"
+    },
+    {
+      "area_id": "area/kwande/ushongo,_benue_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "APC",
+      "organization_id": "legislature",
+      "person_id": "ff16e23f-3be0-4a89-a263-4d974d9c3f24",
+      "role": "member"
+    },
+    {
+      "area_id": "area/aboh_mbaise/ngor_okpala,_imo_state",
+      "legislative_period_id": "term/2015",
+      "on_behalf_of_id": "PDP",
+      "organization_id": "legislature",
+      "person_id": "ff5b5a16-9243-4cc0-83fc-b4c97f44ce63",
+      "role": "member"
+    }
+  ],
+  "events": [
+    {
+      "classification": "general election",
+      "end_date": "1923",
+      "id": "Q22283794",
+      "name": "Nigerian general election, 1923",
+      "start_date": "1923"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1928",
+      "id": "Q22283791",
+      "name": "Nigerian general election, 1928",
+      "start_date": "1928"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1933",
+      "id": "Q22283790",
+      "name": "Nigerian general election, 1933",
+      "start_date": "1933"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1938",
+      "id": "Q22283787",
+      "name": "Nigerian general election, 1938",
+      "start_date": "1938"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1943",
+      "id": "Q22283785",
+      "name": "Nigerian general election, 1943",
+      "start_date": "1943"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1947",
+      "id": "Q22283781",
+      "name": "Nigerian general election, 1947",
+      "start_date": "1947"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1954",
+      "id": "Q22283777",
+      "name": "Nigerian general election, 1954",
+      "start_date": "1954"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1959",
+      "id": "Q1479981",
+      "name": "Nigerian parliamentary election, 1959",
+      "start_date": "1959"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1964",
+      "id": "Q17091809",
+      "name": "Nigerian parliamentary election, 1964",
+      "start_date": "1964"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1979",
+      "id": "Q17091814",
+      "name": "Nigerian parliamentary election, 1979",
+      "start_date": "1979"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1983",
+      "id": "Q17091819",
+      "name": "Nigerian parliamentary election, 1983",
+      "start_date": "1983"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1992",
+      "id": "Q7033040",
+      "name": "Nigerian parliamentary election, 1992",
+      "start_date": "1992"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1998",
+      "id": "Q7033041",
+      "name": "Nigerian parliamentary election, 1998",
+      "start_date": "1998"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1999",
+      "id": "Q7033042",
+      "name": "Nigerian parliamentary election, 1999",
+      "start_date": "1999"
+    },
+    {
+      "classification": "general election",
+      "end_date": "2003",
+      "id": "Q7033046",
+      "name": "Nigerian parliamentary election, 2003",
+      "start_date": "2003"
+    },
+    {
+      "classification": "general election",
+      "end_date": "2007-04-21",
+      "id": "Q177483",
+      "name": "Nigerian general election, 2007",
+      "start_date": "2007-04-21"
+    },
+    {
+      "classification": "general election",
+      "end_date": "2011",
+      "id": "Q7033044",
+      "name": "Nigerian parliamentary election, 2011",
+      "start_date": "2011"
+    },
+    {
+      "classification": "general election",
+      "end_date": "2015-03-28",
+      "id": "Q18205072",
+      "name": "Nigerian general election, 2015",
+      "start_date": "2015-03-28"
+    },
+    {
+      "classification": "legislative period",
+      "id": "term/2015",
+      "name": "2015–",
+      "organization_id": "legislature",
+      "start_date": "2015-06-09"
+    }
+  ],
+  "areas": [
+    {
+      "id": "area/,_state",
+      "name": ", State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/aba_north/south,_abia_state",
+      "name": "Aba North/South, Abia State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/abak/etim_ekpo/ika,_akwa_ibom_state",
+      "name": "Abak/Etim Ekpo/Ika, Akwa Ibom State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/abakaliki/izzi,_ebonyi_state",
+      "name": "Abakaliki/Izzi, Ebonyi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/abeokuta_north/_obafemi-_owode/odeda,_ogun_state",
+      "name": "Abeokuta North/ Obafemi- Owode/Odeda, Ogun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/abeokuta_south,_ogun_state",
+      "name": "Abeokuta South, Ogun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/aboh_mbaise/ngor_okpala,_imo_state",
+      "name": "Aboh Mbaise/Ngor Okpala, Imo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/adavi/okehi,_kogi_state",
+      "name": "Adavi/Okehi, Kogi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ado-odo/ota,_ogun_state",
+      "name": "Ado-Odo/Ota, Ogun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ado/obadigbo/opkokwu,_benue_state",
+      "name": "Ado/Obadigbo/Opkokwu, Benue State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/afijio/oyo_east/oyo_west/_atiba,_oyo_state",
+      "name": "Afijio/Oyo East/Oyo West/ Atiba, Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/afikpo_north/afikpo_south,_ebonyi_state",
+      "name": "Afikpo North/Afikpo South, Ebonyi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/agaie/lapai,_niger_state",
+      "name": "Agaie/Lapai, Niger State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/agege,_lagos_state",
+      "name": "Agege, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/aguta,_anambra_state",
+      "name": "Aguta, Anambra State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/agwara/borgu,_niger_state",
+      "name": "Agwara/Borgu, Niger State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ahiazu_mbaise/ezinihitte,_imo_state",
+      "name": "Ahiazu Mbaise/Ezinihitte, Imo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ahoada-east/abua/odual,_rivers_state",
+      "name": "Ahoada-East/Abua/Odual, Rivers State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ajaokuta,_kogi_state",
+      "name": "Ajaokuta, Kogi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ajeromi-ifelodun,_lagos_state",
+      "name": "Ajeromi-Ifelodun, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/akko,_gombe_state",
+      "name": "Akko, Gombe State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/akoko-edo,_edo_state",
+      "name": "Akoko-Edo, Edo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/akoko_north_east/west,_ondo_state",
+      "name": "Akoko North East/West, Ondo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/akoko_south_east/south_west,_ondo_state",
+      "name": "Akoko South East/South West, Ondo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/akpabuyo/bakassi/calabar_south,_cross_river_state",
+      "name": "Akpabuyo/Bakassi/Calabar South, Cross River State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/akure_north/south,_ondo_state",
+      "name": "Akure North/South, Ondo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/akwanga/nasarawa_eggon/wamba,_nassarawa_state",
+      "name": "Akwanga/Nasarawa Eggon/Wamba, Nassarawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/alabasu/gaya/ajingi,_kano_state",
+      "name": "Alabasu/Gaya/Ajingi, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/alimosho,_lagos_state",
+      "name": "Alimosho, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/alkaleri/kirfi,_bauchi_state",
+      "name": "Alkaleri/Kirfi, Bauchi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/amac/bwari,_federal_capital_territory_state",
+      "name": "AMAC/Bwari, Federal Capital Territory State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/amuwo_odofin,_lagos_state",
+      "name": "Amuwo Odofin, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/anambra_east/west,_anambra_state",
+      "name": "Anambra East/West, Anambra State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/anaocha/njikoka/dunukofia,_anambra_state",
+      "name": "Anaocha/Njikoka/Dunukofia, Anambra State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/andoni/opobo/nkoro,_rivers_state",
+      "name": "Andoni/Opobo/Nkoro, Rivers State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/aninri/agwu/oji-uzo,_enugu_state",
+      "name": "Aninri/Agwu/Oji-uzo, Enugu State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/aniocha_north/aniocha_south/_oshimili_n_&_s,_delta_state",
+      "name": "Aniocha North/Aniocha South/ Oshimili N & S, Delta State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/anka/mafara,_zamfara_state",
+      "name": "Anka/Mafara, Zamfara State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ankpa/omala/olamaboro,_kogi_state",
+      "name": "Ankpa/Omala/Olamaboro, Kogi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/apa/agatu,_benue_state",
+      "name": "Apa/Agatu, Benue State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/apapa,_lagos_state",
+      "name": "Apapa, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/arewa/dandi,_kebbi_state",
+      "name": "Arewa/Dandi, Kebbi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/argungu/augie,_kebbi_state",
+      "name": "Argungu/Augie, Kebbi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/arochukwu/ohafia,_abia_state",
+      "name": "Arochukwu/Ohafia, Abia State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/asa/ilorin_west,_kwara_state",
+      "name": "Asa/Ilorin West, Kwara State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/asalga/akulga,_rivers_state",
+      "name": "Asalga/Akulga, Rivers State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/askira-uba/hawul,_borno_state",
+      "name": "Askira-Uba/Hawul, Borno State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/atakunmosa_east/_atakunmosa_west/ilesha_east/,_osun_state",
+      "name": "Atakunmosa East/ Atakunmosa West/Ilesha East/, Osun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/atisbo/saki_east/saki_west,_oyo_state",
+      "name": "Atisbo/Saki East/Saki West, Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/awe/doma/keana,_nassarawa_state",
+      "name": "Awe/Doma/Keana, Nassarawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/awka_north/south,_anambra_state",
+      "name": "Awka North/South, Anambra State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ayedaade/irewole/isokan,_osun_state",
+      "name": "Ayedaade/Irewole/Isokan, Osun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ayedire/iwo/ola-oluwa,_osun_state",
+      "name": "Ayedire/Iwo/Ola-Oluwa, Osun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/b/kebbi/kalgo/bunza,_kebbi_state",
+      "name": "B/Kebbi/Kalgo/Bunza, Kebbi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/babura/garki,_jigawa_state",
+      "name": "Babura/Garki, Jigawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/badagry,_lagos_state",
+      "name": "Badagry, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bade/jakusko,_yobe_state",
+      "name": "Bade/Jakusko, Yobe State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bagudo/suru,_kebbi_state",
+      "name": "Bagudo/Suru, Kebbi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bagwai/shanono,_kano_state",
+      "name": "Bagwai/Shanono, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bakori/danja,_katsina_state",
+      "name": "Bakori/Danja, Katsina State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bakura/maradun,_zamfara_state",
+      "name": "Bakura/Maradun, Zamfara State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/balanga/billiri,_gombe_state",
+      "name": "Balanga/Billiri, Gombe State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bali/gassol,_taraba_state",
+      "name": "Bali/Gassol, Taraba State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bama/ngala/kalabalge,_borno_state",
+      "name": "Bama/Ngala/Kalabalge, Borno State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/barkin_ladi/riyom,_plateau_state",
+      "name": "Barkin Ladi/Riyom, Plateau State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/baruten/kaiama,_kwara_state",
+      "name": "Baruten/Kaiama, Kwara State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bassa/jos_north,_plateau_state",
+      "name": "Bassa/Jos North, Plateau State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bauchi,_bauchi_state",
+      "name": "Bauchi, Bauchi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/baure/zango,_katsina_state",
+      "name": "Baure/Zango, Katsina State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bebeji/kiru,_kano_state",
+      "name": "Bebeji/Kiru, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bekwarra/obudu/obanliku,_cross_river_state",
+      "name": "Bekwarra/Obudu/Obanliku, Cross River State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bende,_abia_state",
+      "name": "Bende, Abia State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bichi,_kano_state",
+      "name": "Bichi, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bida/gbako/katcha,_niger_state",
+      "name": "Bida/Gbako/Katcha, Niger State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/binji/silame,_sokoto_state",
+      "name": "Binji/Silame, Sokoto State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/birnin-gwari/giwa,_kaduna_state",
+      "name": "Birnin-Gwari/Giwa, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/birnin-kudu/buji,_jigawa_state",
+      "name": "Birnin-Kudu/Buji, Jigawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/birniwa/guri/kiri-kasamma,_jigawa_state",
+      "name": "Birniwa/Guri/Kiri-Kasamma, Jigawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/biu/bayo/shani/kwaya_kusar,_borno_state",
+      "name": "Biu/Bayo/Shani/Kwaya Kusar, Borno State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bodinga/dange-shuni/tureta,_sokoto_state",
+      "name": "Bodinga/Dange-Shuni/Tureta, Sokoto State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bogoro/dass/tafawa_balewa,_bauchi_state",
+      "name": "Bogoro/Dass/Tafawa Balewa, Bauchi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/boluwaduro/ifedayo/illa,_osun_state",
+      "name": "Boluwaduro/Ifedayo/Illa, Osun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bomadi/patani,_delta_state",
+      "name": "Bomadi/Patani, Delta State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bosso/paikoro,_niger_state",
+      "name": "BOSSO/PAIKORO, Niger State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/brass/nembe,_bayelsa_state",
+      "name": "Brass/Nembe, Bayelsa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bungudu/maru,_zamfara_state",
+      "name": "Bungudu/Maru, Zamfara State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/bursari/geidam/yunusari,_yobe_state",
+      "name": "Bursari/Geidam/Yunusari, Yobe State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/buruku,_benue_state",
+      "name": "Buruku, Benue State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/burutu,_delta_state",
+      "name": "Burutu, Delta State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/calabar_munincipal/odukpani,_cross_river_state",
+      "name": "Calabar Munincipal/Odukpani, Cross River State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/chanchaga,_niger_state",
+      "name": "Chanchaga, Niger State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/chikum/kajuru,_kaduna_state",
+      "name": "Chikum/Kajuru, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/dala,_kano_state",
+      "name": "Dala, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/damaturu/gujba/gulani/tarmuwa,_yobe_state",
+      "name": "Damaturu/Gujba/Gulani/Tarmuwa, Yobe State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/dambatta/makoda,_kano_state",
+      "name": "Dambatta/Makoda, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/damboa/gwoza/chibok,_borno_state",
+      "name": "Damboa/Gwoza/Chibok, Borno State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/darazo/gunjuwa,_bauchi_state",
+      "name": "Darazo/Gunjuwa, Bauchi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/daura/sandamu/maiadua,_katsina_state",
+      "name": "Daura/Sandamu/MaiAdua, Katsina State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/dawakin-tofa/tofa/rimin_gado,_kano_state",
+      "name": "Dawakin-Tofa/Tofa/Rimin Gado, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/dawakin_kudu/warawa,_kano_state",
+      "name": "Dawakin Kudu/Warawa, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/degema/bonny,_rivers_state",
+      "name": "Degema/Bonny, Rivers State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/dekina/bassa,_kogi_state",
+      "name": "Dekina/Bassa, Kogi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/demsa/numan/lamurde,_adamawa_state",
+      "name": "Demsa/Numan/Lamurde, Adamawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/dikwa/mafaf/konduga,_borno_state",
+      "name": "Dikwa/Mafaf/Konduga, Borno State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/donga/ussa/takum/special_area,_taraba_state",
+      "name": "Donga/Ussa/Takum/Special Area, Taraba State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/dukku_/_nafada,_gombe_state",
+      "name": "Dukku / Nafada, Gombe State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/dutse/kiyawa,_jigawa_state",
+      "name": "Dutse/Kiyawa, Jigawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/dutsin-ma/kurfi,_katsina_state",
+      "name": "Dutsin-ma/Kurfi, Katsina State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ede_north,south/egbedero/ejigbo,_osun_state",
+      "name": "Ede North,South/Egbedero/Ejigbo, Osun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/edu/moro/patigi,_kwara_state",
+      "name": "Edu/Moro/Patigi, Kwara State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/egbado_south_and_ipokia,_ogun_state",
+      "name": "Egbado South and Ipokia, Ogun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/egor/ikpoba-okha,_edo_state",
+      "name": "Egor/Ikpoba-okha, Edo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ehimembano/ihitte_uboma/obowo,_imo_state",
+      "name": "Ehimembano/ihitte Uboma/Obowo, Imo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/eket/onna/esit_eket/ibeno,_akwa_ibom_state",
+      "name": "Eket/Onna/Esit Eket/Ibeno, Akwa Ibom State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ekiti/isin/irepodun/oke-ero,_kwara_state",
+      "name": "Ekiti/Isin/Irepodun/Oke-ero, Kwara State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ekiti_central,_ekiti_state",
+      "name": "Ekiti Central, Ekiti State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ekiti_south_west/ikere/ise/orun,_ekiti_state",
+      "name": "Ekiti South West/Ikere/Ise/Orun, Ekiti State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/emure/gbonyin/ekiti_east,_ekiti_state",
+      "name": "Emure/Gbonyin/Ekiti East, Ekiti State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/enugu_east/isi-uzo,_enugu_state",
+      "name": "Enugu East/Isi-Uzo, Enugu State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/enugu_north/south,_enugu_state",
+      "name": "Enugu North/South, Enugu State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/epe,_lagos_state",
+      "name": "Epe, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/esan_central/west/igueben,_edo_state",
+      "name": "Esan Central/West/Igueben, Edo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/esan_north-east/esan_south-_east,_edo_state",
+      "name": "Esan North-East/Esan South- East, Edo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/eseodo/ilaje,_ondo_state",
+      "name": "Eseodo/Ilaje, Ondo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/etche/omuma,_rivers_state",
+      "name": "Etche/Omuma, Rivers State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ethiope,_delta_state",
+      "name": "Ethiope, Delta State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/eti-osa,_lagos_state",
+      "name": "Eti-Osa, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/etinan/nsit_ibom/nsit_ubium,_akwa_ibom_state",
+      "name": "Etinan/Nsit Ibom/Nsit Ubium, Akwa Ibom State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/etsako_east/west/central,_edo_state",
+      "name": "Etsako East/West/Central, Edo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ezeagu/udi,_enugu_state",
+      "name": "Ezeagu/Udi, Enugu State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ezza_north/ishielu,_ebonyi_state",
+      "name": "Ezza North/Ishielu, Ebonyi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/fagge,_kano_state",
+      "name": "Fagge, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/fika/fune,_yobe_state",
+      "name": "Fika/Fune, Yobe State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/fufore/song,_adamawa_state",
+      "name": "Fufore/Song, Adamawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/funtua/dandume,_katsina_state",
+      "name": "Funtua/Dandume, Katsina State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gamawa,_bauchi_state",
+      "name": "Gamawa, Bauchi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gashaka/kurmi/sardauna,_taraba_state",
+      "name": "Gashaka/Kurmi/Sardauna, Taraba State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gboko/tarka,_benue_state",
+      "name": "Gboko/Tarka, Benue State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gezawa/gabasawa,_kano_state",
+      "name": "Gezawa/Gabasawa, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gombe,kwami_&funakaye,_gombe_state",
+      "name": "Gombe,kwami &Funakaye, Gombe State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/goronyo/gada,_sokoto_state",
+      "name": "Goronyo/Gada, Sokoto State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gudu/tangaza,_sokoto_state",
+      "name": "Gudu/Tangaza, Sokoto State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gumel/maigatari/sule_tankarkar/gagarawa,_jigawa_state",
+      "name": "Gumel/Maigatari/Sule Tankarkar/Gagarawa, Jigawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gummi/bukkuyum,_zamfara_state",
+      "name": "Gummi/Bukkuyum, Zamfara State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gurara/suleja/tafa,_niger_state",
+      "name": "Gurara/Suleja/Tafa, Niger State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/guyuk/shelleng,_adamawa_state",
+      "name": "Guyuk/Shelleng, Adamawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gwadabawa_/_illela,_sokoto_state",
+      "name": "Gwadabawa / Illela, Sokoto State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gwale,_kano_state",
+      "name": "Gwale, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gwandu/aliero/jega,_kebbi_state",
+      "name": "Gwandu/Aliero/Jega, Kebbi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gwaram,_jigawa_state",
+      "name": "Gwaram, Jigawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gwarzo/ikabo,_kano_state",
+      "name": "Gwarzo/Ikabo, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/gwer_east/gwer_west,_benue_state",
+      "name": "Gwer East/Gwer West, Benue State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/hadejia/kafin_hausa/auyo,_jigawa_state",
+      "name": "Hadejia/Kafin Hausa/Auyo, Jigawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/hong/gombi,_adamawa_state",
+      "name": "Hong/Gombi, Adamawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ibadan_north,_oyo_state",
+      "name": "Ibadan North, Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ibadan_north-_east/south-_east,_oyo_state",
+      "name": "Ibadan North- East/South- East, Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ibadan_north_west/south_west,_oyo_state",
+      "name": "Ibadan North West/South West, Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ibarapa_central/ibarapa_north,_oyo_state",
+      "name": "Ibarapa Central/Ibarapa North, Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ibarapa_east/ido,_oyo_state",
+      "name": "Ibarapa East/Ido, Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ibeju-lekki,_lagos_state",
+      "name": "Ibeju-Lekki, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ibi/wukari,_taraba_state",
+      "name": "Ibi/Wukari, Taraba State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/idah/ibaji/igalamela/ofu,_kogi_state",
+      "name": "Idah/Ibaji/Igalamela/Ofu, Kogi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/idanre/ifedore,_ondo_state",
+      "name": "Idanre/Ifedore, Ondo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ideato_north_/south,_imo_state",
+      "name": "Ideato North /South, Imo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/idemili_north/south,_anambra_state",
+      "name": "Idemili North/South, Anambra State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ido/osi,_moba/ilejeme,_ekiti_state",
+      "name": "Ido/Osi, Moba/Ilejeme, Ekiti State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ifako-ijaiye,_lagos_state",
+      "name": "Ifako-Ijaiye, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ife_central/east/north/south,_osun_state",
+      "name": "Ife Central/East/North/South, Osun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ife_federal_constituency,_osun_state",
+      "name": "Ife Federal Constituency, Osun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ifo/ewekoro,_ogun_state",
+      "name": "Ifo/Ewekoro, Ogun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/igabi,_kaduna_state",
+      "name": "Igabi, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/igbo-etiti/uzo-uwani,_enugu_state",
+      "name": "Igbo-Etiti/Uzo-Uwani, Enugu State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/igboeze_north/udenu,_enugu_state",
+      "name": "Igboeze North/Udenu, Enugu State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ihiala,_anambra_state",
+      "name": "Ihiala, Anambra State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ijebu_north/ijebu_east/ogun_waterside,_ogun_state",
+      "name": "Ijebu North/Ijebu East/Ogun Waterside, Ogun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ijebu_ode/odogbolu/ijebu_north_east,_ogun_state",
+      "name": "Ijebu Ode/Odogbolu/Ijebu North East, Ogun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ijero/ekiti_west/efon,_ekiti_state",
+      "name": "Ijero/Ekiti West/Efon, Ekiti State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ika,_delta_state",
+      "name": "Ika, Delta State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ikara/kubau,_kaduna_state",
+      "name": "Ikara/Kubau, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ikeja,_lagos_state",
+      "name": "Ikeja, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ikenne/shagamu/remo_north,_ogun_state",
+      "name": "Ikenne/Shagamu/Remo North, Ogun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ikole/oye,_ekiti_state",
+      "name": "Ikole/Oye, Ekiti State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ikom/boki,_cross_river_state",
+      "name": "Ikom/Boki, Cross River State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ikono/_ini,_akwa_ibom_state",
+      "name": "Ikono/ Ini, Akwa Ibom State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ikorodu,_lagos_state",
+      "name": "Ikorodu, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ikot_abasi/mkpat_enin/eastern_obolo,_akwa_ibom_state",
+      "name": "Ikot Abasi/Mkpat Enin/Eastern Obolo, Akwa Ibom State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ikot_ekpene/_essien_udim/_obot_akara,_akwa_ibom_state",
+      "name": "Ikot Ekpene/ Essien Udim/ Obot Akara, Akwa Ibom State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ikwerre/_emohua,_rivers_state",
+      "name": "Ikwerre/ Emohua, Rivers State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ikwo/ezza_south,_ebonyi_state",
+      "name": "Ikwo/Ezza South, Ebonyi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ikwuano/umuahia_north/south,_abia_state",
+      "name": "Ikwuano/Umuahia North/South, Abia State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ileoluji-okeibo/odigbo,_ondo_state",
+      "name": "Ileoluji-Okeibo/Odigbo, Ondo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ilorin_east/south,_kwara_state",
+      "name": "Ilorin East/South, Kwara State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/imeko_afon/egbado_north,_ogun_state",
+      "name": "Imeko Afon/Egbado North, Ogun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/irepodun/olurunda/osogbo/orolu,_osun_state",
+      "name": "Irepodun/Olurunda/Osogbo/Orolu, Osun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/isa-sabon-birni,_sokoto_state",
+      "name": "Isa-Sabon-Birni, Sokoto State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/iseyin/itesiwaju/kajola/iwajowa,_oyo_state",
+      "name": "Iseyin/Itesiwaju/Kajola/Iwajowa, Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/isiala_mbano/okigwe/onuimo,_imo_state",
+      "name": "Isiala Mbano/Okigwe/Onuimo, Imo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/isiala_ngwa_north/south,_abia_state",
+      "name": "Isiala Ngwa North/South, Abia State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/isoko_north/south,_delta_state",
+      "name": "Isoko North/South, Delta State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/isu/njaba/nkwerre/nwangele,_imo_state",
+      "name": "Isu/Njaba/Nkwerre/Nwangele, Imo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/isuikwato/umunneochi,_abia_state",
+      "name": "Isuikwato/Umunneochi, Abia State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/itu/ibiono_ibom,_akwa_ibom_state",
+      "name": "Itu/Ibiono Ibom, Akwa Ibom State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/jada/ganye/mayo_belwa/toungo,_adamawa_state",
+      "name": "Jada/Ganye/Mayo Belwa/Toungo, Adamawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/jahun/miga,_jigawa_state",
+      "name": "Jahun/Miga, Jigawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/jalingo/yorro/zing,_taraba_state",
+      "name": "Jalingo/Yorro/Zing, Taraba State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/jama’are/itas-gadau,_bauchi_state",
+      "name": "Jama’are/Itas-Gadau, Bauchi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/jemaa/sanga,_kaduna_state",
+      "name": "Jemaa/Sanga, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/jere,_borno_state",
+      "name": "Jere, Borno State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/jos_south/east,_plateau_state",
+      "name": "Jos South/East, Plateau State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kabba/bunu/ijumu,_kogi_state",
+      "name": "Kabba/Bunu/Ijumu, Kogi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kachia/kagarko,_kaduna_state",
+      "name": "Kachia/Kagarko, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kaduna_north,_kaduna_state",
+      "name": "Kaduna North, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kaduna_south,_kaduna_state",
+      "name": "Kaduna South, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kaga/gubio/magumeri,_borno_state",
+      "name": "Kaga/Gubio/Magumeri, Borno State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kaita/jibia,_katsina_state",
+      "name": "Kaita/Jibia, Katsina State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kaltungo/shongom,_gombe_state",
+      "name": "Kaltungo/Shongom, Gombe State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kankara/sabuwa/faskari,_katsina_state",
+      "name": "Kankara/Sabuwa/Faskari, Katsina State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kankia/ingawa/kusada,_katsina_state",
+      "name": "Kankia/Ingawa/Kusada, Katsina State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kano_municipal,_kano_state",
+      "name": "Kano Municipal, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/karaye/rogo,_kano_state",
+      "name": "Karaye/Rogo, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/katagum,_bauchi_state",
+      "name": "Katagum, Bauchi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/katsina-ala/ukum/logo,_benue_state",
+      "name": "Katsina-Ala/Ukum/Logo, Benue State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kaura,_kaduna_state",
+      "name": "Kaura, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kaura_namoda/birnin_magaji,_zamfara_state",
+      "name": "Kaura Namoda/Birnin Magaji, Zamfara State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kauru,_kaduna_state",
+      "name": "Kauru, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kazaure/roni/gwiwa/yankwashi,_jigawa_state",
+      "name": "Kazaure/Roni/Gwiwa/Yankwashi, Jigawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kebbe/tambuwal,_sokoto_state",
+      "name": "Kebbe/Tambuwal, Sokoto State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/keffi/karu/kokona,_nassarawa_state",
+      "name": "Keffi/Karu/Kokona, Nassarawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/khana/gokana,_rivers_state",
+      "name": "Khana/Gokana, Rivers State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kontagora/wushishi/mariga/masheg,_niger_state",
+      "name": "Kontagora/Wushishi/Mariga/Masheg, Niger State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kosofe,_lagos_state",
+      "name": "Kosofe, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kuje/abaji/gwagwalada/kwali,_federal_capital_territory_state",
+      "name": "Kuje/Abaji/Gwagwalada/Kwali, Federal Capital Territory State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kukawa/mobbar/abadam/guzamalai,_borno_state",
+      "name": "Kukawa/Mobbar/Abadam/Guzamalai, Borno State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kumbosto,_kano_state",
+      "name": "Kumbosto, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kura/madobi/garun_malam,_kano_state",
+      "name": "Kura/Madobi/Garun Malam, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kwande/ushongo,_benue_state",
+      "name": "Kwande/Ushongo, Benue State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/kware/wamakko,_sokoto_state",
+      "name": "Kware/Wamakko, Sokoto State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/lafia/obi,_nassarawa_state",
+      "name": "Lafia/Obi, Nassarawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/lagelu/akinyele,_oyo_state",
+      "name": "Lagelu/Akinyele, Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/lagos_island_i,_lagos_state",
+      "name": "Lagos Island I, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/lagos_island_ii,_lagos_state",
+      "name": "Lagos Island II, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/lagos_mainland,_lagos_state",
+      "name": "Lagos Mainland, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/langtang_north/south,_plateau_state",
+      "name": "Langtang North/South, Plateau State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/lau/k/lamido/ardo-kola,_taraba_state",
+      "name": "Lau/K/Lamido/Ardo-Kola, Taraba State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/lavun/mokwa/edati,_niger_state",
+      "name": "Lavun/Mokwa/Edati, Niger State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/lere,_kaduna_state",
+      "name": "Lere, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/lokoja/kogi/kk,_kogi_state",
+      "name": "Lokoja/Kogi/KK, Kogi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/machina/nguru/karasuwa/yusufari,_yobe_state",
+      "name": "Machina/Nguru/Karasuwa/Yusufari, Yobe State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/magama/rijau,_niger_state",
+      "name": "Magama/Rijau, Niger State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/maiduguri_(metropolitan),_borno_state",
+      "name": "Maiduguri (Metropolitan), Borno State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/maiyama/koko/besse,_kebbi_state",
+      "name": "Maiyama/Koko/Besse, Kebbi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/makarfi/kudan,_kaduna_state",
+      "name": "Makarfi/Kudan, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/makurdi/guma,_benue_state",
+      "name": "Makurdi/Guma, Benue State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/mallam_madori/kaugama,_jigawa_state",
+      "name": "Mallam Madori/Kaugama, Jigawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/malumfashi/kafur,_katsina_state",
+      "name": "MalumFashi/Kafur, Katsina State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/mangu/bokkos,_plateau_state",
+      "name": "Mangu/Bokkos, Plateau State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/mani/bindawa,_katsina_state",
+      "name": "Mani/Bindawa, Katsina State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/mashi/dvisi,_katsina_state",
+      "name": "Mashi/Dvisi, Katsina State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/mbaitolu/ikeduru,_imo_state",
+      "name": "Mbaitolu/ikeduru, Imo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/michika/madagali,_adamawa_state",
+      "name": "Michika/Madagali, Adamawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/mikang/quan.pan/shendam,_plateau_state",
+      "name": "Mikang/Quan.Pan/Shendam, Plateau State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/minjibir/ungogo,_kano_state",
+      "name": "Minjibir/Ungogo, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/misau/dambam,_bauchi_state",
+      "name": "Misau/Dambam, Bauchi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/mubi_n/mu_s/maiha,_adamawa_state",
+      "name": "Mubi N/Mu S/Maiha, Adamawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/musawa/matazu,_katsina_state",
+      "name": "Musawa/Matazu, Katsina State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/mushin_i,_lagos_state",
+      "name": "Mushin I, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/mushin_ii,_lagos_state",
+      "name": "Mushin II, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/nangere/potiskum,_yobe_state",
+      "name": "Nangere/Potiskum, Yobe State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/nasarawa/toto,_nassarawa_state",
+      "name": "Nasarawa/Toto, Nassarawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/nassarawa,_kano_state",
+      "name": "Nassarawa, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ndokwa/ukwani,_delta_state",
+      "name": "Ndokwa/Ukwani, Delta State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ningi/warji,_bauchi_state",
+      "name": "Ningi/Warji, Bauchi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/nkanu_east/nkanu_west,_enugu_state",
+      "name": "Nkanu East/Nkanu West, Enugu State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/nnewi_north/south/ekwusigo,_anambra_state",
+      "name": "Nnewi North/South/Ekwusigo, Anambra State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/nsukka/igbo-eze_south,_enugu_state",
+      "name": "Nsukka/Igbo-Eze South, Enugu State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/obingwa/osisioma/ugbunagbo,_abia_state",
+      "name": "Obingwa/Osisioma/Ugbunagbo, Abia State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/obio/akpor,_rivers_state",
+      "name": "Obio/Akpor, Rivers State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/obokon/oriade,_osun_state",
+      "name": "Obokon/Oriade, Osun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/obubra/etung,_cross_river_state",
+      "name": "Obubra/Etung, Cross River State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/odo-otin/ifelodun/boripe,_osun_state",
+      "name": "Odo-Otin/Ifelodun/Boripe, Osun State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/offa/oyun/ifelodun,_kwara_state",
+      "name": "Offa/Oyun/Ifelodun, Kwara State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ogbaru,_anambra_state",
+      "name": "Ogbaru, Anambra State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ogbia,_bayelsa_state",
+      "name": "Ogbia, Bayelsa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ogbomosho/north/south/orire,_oyo_state",
+      "name": "Ogbomosho/North/South/Orire, Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ogo-oluwa,_oyo_state",
+      "name": "Ogo-oluwa, Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ogoja/yala,_cross_river_state",
+      "name": "Ogoja/Yala, Cross River State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ohaukwu/ebonyi,_ebonyi_state",
+      "name": "Ohaukwu/Ebonyi, Ebonyi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ojo,_lagos_state",
+      "name": "Ojo, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/oju/obi,_benue_state",
+      "name": "Oju/Obi, Benue State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/okene/ogori-magogo,_kogi_state",
+      "name": "Okene/Ogori-Magogo, Kogi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/okitipupa/irele,_ondo_state",
+      "name": "Okitipupa/Irele, Ondo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/okrika/ogu-bolo,_rivers_state",
+      "name": "Okrika/Ogu-Bolo, Rivers State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/olurunsogo/oorelope,_oyo_state",
+      "name": "Olurunsogo/Oorelope, Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/oluyole_local_govt.,_oyo_state",
+      "name": "Oluyole Local Govt., Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ona-ara/egbeda,_oyo_state",
+      "name": "Ona-Ara/Egbeda, Oyo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ondo_east/ondo_west,_ondo_state",
+      "name": "Ondo East/Ondo West, Ondo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/onitsha_north/south,_anambra_state",
+      "name": "Onitsha North/South, Anambra State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/opke/sapele/uvwie,_delta_state",
+      "name": "Opke/Sapele/Uvwie, Delta State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/oredo,_edo_state",
+      "name": "Oredo, Edo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/orhionmwon/uhunmwode,_edo_state",
+      "name": "Orhionmwon/Uhunmwode, Edo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/orlu/oru_east/orsu,_imo_state",
+      "name": "Orlu/Oru East/Orsu, Imo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/oron/mbo/okobo/urueoffong/oruko/udung-uko,_akwa_ibom_state",
+      "name": "Oron/Mbo/Okobo/UrueOffong/Oruko/Udung-Uko, Akwa Ibom State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/orumba_north/south,_anambra_state",
+      "name": "Orumba North/South, Anambra State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/oshodi-isolo_i,_lagos_state",
+      "name": "Oshodi-Isolo I, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/oshodi-isolo_ii,_lagos_state",
+      "name": "Oshodi-Isolo II, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/otukpo/ohimini,_benue_state",
+      "name": "Otukpo/Ohimini, Benue State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ovia_south/west-ovia_north/east,_edo_state",
+      "name": "Ovia South/West-Ovia North/East, Edo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/owan_west/east,_edo_state",
+      "name": "Owan West/East, Edo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/owerri_municipal/owerri_north/west,_imo_state",
+      "name": "Owerri Municipal/Owerri North/West, Imo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/owo/ose,_ondo_state",
+      "name": "Owo/Ose, Ondo State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/oyi/ayamelum,_anambra_state",
+      "name": "Oyi/Ayamelum, Anambra State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/pankshin/kanke/kanam,_plateau_state",
+      "name": "Pankshin/Kanke/Kanam, Plateau State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/port_harcourt_1,_rivers_state",
+      "name": "Port Harcourt 1, Rivers State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/port_harcourt_2,_rivers_state",
+      "name": "Port Harcourt 2, Rivers State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/rano/bunkure/kibiya,_kano_state",
+      "name": "Rano/Bunkure/Kibiya, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/rimi/charanchi/batagarawa,_katsina_state",
+      "name": "Rimi/Charanchi/Batagarawa, Katsina State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ringim/taura,_jigawa_state",
+      "name": "Ringim/Taura, Jigawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/sabon_gari,_kaduna_state",
+      "name": "Sabon Gari, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/sagbama/ekeremor,_bayelsa_state",
+      "name": "Sagbama/Ekeremor, Bayelsa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/shagari/yabo,_sokoto_state",
+      "name": "Shagari/Yabo, Sokoto State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/shira/giade,_bauchi_state",
+      "name": "Shira/Giade, Bauchi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/shiroro/rafi/munya,_niger_state",
+      "name": "Shiroro/Rafi/Munya, Niger State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/soba,_kaduna_state",
+      "name": "Soba, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/sokoto_north/sokoto_south,_sokoto_state",
+      "name": "Sokoto North/Sokoto South, Sokoto State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/somolu,_lagos_state",
+      "name": "Somolu, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/southern_ijaw,_bayelsa_state",
+      "name": "Southern Ijaw, Bayelsa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/sumaila/takai,_kano_state",
+      "name": "Sumaila/Takai, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/surulere_i,_lagos_state",
+      "name": "Surulere I, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/surulere_ii,_lagos_state",
+      "name": "Surulere II, Lagos State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/tai/eleme/oyigbo,_rivers_state",
+      "name": "Tai/Eleme/Oyigbo, Rivers State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/tarauni,_kano_state",
+      "name": "Tarauni, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/toro,_bauchi_state",
+      "name": "Toro, Bauchi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/tsafe/gusau,_zamfara_state",
+      "name": "Tsafe/Gusau, Zamfara State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/tsanyawa/kunchi,_kano_state",
+      "name": "Tsanyawa/Kunchi, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/tudun-wada/doguwa,_kano_state",
+      "name": "Tudun-Wada/Doguwa, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ughelli_north/south/udu,_delta_state",
+      "name": "Ughelli North/South/Udu, Delta State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ukanafun/orukanam,_akwa_ibom_state",
+      "name": "Ukanafun/Orukanam, Akwa Ibom State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/ukwa_east/ukwa_west,_abia_state",
+      "name": "Ukwa East/Ukwa West, Abia State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/uyo/uruan/nsit_ata/ibeskip_asutan,_akwa_ibom_state",
+      "name": "Uyo/Uruan/Nsit Ata/Ibeskip Asutan, Akwa Ibom State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/vandeikya/konshisha,_benue_state",
+      "name": "Vandeikya/Konshisha, Benue State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/warri,_delta_state",
+      "name": "Warri, Delta State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/wase,_plateau_state",
+      "name": "Wase, Plateau State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/wudil/garko,_kano_state",
+      "name": "Wudil/Garko, Kano State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/wurno/rabah,_sokoto_state",
+      "name": "Wurno/Rabah, Sokoto State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/yagba_east/yagba_west/mopa-muro,_kogi_state",
+      "name": "Yagba East/Yagba West/Mopa-muro, Kogi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/yakurr/abi,_cross_river_state",
+      "name": "Yakurr/Abi, Cross River State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/yamaltu-deba,_gombe_state",
+      "name": "Yamaltu-Deba, Gombe State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/yauri/shanga/ngaski,_kebbi_state",
+      "name": "Yauri/Shanga/Ngaski, Kebbi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/yenagoa/kolokuna/opokuma,_bayelsa_state",
+      "name": "Yenagoa/Kolokuna/Opokuma, Bayelsa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/yola_north/yola_south/girei,_adamawa_state",
+      "name": "Yola North/Yola South/Girei, Adamawa State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/zaki,_bauchi_state",
+      "name": "Zaki, Bauchi State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/zangon_kataf/jaba,_kaduna_state",
+      "name": "Zangon Kataf/Jaba, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/zaria_federal,_kaduna_state",
+      "name": "Zaria Federal, Kaduna State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/zurmi/shinkafi,_zamfara_state",
+      "name": "Zurmi/Shinkafi, Zamfara State",
+      "type": "constituency"
+    },
+    {
+      "id": "area/zuru/fakai/sakaba/d/wasagu,_kebbi_state",
+      "name": "Zuru/Fakai/Sakaba/D/Wasagu, Kebbi State",
+      "type": "constituency"
+    }
+  ]
+}

--- a/tests/fixtures/ep_data/d8a4682/countries.json
+++ b/tests/fixtures/ep_data/d8a4682/countries.json
@@ -1,0 +1,11172 @@
+[
+  {
+    "name": "Abkhazia",
+    "country": "Abkhazia",
+    "code": "GE-AB",
+    "slug": "Abkhazia",
+    "legislatures": [
+      {
+        "name": "People's Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Abkhazia/Assembly/sources",
+        "popolo": "data/Abkhazia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/64a8492/data/Abkhazia/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Abkhazia/Assembly/names.csv",
+        "lastmod": "1466353499",
+        "person_count": 35,
+        "sha": "64a8492",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "5th Convocation",
+            "start_date": "2012-04-03",
+            "slug": "5",
+            "csv": "data/Abkhazia/Assembly/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/64a8492/data/Abkhazia/Assembly/term-5.csv"
+          }
+        ],
+        "statement_count": 694
+      }
+    ]
+  },
+  {
+    "name": "Afghanistan",
+    "country": "Afghanistan",
+    "code": "AF",
+    "slug": "Afghanistan",
+    "legislatures": [
+      {
+        "name": "Wolesi Jirga",
+        "slug": "Wolesi-Jirga",
+        "sources_directory": "data/Afghanistan/Wolesi_Jirga/sources",
+        "popolo": "data/Afghanistan/Wolesi_Jirga/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2b38667/data/Afghanistan/Wolesi_Jirga/ep-popolo-v1.0.json",
+        "names": "data/Afghanistan/Wolesi_Jirga/names.csv",
+        "lastmod": "1466353512",
+        "person_count": 228,
+        "sha": "2b38667",
+        "legislative_periods": [
+          {
+            "end_date": "2015-06-22",
+            "id": "term/2010",
+            "name": "2010–2015",
+            "start_date": "2011-01-26",
+            "slug": "2010",
+            "csv": "data/Afghanistan/Wolesi_Jirga/term-2010.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2b38667/data/Afghanistan/Wolesi_Jirga/term-2010.csv"
+          }
+        ],
+        "statement_count": 3473
+      }
+    ]
+  },
+  {
+    "name": "Albania",
+    "country": "Albania",
+    "code": "AL",
+    "slug": "Albania",
+    "legislatures": [
+      {
+        "name": "Kuvendi",
+        "slug": "Assembly",
+        "sources_directory": "data/Albania/Assembly/sources",
+        "popolo": "data/Albania/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b248141/data/Albania/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Albania/Assembly/names.csv",
+        "lastmod": "1467966986",
+        "person_count": 213,
+        "sha": "b248141",
+        "legislative_periods": [
+          {
+            "id": "term/8",
+            "name": "Legislature VIII",
+            "start_date": "2013-09-09",
+            "slug": "8",
+            "csv": "data/Albania/Assembly/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b248141/data/Albania/Assembly/term-8.csv"
+          },
+          {
+            "end_date": "2013",
+            "id": "term/7",
+            "name": "Legislature VII",
+            "start_date": "2009",
+            "slug": "7",
+            "csv": "data/Albania/Assembly/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b248141/data/Albania/Assembly/term-7.csv"
+          }
+        ],
+        "statement_count": 9836
+      }
+    ]
+  },
+  {
+    "name": "Alderney",
+    "country": "Alderney",
+    "code": "GG-ALD",
+    "slug": "Alderney",
+    "legislatures": [
+      {
+        "name": "States",
+        "slug": "States",
+        "sources_directory": "data/Alderney/States/sources",
+        "popolo": "data/Alderney/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/beb21e5/data/Alderney/States/ep-popolo-v1.0.json",
+        "names": "data/Alderney/States/names.csv",
+        "lastmod": "1467808300",
+        "person_count": 10,
+        "sha": "beb21e5",
+        "legislative_periods": [
+          {
+            "end_date": "2016-11",
+            "id": "term/2014",
+            "name": "2014–2016",
+            "start_date": "2014-11-22",
+            "slug": "2014",
+            "csv": "data/Alderney/States/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/beb21e5/data/Alderney/States/term-2014.csv"
+          }
+        ],
+        "statement_count": 531
+      }
+    ]
+  },
+  {
+    "name": "Algeria",
+    "country": "Algeria",
+    "code": "DZ",
+    "slug": "Algeria",
+    "legislatures": [
+      {
+        "name": "People's National Assembly",
+        "slug": "Majlis",
+        "sources_directory": "data/Algeria/Majlis/sources",
+        "popolo": "data/Algeria/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e65e8fc/data/Algeria/Majlis/ep-popolo-v1.0.json",
+        "names": "data/Algeria/Majlis/names.csv",
+        "lastmod": "1466353523",
+        "person_count": 478,
+        "sha": "e65e8fc",
+        "legislative_periods": [
+          {
+            "id": "term/7",
+            "name": "7th National Assembly",
+            "start_date": "2012-05-10",
+            "slug": "7",
+            "csv": "data/Algeria/Majlis/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e65e8fc/data/Algeria/Majlis/term-7.csv"
+          }
+        ],
+        "statement_count": 8261
+      }
+    ]
+  },
+  {
+    "name": "American Samoa",
+    "country": "American Samoa",
+    "code": "AS",
+    "slug": "American-Samoa",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House",
+        "sources_directory": "data/American_Samoa/House/sources",
+        "popolo": "data/American_Samoa/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e56c70/data/American_Samoa/House/ep-popolo-v1.0.json",
+        "names": "data/American_Samoa/House/names.csv",
+        "lastmod": "1467652409",
+        "person_count": 17,
+        "sha": "6e56c70",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "2015–",
+            "start_date": "2015-01-03",
+            "slug": "2014",
+            "csv": "data/American_Samoa/House/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e56c70/data/American_Samoa/House/term-2014.csv"
+          }
+        ],
+        "statement_count": 651
+      }
+    ]
+  },
+  {
+    "name": "Andorra",
+    "country": "Andorra",
+    "code": "AD",
+    "slug": "Andorra",
+    "legislatures": [
+      {
+        "name": "Consell General",
+        "slug": "General-Council",
+        "sources_directory": "data/Andorra/General_Council/sources",
+        "popolo": "data/Andorra/General_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9f0a475/data/Andorra/General_Council/ep-popolo-v1.0.json",
+        "names": "data/Andorra/General_Council/names.csv",
+        "lastmod": "1466353528",
+        "person_count": 30,
+        "sha": "9f0a475",
+        "legislative_periods": [
+          {
+            "id": "term/2015",
+            "name": "2015",
+            "start_date": "2015-03-23",
+            "slug": "2015",
+            "csv": "data/Andorra/General_Council/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9f0a475/data/Andorra/General_Council/term-2015.csv"
+          }
+        ],
+        "statement_count": 887
+      }
+    ]
+  },
+  {
+    "name": "Angola",
+    "country": "Angola",
+    "code": "AO",
+    "slug": "Angola",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "National-Assembly",
+        "sources_directory": "data/Angola/National_Assembly/sources",
+        "popolo": "data/Angola/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5d4ac3b/data/Angola/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Angola/National_Assembly/names.csv",
+        "lastmod": "1467671957",
+        "person_count": 216,
+        "sha": "5d4ac3b",
+        "legislative_periods": [
+          {
+            "id": "term/3",
+            "name": "3rd National Assembly",
+            "start_date": "2012-09-27",
+            "slug": "3",
+            "csv": "data/Angola/National_Assembly/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5d4ac3b/data/Angola/National_Assembly/term-3.csv"
+          }
+        ],
+        "statement_count": 4107
+      }
+    ]
+  },
+  {
+    "name": "Anguilla",
+    "country": "Anguilla",
+    "code": "AI",
+    "slug": "Anguilla",
+    "legislatures": [
+      {
+        "name": "House of Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Anguilla/Assembly/sources",
+        "popolo": "data/Anguilla/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/540ff32/data/Anguilla/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Anguilla/Assembly/names.csv",
+        "lastmod": "1467667198",
+        "person_count": 18,
+        "sha": "540ff32",
+        "legislative_periods": [
+          {
+            "end_date": "2020",
+            "id": "term/2015",
+            "name": "2015–2020",
+            "start_date": "2015",
+            "slug": "2015",
+            "csv": "data/Anguilla/Assembly/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/540ff32/data/Anguilla/Assembly/term-2015.csv"
+          },
+          {
+            "end_date": "2015",
+            "id": "term/2010",
+            "name": "2010–2015",
+            "start_date": "2010",
+            "slug": "2010",
+            "csv": "data/Anguilla/Assembly/term-2010.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/540ff32/data/Anguilla/Assembly/term-2010.csv"
+          },
+          {
+            "end_date": "2010",
+            "id": "term/2005",
+            "name": "2005–2010",
+            "start_date": "2005",
+            "slug": "2005",
+            "csv": "data/Anguilla/Assembly/term-2005.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/540ff32/data/Anguilla/Assembly/term-2005.csv"
+          },
+          {
+            "end_date": "2005",
+            "id": "term/2000",
+            "name": "2000–2005",
+            "start_date": "2000",
+            "slug": "2000",
+            "csv": "data/Anguilla/Assembly/term-2000.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/540ff32/data/Anguilla/Assembly/term-2000.csv"
+          },
+          {
+            "end_date": "2000",
+            "id": "term/1999",
+            "name": "1999–2000",
+            "start_date": "1999",
+            "slug": "1999",
+            "csv": "data/Anguilla/Assembly/term-1999.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/540ff32/data/Anguilla/Assembly/term-1999.csv"
+          },
+          {
+            "end_date": "1999",
+            "id": "term/1994",
+            "name": "1994–1999",
+            "start_date": "1994",
+            "slug": "1994",
+            "csv": "data/Anguilla/Assembly/term-1994.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/540ff32/data/Anguilla/Assembly/term-1994.csv"
+          },
+          {
+            "end_date": "1994",
+            "id": "term/1989",
+            "name": "1989–1994",
+            "start_date": "1989",
+            "slug": "1989",
+            "csv": "data/Anguilla/Assembly/term-1989.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/540ff32/data/Anguilla/Assembly/term-1989.csv"
+          }
+        ],
+        "statement_count": 1006
+      }
+    ]
+  },
+  {
+    "name": "Antigua and Barbuda",
+    "country": "Antigua and Barbuda",
+    "code": "AG",
+    "slug": "Antigua-and-Barbuda",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "Representatives",
+        "sources_directory": "data/Antigua_and_Barbuda/Representatives/sources",
+        "popolo": "data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ca0158/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
+        "names": "data/Antigua_and_Barbuda/Representatives/names.csv",
+        "lastmod": "1466612119",
+        "person_count": 63,
+        "sha": "5ca0158",
+        "legislative_periods": [
+          {
+            "end_date": "2019",
+            "id": "term/2014",
+            "name": "2014–2019",
+            "start_date": "2014-06-25",
+            "slug": "2014",
+            "csv": "data/Antigua_and_Barbuda/Representatives/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ca0158/data/Antigua_and_Barbuda/Representatives/term-2014.csv"
+          },
+          {
+            "end_date": "2014-04-26",
+            "id": "term/2009",
+            "name": "2009–2014",
+            "start_date": "2009-04-27",
+            "slug": "2009",
+            "csv": "data/Antigua_and_Barbuda/Representatives/term-2009.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ca0158/data/Antigua_and_Barbuda/Representatives/term-2009.csv"
+          },
+          {
+            "end_date": "2009-02-09",
+            "id": "term/2004",
+            "name": "2004–2009",
+            "start_date": "2004-03-24",
+            "slug": "2004",
+            "csv": "data/Antigua_and_Barbuda/Representatives/term-2004.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ca0158/data/Antigua_and_Barbuda/Representatives/term-2004.csv"
+          },
+          {
+            "end_date": "2004",
+            "id": "term/1999",
+            "name": "1999–2004",
+            "start_date": "1999",
+            "slug": "1999",
+            "csv": "data/Antigua_and_Barbuda/Representatives/term-1999.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ca0158/data/Antigua_and_Barbuda/Representatives/term-1999.csv"
+          },
+          {
+            "end_date": "1999",
+            "id": "term/1994",
+            "name": "1994–1999",
+            "start_date": "1994",
+            "slug": "1994",
+            "csv": "data/Antigua_and_Barbuda/Representatives/term-1994.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ca0158/data/Antigua_and_Barbuda/Representatives/term-1994.csv"
+          },
+          {
+            "end_date": "1994",
+            "id": "term/1989",
+            "name": "1989–1994",
+            "start_date": "1989",
+            "slug": "1989",
+            "csv": "data/Antigua_and_Barbuda/Representatives/term-1989.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ca0158/data/Antigua_and_Barbuda/Representatives/term-1989.csv"
+          },
+          {
+            "end_date": "1989",
+            "id": "term/1984",
+            "name": "1984–1989",
+            "start_date": "1984",
+            "slug": "1984",
+            "csv": "data/Antigua_and_Barbuda/Representatives/term-1984.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ca0158/data/Antigua_and_Barbuda/Representatives/term-1984.csv"
+          },
+          {
+            "end_date": "1984",
+            "id": "term/1980",
+            "name": "1980–1984",
+            "start_date": "1980",
+            "slug": "1980",
+            "csv": "data/Antigua_and_Barbuda/Representatives/term-1980.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ca0158/data/Antigua_and_Barbuda/Representatives/term-1980.csv"
+          },
+          {
+            "end_date": "1980",
+            "id": "term/1976",
+            "name": "1976–1980",
+            "start_date": "1976",
+            "slug": "1976",
+            "csv": "data/Antigua_and_Barbuda/Representatives/term-1976.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ca0158/data/Antigua_and_Barbuda/Representatives/term-1976.csv"
+          },
+          {
+            "end_date": "1976",
+            "id": "term/1971",
+            "name": "1971–1976",
+            "start_date": "1971",
+            "slug": "1971",
+            "csv": "data/Antigua_and_Barbuda/Representatives/term-1971.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ca0158/data/Antigua_and_Barbuda/Representatives/term-1971.csv"
+          }
+        ],
+        "statement_count": 2340
+      }
+    ]
+  },
+  {
+    "name": "Argentina",
+    "country": "Argentina",
+    "code": "AR",
+    "slug": "Argentina",
+    "legislatures": [
+      {
+        "name": "Cámara de Diputados",
+        "slug": "Diputados",
+        "sources_directory": "data/Argentina/Diputados/sources",
+        "popolo": "data/Argentina/Diputados/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e41aeaf/data/Argentina/Diputados/ep-popolo-v1.0.json",
+        "names": "data/Argentina/Diputados/names.csv",
+        "lastmod": "1467835217",
+        "person_count": 390,
+        "sha": "e41aeaf",
+        "legislative_periods": [
+          {
+            "id": "term/133",
+            "name": "133º",
+            "start_date": "2015",
+            "slug": "133",
+            "csv": "data/Argentina/Diputados/term-133.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e41aeaf/data/Argentina/Diputados/term-133.csv"
+          }
+        ],
+        "statement_count": 14315
+      },
+      {
+        "name": "Cámara de Senadores",
+        "slug": "Senado",
+        "sources_directory": "data/Argentina/Senado/sources",
+        "popolo": "data/Argentina/Senado/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/186fa3f/data/Argentina/Senado/ep-popolo-v1.0.json",
+        "names": "data/Argentina/Senado/names.csv",
+        "lastmod": "1467770545",
+        "person_count": 72,
+        "sha": "186fa3f",
+        "legislative_periods": [
+          {
+            "end_date": "2017-12-09",
+            "id": "term/2015",
+            "name": "2015–",
+            "start_date": "2015-12-10",
+            "slug": "2015",
+            "csv": "data/Argentina/Senado/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/186fa3f/data/Argentina/Senado/term-2015.csv"
+          }
+        ],
+        "statement_count": 3931
+      }
+    ]
+  },
+  {
+    "name": "Armenia",
+    "country": "Armenia",
+    "code": "AM",
+    "slug": "Armenia",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Armenia/Assembly/sources",
+        "popolo": "data/Armenia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4ccdc74/data/Armenia/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Armenia/Assembly/names.csv",
+        "lastmod": "1467302751",
+        "person_count": 132,
+        "sha": "4ccdc74",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "5th Convocation",
+            "start_date": "2012-05-31",
+            "slug": "5",
+            "csv": "data/Armenia/Assembly/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4ccdc74/data/Armenia/Assembly/term-5.csv"
+          }
+        ],
+        "statement_count": 5730
+      }
+    ]
+  },
+  {
+    "name": "Aruba",
+    "country": "Aruba",
+    "code": "AW",
+    "slug": "Aruba",
+    "legislatures": [
+      {
+        "name": "Estates of Aruba",
+        "slug": "Estates",
+        "sources_directory": "data/Aruba/Estates/sources",
+        "popolo": "data/Aruba/Estates/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e6ef189/data/Aruba/Estates/ep-popolo-v1.0.json",
+        "names": "data/Aruba/Estates/names.csv",
+        "lastmod": "1467738477",
+        "person_count": 21,
+        "sha": "e6ef189",
+        "legislative_periods": [
+          {
+            "id": "term/7",
+            "name": "7th Aruban Estates",
+            "start_date": "2013",
+            "slug": "7",
+            "csv": "data/Aruba/Estates/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e6ef189/data/Aruba/Estates/term-7.csv"
+          }
+        ],
+        "statement_count": 605
+      }
+    ]
+  },
+  {
+    "name": "Australia",
+    "country": "Australia",
+    "code": "AU",
+    "slug": "Australia",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "Representatives",
+        "sources_directory": "data/Australia/Representatives/sources",
+        "popolo": "data/Australia/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6139efe/data/Australia/Representatives/ep-popolo-v1.0.json",
+        "names": "data/Australia/Representatives/names.csv",
+        "lastmod": "1467888383",
+        "person_count": 475,
+        "sha": "6139efe",
+        "legislative_periods": [
+          {
+            "id": "term/44",
+            "name": "44th Parliament",
+            "start_date": "2013-09-07",
+            "slug": "44",
+            "csv": "data/Australia/Representatives/term-44.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6139efe/data/Australia/Representatives/term-44.csv"
+          },
+          {
+            "end_date": "2013-09-07",
+            "id": "term/43",
+            "name": "43rd Parliament",
+            "start_date": "2010-08-21",
+            "slug": "43",
+            "csv": "data/Australia/Representatives/term-43.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6139efe/data/Australia/Representatives/term-43.csv"
+          },
+          {
+            "end_date": "2010-08-21",
+            "id": "term/42",
+            "name": "42nd Parliament",
+            "start_date": "2007-11-24",
+            "slug": "42",
+            "csv": "data/Australia/Representatives/term-42.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6139efe/data/Australia/Representatives/term-42.csv"
+          },
+          {
+            "end_date": "2007-11-24",
+            "id": "term/41",
+            "name": "41st Parliament",
+            "start_date": "2004-10-09",
+            "slug": "41",
+            "csv": "data/Australia/Representatives/term-41.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6139efe/data/Australia/Representatives/term-41.csv"
+          },
+          {
+            "end_date": "2004-10-09",
+            "id": "term/40",
+            "name": "40th Parliament",
+            "start_date": "2001-11-10",
+            "slug": "40",
+            "csv": "data/Australia/Representatives/term-40.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6139efe/data/Australia/Representatives/term-40.csv"
+          },
+          {
+            "end_date": "2001-11-10",
+            "id": "term/39",
+            "name": "39th Parliament",
+            "start_date": "1998-10-03",
+            "slug": "39",
+            "csv": "data/Australia/Representatives/term-39.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6139efe/data/Australia/Representatives/term-39.csv"
+          },
+          {
+            "end_date": "1998-10-03",
+            "id": "term/38",
+            "name": "38th Parliament",
+            "start_date": "1996-03-02",
+            "slug": "38",
+            "csv": "data/Australia/Representatives/term-38.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6139efe/data/Australia/Representatives/term-38.csv"
+          },
+          {
+            "end_date": "1996-03-02",
+            "id": "term/37",
+            "name": "37th Parliament",
+            "start_date": "1993-03-13",
+            "slug": "37",
+            "csv": "data/Australia/Representatives/term-37.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6139efe/data/Australia/Representatives/term-37.csv"
+          },
+          {
+            "end_date": "1993-03-13",
+            "id": "term/36",
+            "name": "36th Parliament",
+            "start_date": "1990-03-24",
+            "slug": "36",
+            "csv": "data/Australia/Representatives/term-36.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6139efe/data/Australia/Representatives/term-36.csv"
+          },
+          {
+            "end_date": "1990-03-24",
+            "id": "term/35",
+            "name": "35th Parliament",
+            "start_date": "1987-07-11",
+            "slug": "35",
+            "csv": "data/Australia/Representatives/term-35.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6139efe/data/Australia/Representatives/term-35.csv"
+          }
+        ],
+        "statement_count": 36280
+      },
+      {
+        "name": "Senate",
+        "slug": "Senate",
+        "sources_directory": "data/Australia/Senate/sources",
+        "popolo": "data/Australia/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8dcbd9/data/Australia/Senate/ep-popolo-v1.0.json",
+        "names": "data/Australia/Senate/names.csv",
+        "lastmod": "1467980286",
+        "person_count": 244,
+        "sha": "f8dcbd9",
+        "legislative_periods": [
+          {
+            "id": "term/44",
+            "name": "44th Parliament",
+            "start_date": "2013-09-07",
+            "slug": "44",
+            "csv": "data/Australia/Senate/term-44.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8dcbd9/data/Australia/Senate/term-44.csv"
+          },
+          {
+            "end_date": "2013-09-07",
+            "id": "term/43",
+            "name": "43rd Parliament",
+            "start_date": "2010-08-21",
+            "slug": "43",
+            "csv": "data/Australia/Senate/term-43.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8dcbd9/data/Australia/Senate/term-43.csv"
+          },
+          {
+            "end_date": "2010-08-21",
+            "id": "term/42",
+            "name": "42nd Parliament",
+            "start_date": "2007-11-24",
+            "slug": "42",
+            "csv": "data/Australia/Senate/term-42.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8dcbd9/data/Australia/Senate/term-42.csv"
+          },
+          {
+            "end_date": "2007-11-24",
+            "id": "term/41",
+            "name": "41st Parliament",
+            "start_date": "2004-10-09",
+            "slug": "41",
+            "csv": "data/Australia/Senate/term-41.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8dcbd9/data/Australia/Senate/term-41.csv"
+          },
+          {
+            "end_date": "2004-10-09",
+            "id": "term/40",
+            "name": "40th Parliament",
+            "start_date": "2001-11-10",
+            "slug": "40",
+            "csv": "data/Australia/Senate/term-40.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8dcbd9/data/Australia/Senate/term-40.csv"
+          },
+          {
+            "end_date": "2001-11-10",
+            "id": "term/39",
+            "name": "39th Parliament",
+            "start_date": "1998-10-03",
+            "slug": "39",
+            "csv": "data/Australia/Senate/term-39.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8dcbd9/data/Australia/Senate/term-39.csv"
+          },
+          {
+            "end_date": "1998-10-03",
+            "id": "term/38",
+            "name": "38th Parliament",
+            "start_date": "1996-03-02",
+            "slug": "38",
+            "csv": "data/Australia/Senate/term-38.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8dcbd9/data/Australia/Senate/term-38.csv"
+          },
+          {
+            "end_date": "1996-03-02",
+            "id": "term/37",
+            "name": "37th Parliament",
+            "start_date": "1993-03-13",
+            "slug": "37",
+            "csv": "data/Australia/Senate/term-37.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8dcbd9/data/Australia/Senate/term-37.csv"
+          },
+          {
+            "end_date": "1993-03-13",
+            "id": "term/36",
+            "name": "36th Parliament",
+            "start_date": "1990-03-24",
+            "slug": "36",
+            "csv": "data/Australia/Senate/term-36.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8dcbd9/data/Australia/Senate/term-36.csv"
+          },
+          {
+            "end_date": "1990-03-24",
+            "id": "term/35",
+            "name": "35th Parliament",
+            "start_date": "1987-07-11",
+            "slug": "35",
+            "csv": "data/Australia/Senate/term-35.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8dcbd9/data/Australia/Senate/term-35.csv"
+          }
+        ],
+        "statement_count": 19472
+      }
+    ]
+  },
+  {
+    "name": "Austria",
+    "country": "Austria",
+    "code": "AT",
+    "slug": "Austria",
+    "legislatures": [
+      {
+        "name": "Nationalrat",
+        "slug": "Nationalrat",
+        "sources_directory": "data/Austria/Nationalrat/sources",
+        "popolo": "data/Austria/Nationalrat/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3df153b/data/Austria/Nationalrat/ep-popolo-v1.0.json",
+        "names": "data/Austria/Nationalrat/names.csv",
+        "lastmod": "1467888746",
+        "person_count": 182,
+        "sha": "3df153b",
+        "legislative_periods": [
+          {
+            "id": "term/25",
+            "name": "25th Legislative Period",
+            "start_date": "2013-09-29",
+            "slug": "25",
+            "csv": "data/Austria/Nationalrat/term-25.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3df153b/data/Austria/Nationalrat/term-25.csv"
+          }
+        ],
+        "statement_count": 13057
+      }
+    ]
+  },
+  {
+    "name": "Azerbaijan",
+    "country": "Azerbaijan",
+    "code": "AZ",
+    "slug": "Azerbaijan",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "National-Assembly",
+        "sources_directory": "data/Azerbaijan/National_Assembly/sources",
+        "popolo": "data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cfb5947/data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Azerbaijan/National_Assembly/names.csv",
+        "lastmod": "1467657870",
+        "person_count": 152,
+        "sha": "cfb5947",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "V çağırış",
+            "start_date": "2015-12-01",
+            "slug": "5",
+            "csv": "data/Azerbaijan/National_Assembly/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cfb5947/data/Azerbaijan/National_Assembly/term-5.csv"
+          },
+          {
+            "end_date": "2015",
+            "id": "term/4",
+            "name": "IV çağırış",
+            "start_date": "2010",
+            "slug": "4",
+            "csv": "data/Azerbaijan/National_Assembly/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cfb5947/data/Azerbaijan/National_Assembly/term-4.csv"
+          }
+        ],
+        "statement_count": 5344
+      }
+    ]
+  },
+  {
+    "name": "Bahamas",
+    "country": "Bahamas",
+    "code": "BS",
+    "slug": "Bahamas",
+    "legislatures": [
+      {
+        "name": "House of Assembly",
+        "slug": "House-of-Assembly",
+        "sources_directory": "data/Bahamas/House_of_Assembly/sources",
+        "popolo": "data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4da60b8/data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Bahamas/House_of_Assembly/names.csv",
+        "lastmod": "1467817597",
+        "person_count": 38,
+        "sha": "4da60b8",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012–",
+            "start_date": "2012-05-08",
+            "slug": "2012",
+            "csv": "data/Bahamas/House_of_Assembly/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4da60b8/data/Bahamas/House_of_Assembly/term-2012.csv"
+          }
+        ],
+        "statement_count": 1383
+      }
+    ]
+  },
+  {
+    "name": "Bahrain",
+    "country": "Bahrain",
+    "code": "BH",
+    "slug": "Bahrain",
+    "legislatures": [
+      {
+        "name": "Council of Representatives",
+        "slug": "Council-of-Representatives",
+        "sources_directory": "data/Bahrain/Council_of_Representatives/sources",
+        "popolo": "data/Bahrain/Council_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b99a63a/data/Bahrain/Council_of_Representatives/ep-popolo-v1.0.json",
+        "names": "data/Bahrain/Council_of_Representatives/names.csv",
+        "lastmod": "1467821730",
+        "person_count": 40,
+        "sha": "b99a63a",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "2014–",
+            "start_date": "2014-12-14",
+            "slug": "2014",
+            "csv": "data/Bahrain/Council_of_Representatives/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b99a63a/data/Bahrain/Council_of_Representatives/term-2014.csv"
+          }
+        ],
+        "statement_count": 523
+      }
+    ]
+  },
+  {
+    "name": "Bangladesh",
+    "country": "Bangladesh",
+    "code": "BD",
+    "slug": "Bangladesh",
+    "legislatures": [
+      {
+        "name": "Jatiyo Sangshad",
+        "slug": "House",
+        "sources_directory": "data/Bangladesh/House/sources",
+        "popolo": "data/Bangladesh/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2dda385/data/Bangladesh/House/ep-popolo-v1.0.json",
+        "names": "data/Bangladesh/House/names.csv",
+        "lastmod": "1467873953",
+        "person_count": 543,
+        "sha": "2dda385",
+        "legislative_periods": [
+          {
+            "id": "term/10",
+            "name": "10th Parliament",
+            "start_date": "2014-01-29",
+            "slug": "10",
+            "csv": "data/Bangladesh/House/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2dda385/data/Bangladesh/House/term-10.csv"
+          },
+          {
+            "end_date": "2014-01-24",
+            "id": "term/9",
+            "name": "9th Parliament",
+            "start_date": "2009-01-25",
+            "slug": "9",
+            "csv": "data/Bangladesh/House/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2dda385/data/Bangladesh/House/term-9.csv"
+          }
+        ],
+        "statement_count": 12100
+      }
+    ]
+  },
+  {
+    "name": "Barbados",
+    "country": "Barbados",
+    "code": "BB",
+    "slug": "Barbados",
+    "legislatures": [
+      {
+        "name": "House of Assembly",
+        "slug": "House-of-Assembly",
+        "sources_directory": "data/Barbados/House_of_Assembly/sources",
+        "popolo": "data/Barbados/House_of_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e172fea/data/Barbados/House_of_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Barbados/House_of_Assembly/names.csv",
+        "lastmod": "1467825273",
+        "person_count": 30,
+        "sha": "e172fea",
+        "legislative_periods": [
+          {
+            "id": "term/2013",
+            "name": "2013–2018",
+            "start_date": "2013-03-06",
+            "slug": "2013",
+            "csv": "data/Barbados/House_of_Assembly/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e172fea/data/Barbados/House_of_Assembly/term-2013.csv"
+          }
+        ],
+        "statement_count": 904
+      }
+    ]
+  },
+  {
+    "name": "Belarus",
+    "country": "Belarus",
+    "code": "BY",
+    "slug": "Belarus",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "Chamber",
+        "sources_directory": "data/Belarus/Chamber/sources",
+        "popolo": "data/Belarus/Chamber/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa99609/data/Belarus/Chamber/ep-popolo-v1.0.json",
+        "names": "data/Belarus/Chamber/names.csv",
+        "lastmod": "1467820057",
+        "person_count": 109,
+        "sha": "fa99609",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "5th Convocation",
+            "start_date": "2012-09-23",
+            "slug": "5",
+            "csv": "data/Belarus/Chamber/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa99609/data/Belarus/Chamber/term-5.csv"
+          }
+        ],
+        "statement_count": 3332
+      }
+    ]
+  },
+  {
+    "name": "Belgium",
+    "country": "Belgium",
+    "code": "BE",
+    "slug": "Belgium",
+    "legislatures": [
+      {
+        "name": "Chamber of Representatives",
+        "slug": "Representatives",
+        "sources_directory": "data/Belgium/Representatives/sources",
+        "popolo": "data/Belgium/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d85bfcc/data/Belgium/Representatives/ep-popolo-v1.0.json",
+        "names": "data/Belgium/Representatives/names.csv",
+        "lastmod": "1467777510",
+        "person_count": 168,
+        "sha": "d85bfcc",
+        "legislative_periods": [
+          {
+            "id": "term/54",
+            "name": "Législature 54",
+            "start_date": "2014-06-19",
+            "slug": "54",
+            "csv": "data/Belgium/Representatives/term-54.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d85bfcc/data/Belgium/Representatives/term-54.csv"
+          }
+        ],
+        "statement_count": 12242
+      }
+    ]
+  },
+  {
+    "name": "Belize",
+    "country": "Belize",
+    "code": "BZ",
+    "slug": "Belize",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "Representatives",
+        "sources_directory": "data/Belize/Representatives/sources",
+        "popolo": "data/Belize/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/361dd77/data/Belize/Representatives/ep-popolo-v1.0.json",
+        "names": "data/Belize/Representatives/names.csv",
+        "lastmod": "1466353605",
+        "person_count": 27,
+        "sha": "361dd77",
+        "legislative_periods": [
+          {
+            "end_date": "2017",
+            "id": "term/2012",
+            "name": "2012–2017",
+            "start_date": "2012-03-21",
+            "slug": "2012",
+            "csv": "data/Belize/Representatives/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/361dd77/data/Belize/Representatives/term-2012.csv"
+          }
+        ],
+        "statement_count": 1224
+      }
+    ]
+  },
+  {
+    "name": "Benin",
+    "country": "Benin",
+    "code": "BJ",
+    "slug": "Benin",
+    "legislatures": [
+      {
+        "name": "Assemblée Nationale",
+        "slug": "National-Assembly",
+        "sources_directory": "data/Benin/National_Assembly/sources",
+        "popolo": "data/Benin/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f76ade5/data/Benin/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Benin/National_Assembly/names.csv",
+        "lastmod": "1466150449",
+        "person_count": 83,
+        "sha": "f76ade5",
+        "legislative_periods": [
+          {
+            "id": "term/6",
+            "name": "6e législature",
+            "start_date": "2015-04-26",
+            "slug": "6",
+            "csv": "data/Benin/National_Assembly/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f76ade5/data/Benin/National_Assembly/term-6.csv"
+          }
+        ],
+        "statement_count": 1848
+      }
+    ]
+  },
+  {
+    "name": "Bermuda",
+    "country": "Bermuda",
+    "code": "BM",
+    "slug": "Bermuda",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Assembly",
+        "sources_directory": "data/Bermuda/Assembly/sources",
+        "popolo": "data/Bermuda/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3d980d8/data/Bermuda/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Bermuda/Assembly/names.csv",
+        "lastmod": "1467887132",
+        "person_count": 37,
+        "sha": "3d980d8",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012–",
+            "start_date": "2012-12-17",
+            "slug": "2012",
+            "csv": "data/Bermuda/Assembly/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3d980d8/data/Bermuda/Assembly/term-2012.csv"
+          }
+        ],
+        "statement_count": 1223
+      }
+    ]
+  },
+  {
+    "name": "Bhutan",
+    "country": "Bhutan",
+    "code": "BT",
+    "slug": "Bhutan",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Bhutan/Assembly/sources",
+        "popolo": "data/Bhutan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4626e37/data/Bhutan/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Bhutan/Assembly/names.csv",
+        "lastmod": "1467737920",
+        "person_count": 47,
+        "sha": "4626e37",
+        "legislative_periods": [
+          {
+            "id": "term/2",
+            "name": "2nd Parliament",
+            "start_date": "2013-07-13",
+            "slug": "2",
+            "csv": "data/Bhutan/Assembly/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4626e37/data/Bhutan/Assembly/term-2.csv"
+          }
+        ],
+        "statement_count": 1098
+      }
+    ]
+  },
+  {
+    "name": "Bolivia",
+    "country": "Bolivia",
+    "code": "BO",
+    "slug": "Bolivia",
+    "legislatures": [
+      {
+        "name": "Chamber of Deputies",
+        "slug": "Deputies",
+        "sources_directory": "data/Bolivia/Deputies/sources",
+        "popolo": "data/Bolivia/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/73152b1/data/Bolivia/Deputies/ep-popolo-v1.0.json",
+        "names": "data/Bolivia/Deputies/names.csv",
+        "lastmod": "1465844372",
+        "person_count": 128,
+        "sha": "73152b1",
+        "legislative_periods": [
+          {
+            "id": "term/2015",
+            "name": "2015–",
+            "start_date": "2015-01-21",
+            "slug": "2015",
+            "csv": "data/Bolivia/Deputies/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/73152b1/data/Bolivia/Deputies/term-2015.csv"
+          }
+        ],
+        "statement_count": 2389
+      }
+    ]
+  },
+  {
+    "name": "Bosnia and Herzegovina",
+    "country": "Bosnia and Herzegovina",
+    "code": "BA",
+    "slug": "Bosnia-and-Herzegovina",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House-of-Representatives",
+        "sources_directory": "data/Bosnia_and_Herzegovina/House_of_Representatives/sources",
+        "popolo": "data/Bosnia_and_Herzegovina/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Bosnia_and_Herzegovina/House_of_Representatives/ep-popolo-v1.0.json",
+        "names": "data/Bosnia_and_Herzegovina/House_of_Representatives/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 42,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/7",
+            "name": "2014–",
+            "start_date": "2014-12-09",
+            "slug": "7",
+            "csv": "data/Bosnia_and_Herzegovina/House_of_Representatives/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Bosnia_and_Herzegovina/House_of_Representatives/term-7.csv"
+          }
+        ],
+        "statement_count": 1501
+      }
+    ]
+  },
+  {
+    "name": "Botswana",
+    "country": "Botswana",
+    "code": "BW",
+    "slug": "Botswana",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Botswana/Assembly/sources",
+        "popolo": "data/Botswana/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Botswana/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Botswana/Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 63,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "2014",
+            "start_date": "2014-10-29",
+            "slug": "2014",
+            "csv": "data/Botswana/Assembly/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Botswana/Assembly/term-2014.csv"
+          }
+        ],
+        "statement_count": 1665
+      }
+    ]
+  },
+  {
+    "name": "Brazil",
+    "country": "Brazil",
+    "code": "BR",
+    "slug": "Brazil",
+    "legislatures": [
+      {
+        "name": "Chamber of Deputies",
+        "slug": "Deputies",
+        "sources_directory": "data/Brazil/Deputies/sources",
+        "popolo": "data/Brazil/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df0d42e/data/Brazil/Deputies/ep-popolo-v1.0.json",
+        "names": "data/Brazil/Deputies/names.csv",
+        "lastmod": "1467962614",
+        "person_count": 926,
+        "sha": "df0d42e",
+        "legislative_periods": [
+          {
+            "id": "term/55",
+            "name": "55th Legislature",
+            "start_date": "2015-02-01",
+            "slug": "55",
+            "csv": "data/Brazil/Deputies/term-55.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df0d42e/data/Brazil/Deputies/term-55.csv"
+          },
+          {
+            "end_date": "2015",
+            "id": "term/54",
+            "name": "54th Legislature",
+            "start_date": "2011",
+            "slug": "54",
+            "csv": "data/Brazil/Deputies/term-54.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df0d42e/data/Brazil/Deputies/term-54.csv"
+          }
+        ],
+        "statement_count": 32483
+      }
+    ]
+  },
+  {
+    "name": "British Virgin Islands",
+    "country": "British Virgin Islands",
+    "code": "VG",
+    "slug": "British-Virgin-Islands",
+    "legislatures": [
+      {
+        "name": "House of Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/British_Virgin_Islands/Assembly/sources",
+        "popolo": "data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/76647a7/data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
+        "names": "data/British_Virgin_Islands/Assembly/names.csv",
+        "lastmod": "1467777993",
+        "person_count": 23,
+        "sha": "76647a7",
+        "legislative_periods": [
+          {
+            "id": "term/2015",
+            "name": "3rd Assembly",
+            "start_date": "2015-06-08",
+            "slug": "2015",
+            "csv": "data/British_Virgin_Islands/Assembly/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/76647a7/data/British_Virgin_Islands/Assembly/term-2015.csv"
+          },
+          {
+            "end_date": "2015",
+            "id": "term/2011",
+            "name": "2nd Assembly",
+            "start_date": "2011",
+            "slug": "2011",
+            "csv": "data/British_Virgin_Islands/Assembly/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/76647a7/data/British_Virgin_Islands/Assembly/term-2011.csv"
+          },
+          {
+            "end_date": "2011",
+            "id": "term/2007",
+            "name": "1st Assembly",
+            "start_date": "2007",
+            "slug": "2007",
+            "csv": "data/British_Virgin_Islands/Assembly/term-2007.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/76647a7/data/British_Virgin_Islands/Assembly/term-2007.csv"
+          }
+        ],
+        "statement_count": 1187
+      },
+      {
+        "name": "Legislative Council",
+        "slug": "Council",
+        "sources_directory": "data/British_Virgin_Islands/Council/sources",
+        "popolo": "data/British_Virgin_Islands/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/441b93f/data/British_Virgin_Islands/Council/ep-popolo-v1.0.json",
+        "names": "data/British_Virgin_Islands/Council/names.csv",
+        "lastmod": "1466159132",
+        "person_count": 36,
+        "sha": "441b93f",
+        "legislative_periods": [
+          {
+            "end_date": "2007-08-20",
+            "id": "term/2003",
+            "name": "15th Council",
+            "start_date": "2003-06-16",
+            "slug": "2003",
+            "csv": "data/British_Virgin_Islands/Council/term-2003.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/441b93f/data/British_Virgin_Islands/Council/term-2003.csv"
+          },
+          {
+            "end_date": "2003",
+            "id": "term/1999",
+            "name": "14th Council",
+            "start_date": "1999",
+            "slug": "1999",
+            "csv": "data/British_Virgin_Islands/Council/term-1999.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/441b93f/data/British_Virgin_Islands/Council/term-1999.csv"
+          },
+          {
+            "end_date": "1999",
+            "id": "term/1995",
+            "name": "13th Council",
+            "start_date": "1995",
+            "slug": "1995",
+            "csv": "data/British_Virgin_Islands/Council/term-1995.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/441b93f/data/British_Virgin_Islands/Council/term-1995.csv"
+          },
+          {
+            "end_date": "1995",
+            "id": "term/1990",
+            "name": "12th Council",
+            "start_date": "1990",
+            "slug": "1990",
+            "csv": "data/British_Virgin_Islands/Council/term-1990.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/441b93f/data/British_Virgin_Islands/Council/term-1990.csv"
+          },
+          {
+            "end_date": "1990",
+            "id": "term/1986",
+            "name": "11th Council",
+            "start_date": "1986",
+            "slug": "1986",
+            "csv": "data/British_Virgin_Islands/Council/term-1986.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/441b93f/data/British_Virgin_Islands/Council/term-1986.csv"
+          },
+          {
+            "end_date": "1986",
+            "id": "term/1983",
+            "name": "10th Council",
+            "start_date": "1983",
+            "slug": "1983",
+            "csv": "data/British_Virgin_Islands/Council/term-1983.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/441b93f/data/British_Virgin_Islands/Council/term-1983.csv"
+          },
+          {
+            "end_date": "1983",
+            "id": "term/1979",
+            "name": "9th Council",
+            "start_date": "1979",
+            "slug": "1979",
+            "csv": "data/British_Virgin_Islands/Council/term-1979.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/441b93f/data/British_Virgin_Islands/Council/term-1979.csv"
+          },
+          {
+            "end_date": "1979",
+            "id": "term/1975",
+            "name": "8th Council",
+            "start_date": "1975",
+            "slug": "1975",
+            "csv": "data/British_Virgin_Islands/Council/term-1975.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/441b93f/data/British_Virgin_Islands/Council/term-1975.csv"
+          },
+          {
+            "end_date": "1975",
+            "id": "term/1971",
+            "name": "7th Council",
+            "start_date": "1971",
+            "slug": "1971",
+            "csv": "data/British_Virgin_Islands/Council/term-1971.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/441b93f/data/British_Virgin_Islands/Council/term-1971.csv"
+          }
+        ],
+        "statement_count": 2007
+      }
+    ]
+  },
+  {
+    "name": "Brunei",
+    "country": "Brunei",
+    "code": "BN",
+    "slug": "Brunei",
+    "legislatures": [
+      {
+        "name": "Legislative Council of Brunei",
+        "slug": "Legislative-Council",
+        "sources_directory": "data/Brunei/Legislative_Council/sources",
+        "popolo": "data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
+        "names": "data/Brunei/Legislative_Council/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 19,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "end_date": "2015-03-24",
+            "id": "term/11",
+            "name": "11th Legislative Council",
+            "start_date": "2015-03-05",
+            "slug": "11",
+            "csv": "data/Brunei/Legislative_Council/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Brunei/Legislative_Council/term-11.csv"
+          }
+        ],
+        "statement_count": 311
+      }
+    ]
+  },
+  {
+    "name": "Bulgaria",
+    "country": "Bulgaria",
+    "code": "BG",
+    "slug": "Bulgaria",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "National-Assembly",
+        "sources_directory": "data/Bulgaria/National_Assembly/sources",
+        "popolo": "data/Bulgaria/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/270c5ca/data/Bulgaria/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Bulgaria/National_Assembly/names.csv",
+        "lastmod": "1467318967",
+        "person_count": 940,
+        "sha": "270c5ca",
+        "legislative_periods": [
+          {
+            "end_date": "2015-09-10",
+            "id": "term/43",
+            "name": "43rd National Assembly",
+            "start_date": "2014-10-27",
+            "slug": "43",
+            "csv": "data/Bulgaria/National_Assembly/term-43.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/270c5ca/data/Bulgaria/National_Assembly/term-43.csv"
+          },
+          {
+            "end_date": "2014-08-05",
+            "id": "term/42",
+            "name": "42nd National Assembly",
+            "start_date": "2013-05-21",
+            "slug": "42",
+            "csv": "data/Bulgaria/National_Assembly/term-42.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/270c5ca/data/Bulgaria/National_Assembly/term-42.csv"
+          },
+          {
+            "end_date": "2013-03-14",
+            "id": "term/41",
+            "name": "41st National Assembly",
+            "start_date": "2009-07-14",
+            "slug": "41",
+            "csv": "data/Bulgaria/National_Assembly/term-41.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/270c5ca/data/Bulgaria/National_Assembly/term-41.csv"
+          },
+          {
+            "end_date": "2009-06-25",
+            "id": "term/40",
+            "name": "40th National Assembly",
+            "start_date": "2005-07-11",
+            "slug": "40",
+            "csv": "data/Bulgaria/National_Assembly/term-40.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/270c5ca/data/Bulgaria/National_Assembly/term-40.csv"
+          },
+          {
+            "end_date": "2005-06-17",
+            "id": "term/39",
+            "name": "39th National Assembly",
+            "start_date": "2001-07-05",
+            "slug": "39",
+            "csv": "data/Bulgaria/National_Assembly/term-39.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/270c5ca/data/Bulgaria/National_Assembly/term-39.csv"
+          }
+        ],
+        "statement_count": 37513
+      }
+    ]
+  },
+  {
+    "name": "Burkina Faso",
+    "country": "Burkina Faso",
+    "code": "BF",
+    "slug": "Burkina-Faso",
+    "legislatures": [
+      {
+        "name": "Assemblée Nationale",
+        "slug": "Assembly",
+        "sources_directory": "data/Burkina_Faso/Assembly/sources",
+        "popolo": "data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Burkina_Faso/Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 475,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/7",
+            "name": "VIIe législature",
+            "start_date": "2015-12-30",
+            "slug": "7",
+            "csv": "data/Burkina_Faso/Assembly/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burkina_Faso/Assembly/term-7.csv"
+          },
+          {
+            "id": "term/2012",
+            "name": "Ve législature",
+            "start_date": "2012-12-02",
+            "slug": "2012",
+            "csv": "data/Burkina_Faso/Assembly/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burkina_Faso/Assembly/term-2012.csv"
+          },
+          {
+            "id": "term/3",
+            "name": "IIIe législature",
+            "start_date": "2002",
+            "slug": "3",
+            "csv": "data/Burkina_Faso/Assembly/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burkina_Faso/Assembly/term-3.csv"
+          },
+          {
+            "id": "term/2",
+            "name": "IIe législature",
+            "start_date": "1997",
+            "slug": "2",
+            "csv": "data/Burkina_Faso/Assembly/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burkina_Faso/Assembly/term-2.csv"
+          },
+          {
+            "id": "term/1",
+            "name": "Ie législature",
+            "start_date": "1992",
+            "slug": "1",
+            "csv": "data/Burkina_Faso/Assembly/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burkina_Faso/Assembly/term-1.csv"
+          }
+        ],
+        "statement_count": 7063
+      }
+    ]
+  },
+  {
+    "name": "Burundi",
+    "country": "Burundi",
+    "code": "BI",
+    "slug": "Burundi",
+    "legislatures": [
+      {
+        "name": "Assemblée nationale",
+        "slug": "Assembly",
+        "sources_directory": "data/Burundi/Assembly/sources",
+        "popolo": "data/Burundi/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burundi/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Burundi/Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 227,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/2015",
+            "name": "2015–",
+            "start_date": "2015-07-27",
+            "slug": "2015",
+            "csv": "data/Burundi/Assembly/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burundi/Assembly/term-2015.csv"
+          },
+          {
+            "end_date": "2015-04-30",
+            "id": "term/2010",
+            "name": "2010–2015",
+            "start_date": "2010",
+            "slug": "2010",
+            "csv": "data/Burundi/Assembly/term-2010.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burundi/Assembly/term-2010.csv"
+          }
+        ],
+        "statement_count": 2905
+      }
+    ]
+  },
+  {
+    "name": "Cabo Verde",
+    "country": "Cabo Verde",
+    "code": "CV",
+    "slug": "Cabo-Verde",
+    "legislatures": [
+      {
+        "name": "Assembleia Nacional",
+        "slug": "Assembly",
+        "sources_directory": "data/Cabo_Verde/Assembly/sources",
+        "popolo": "data/Cabo_Verde/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2131da6/data/Cabo_Verde/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Cabo_Verde/Assembly/names.csv",
+        "lastmod": "1467897833",
+        "person_count": 124,
+        "sha": "2131da6",
+        "legislative_periods": [
+          {
+            "id": "term/9",
+            "name": "IX Legislatura",
+            "start_date": "2016-04-20",
+            "slug": "9",
+            "csv": "data/Cabo_Verde/Assembly/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2131da6/data/Cabo_Verde/Assembly/term-9.csv"
+          },
+          {
+            "end_date": "2016-03-20",
+            "id": "term/8",
+            "name": "VIII Legislatura",
+            "start_date": "2011-03-11",
+            "slug": "8",
+            "csv": "data/Cabo_Verde/Assembly/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2131da6/data/Cabo_Verde/Assembly/term-8.csv"
+          }
+        ],
+        "statement_count": 1967
+      }
+    ]
+  },
+  {
+    "name": "Cambodia",
+    "country": "Cambodia",
+    "code": "KH",
+    "slug": "Cambodia",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "National-Assembly",
+        "sources_directory": "data/Cambodia/National_Assembly/sources",
+        "popolo": "data/Cambodia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/63bfb22/data/Cambodia/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Cambodia/National_Assembly/names.csv",
+        "lastmod": "1467882036",
+        "person_count": 123,
+        "sha": "63bfb22",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "5th Mandate",
+            "start_date": "2013-09-23",
+            "slug": "5",
+            "csv": "data/Cambodia/National_Assembly/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/63bfb22/data/Cambodia/National_Assembly/term-5.csv"
+          }
+        ],
+        "statement_count": 3184
+      }
+    ]
+  },
+  {
+    "name": "Cameroon",
+    "country": "Cameroon",
+    "code": "CM",
+    "slug": "Cameroon",
+    "legislatures": [
+      {
+        "name": "Assemblée Nationale",
+        "slug": "Assembly",
+        "sources_directory": "data/Cameroon/Assembly/sources",
+        "popolo": "data/Cameroon/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1568d8b/data/Cameroon/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Cameroon/Assembly/names.csv",
+        "lastmod": "1467166491",
+        "person_count": 964,
+        "sha": "1568d8b",
+        "legislative_periods": [
+          {
+            "id": "term/9",
+            "name": "9e législature",
+            "start_date": "2013-10-29",
+            "slug": "9",
+            "csv": "data/Cameroon/Assembly/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1568d8b/data/Cameroon/Assembly/term-9.csv"
+          },
+          {
+            "end_date": "2013-07-22",
+            "id": "term/8",
+            "name": "8e législature",
+            "start_date": "2007",
+            "slug": "8",
+            "csv": "data/Cameroon/Assembly/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1568d8b/data/Cameroon/Assembly/term-8.csv"
+          },
+          {
+            "end_date": "2007",
+            "id": "term/7",
+            "name": "7e législature",
+            "start_date": "2002",
+            "slug": "7",
+            "csv": "data/Cameroon/Assembly/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1568d8b/data/Cameroon/Assembly/term-7.csv"
+          },
+          {
+            "end_date": "2002",
+            "id": "term/6",
+            "name": "6e législature",
+            "start_date": "1997",
+            "slug": "6",
+            "csv": "data/Cameroon/Assembly/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1568d8b/data/Cameroon/Assembly/term-6.csv"
+          },
+          {
+            "end_date": "1997",
+            "id": "term/5",
+            "name": "5e législature",
+            "start_date": "1992",
+            "slug": "5",
+            "csv": "data/Cameroon/Assembly/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1568d8b/data/Cameroon/Assembly/term-5.csv"
+          },
+          {
+            "end_date": "1992",
+            "id": "term/4",
+            "name": "4e législature",
+            "start_date": "1988",
+            "slug": "4",
+            "csv": "data/Cameroon/Assembly/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1568d8b/data/Cameroon/Assembly/term-4.csv"
+          },
+          {
+            "end_date": "1988",
+            "id": "term/3",
+            "name": "3e législature",
+            "start_date": "1983",
+            "slug": "3",
+            "csv": "data/Cameroon/Assembly/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1568d8b/data/Cameroon/Assembly/term-3.csv"
+          },
+          {
+            "end_date": "1978",
+            "id": "term/1",
+            "name": "1e législature",
+            "start_date": "1973",
+            "slug": "1",
+            "csv": "data/Cameroon/Assembly/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1568d8b/data/Cameroon/Assembly/term-1.csv"
+          }
+        ],
+        "statement_count": 13140
+      },
+      {
+        "name": "Sénat",
+        "slug": "Senate",
+        "sources_directory": "data/Cameroon/Senate/sources",
+        "popolo": "data/Cameroon/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Cameroon/Senate/ep-popolo-v1.0.json",
+        "names": "data/Cameroon/Senate/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 100,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/9",
+            "name": "9e législature",
+            "start_date": "2013",
+            "slug": "9",
+            "csv": "data/Cameroon/Senate/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Cameroon/Senate/term-9.csv"
+          }
+        ],
+        "statement_count": 1335
+      }
+    ]
+  },
+  {
+    "name": "Canada",
+    "country": "Canada",
+    "code": "CA",
+    "slug": "Canada",
+    "legislatures": [
+      {
+        "name": "House of Commons",
+        "slug": "Commons",
+        "sources_directory": "data/Canada/Commons/sources",
+        "popolo": "data/Canada/Commons/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf0ca75/data/Canada/Commons/ep-popolo-v1.0.json",
+        "names": "data/Canada/Commons/names.csv",
+        "lastmod": "1467831088",
+        "person_count": 537,
+        "sha": "bf0ca75",
+        "legislative_periods": [
+          {
+            "id": "term/42",
+            "name": "42nd Parliament",
+            "start_date": "2015-12-03",
+            "wikidata": "Q21157957",
+            "slug": "42",
+            "csv": "data/Canada/Commons/term-42.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf0ca75/data/Canada/Commons/term-42.csv"
+          },
+          {
+            "end_date": "2015-08-02",
+            "id": "term/41",
+            "name": "41st Parliament",
+            "start_date": "2011-06-02",
+            "wikidata": "Q2816776",
+            "slug": "41",
+            "csv": "data/Canada/Commons/term-41.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf0ca75/data/Canada/Commons/term-41.csv"
+          }
+        ],
+        "statement_count": 35993
+      }
+    ]
+  },
+  {
+    "name": "Cayman Islands",
+    "country": "Cayman Islands",
+    "code": "KY",
+    "slug": "Cayman-Islands",
+    "legislatures": [
+      {
+        "name": "Legislative Assembly",
+        "slug": "Legislative-Assembly",
+        "sources_directory": "data/Cayman_Islands/Legislative_Assembly/sources",
+        "popolo": "data/Cayman_Islands/Legislative_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b1947a0/data/Cayman_Islands/Legislative_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Cayman_Islands/Legislative_Assembly/names.csv",
+        "lastmod": "1467886490",
+        "person_count": 18,
+        "sha": "b1947a0",
+        "legislative_periods": [
+          {
+            "id": "term/2013",
+            "name": "2013–2017",
+            "start_date": "2013",
+            "slug": "2013",
+            "csv": "data/Cayman_Islands/Legislative_Assembly/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b1947a0/data/Cayman_Islands/Legislative_Assembly/term-2013.csv"
+          }
+        ],
+        "statement_count": 705
+      }
+    ]
+  },
+  {
+    "name": "Chad",
+    "country": "Chad",
+    "code": "TD",
+    "slug": "Chad",
+    "legislatures": [
+      {
+        "name": "Assemblée Nationale",
+        "slug": "Assembly",
+        "sources_directory": "data/Chad/Assembly/sources",
+        "popolo": "data/Chad/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Chad/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Chad/Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 191,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/3",
+            "name": "Troisième Législature",
+            "start_date": "2011-06-23",
+            "slug": "3",
+            "csv": "data/Chad/Assembly/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Chad/Assembly/term-3.csv"
+          }
+        ],
+        "statement_count": 2587
+      }
+    ]
+  },
+  {
+    "name": "Chile",
+    "country": "Chile",
+    "code": "CL",
+    "slug": "Chile",
+    "legislatures": [
+      {
+        "name": "National Congress",
+        "slug": "Deputies",
+        "sources_directory": "data/Chile/Deputies/sources",
+        "popolo": "data/Chile/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/23d4c32/data/Chile/Deputies/ep-popolo-v1.0.json",
+        "names": "data/Chile/Deputies/names.csv",
+        "lastmod": "1467079551",
+        "person_count": 375,
+        "sha": "23d4c32",
+        "legislative_periods": [
+          {
+            "end_date": "2018-03-10",
+            "id": "term/8",
+            "name": "Legislativo 2014-2018",
+            "start_date": "2014-03-11",
+            "slug": "8",
+            "csv": "data/Chile/Deputies/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/23d4c32/data/Chile/Deputies/term-8.csv"
+          },
+          {
+            "end_date": "2014-03-10",
+            "id": "term/6",
+            "name": "Legislativo 2010-2014",
+            "start_date": "2010-03-11",
+            "slug": "6",
+            "csv": "data/Chile/Deputies/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/23d4c32/data/Chile/Deputies/term-6.csv"
+          },
+          {
+            "end_date": "2010-03-10",
+            "id": "term/5",
+            "name": "Legislativo 2006-2010",
+            "start_date": "2006-03-11",
+            "slug": "5",
+            "csv": "data/Chile/Deputies/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/23d4c32/data/Chile/Deputies/term-5.csv"
+          },
+          {
+            "end_date": "2006-03-10",
+            "id": "term/4",
+            "name": "Legislativo 2002-2006",
+            "start_date": "2002-03-11",
+            "slug": "4",
+            "csv": "data/Chile/Deputies/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/23d4c32/data/Chile/Deputies/term-4.csv"
+          },
+          {
+            "end_date": "2002-03-10",
+            "id": "term/3",
+            "name": "Legislativo 1998-2002",
+            "start_date": "1998-03-11",
+            "slug": "3",
+            "csv": "data/Chile/Deputies/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/23d4c32/data/Chile/Deputies/term-3.csv"
+          },
+          {
+            "end_date": "1998-03-10",
+            "id": "term/2",
+            "name": "Legislativo 1994-1998",
+            "start_date": "1994-03-11",
+            "slug": "2",
+            "csv": "data/Chile/Deputies/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/23d4c32/data/Chile/Deputies/term-2.csv"
+          },
+          {
+            "end_date": "1994-03-10",
+            "id": "term/1",
+            "name": "Legislativo 1990-1994",
+            "start_date": "1990-03-11",
+            "slug": "1",
+            "csv": "data/Chile/Deputies/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/23d4c32/data/Chile/Deputies/term-1.csv"
+          }
+        ],
+        "statement_count": 17547
+      }
+    ]
+  },
+  {
+    "name": "China",
+    "country": "China",
+    "code": "CN",
+    "slug": "China",
+    "legislatures": [
+      {
+        "name": "National People’s Congress",
+        "slug": "Congress",
+        "sources_directory": "data/China/Congress/sources",
+        "popolo": "data/China/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/China/Congress/ep-popolo-v1.0.json",
+        "names": "data/China/Congress/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 2956,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/12",
+            "name": "12th National People’s Congress",
+            "start_date": "2013-03-05",
+            "slug": "12",
+            "csv": "data/China/Congress/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/China/Congress/term-12.csv"
+          }
+        ],
+        "statement_count": 29864
+      }
+    ]
+  },
+  {
+    "name": "Colombia",
+    "country": "Colombia",
+    "code": "CO",
+    "slug": "Colombia",
+    "legislatures": [
+      {
+        "name": "Cámara de Representantes",
+        "slug": "Representatives",
+        "sources_directory": "data/Colombia/Representatives/sources",
+        "popolo": "data/Colombia/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee51e9b/data/Colombia/Representatives/ep-popolo-v1.0.json",
+        "names": "data/Colombia/Representatives/names.csv",
+        "lastmod": "1467980306",
+        "person_count": 168,
+        "sha": "ee51e9b",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "2014–",
+            "start_date": "2014-07-20",
+            "slug": "2014",
+            "csv": "data/Colombia/Representatives/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee51e9b/data/Colombia/Representatives/term-2014.csv"
+          }
+        ],
+        "statement_count": 4713
+      },
+      {
+        "name": "Senado",
+        "slug": "Senate",
+        "sources_directory": "data/Colombia/Senate/sources",
+        "popolo": "data/Colombia/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8c8809e/data/Colombia/Senate/ep-popolo-v1.0.json",
+        "names": "data/Colombia/Senate/names.csv",
+        "lastmod": "1467995091",
+        "person_count": 101,
+        "sha": "8c8809e",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "2014–",
+            "start_date": "2014-07-20",
+            "slug": "2014",
+            "csv": "data/Colombia/Senate/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8c8809e/data/Colombia/Senate/term-2014.csv"
+          }
+        ],
+        "statement_count": 1904
+      }
+    ]
+  },
+  {
+    "name": "Comoros",
+    "country": "Comoros",
+    "code": "KM",
+    "slug": "Comoros",
+    "legislatures": [
+      {
+        "name": "Assembly of the Union",
+        "slug": "Assembly",
+        "sources_directory": "data/Comoros/Assembly/sources",
+        "popolo": "data/Comoros/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6847688/data/Comoros/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Comoros/Assembly/names.csv",
+        "lastmod": "1465855657",
+        "person_count": 24,
+        "sha": "6847688",
+        "legislative_periods": [
+          {
+            "id": "term/2015",
+            "name": "2015–",
+            "start_date": "2015-04-03",
+            "slug": "2015",
+            "csv": "data/Comoros/Assembly/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6847688/data/Comoros/Assembly/term-2015.csv"
+          }
+        ],
+        "statement_count": 771
+      }
+    ]
+  },
+  {
+    "name": "Congo-Brazzaville",
+    "country": "Congo-Brazzaville",
+    "code": "CG",
+    "slug": "Congo-Brazzaville",
+    "legislatures": [
+      {
+        "name": "Assemblee Nationale",
+        "slug": "Assembly",
+        "sources_directory": "data/Congo-Brazzaville/Assembly/sources",
+        "popolo": "data/Congo-Brazzaville/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/522f7c5/data/Congo-Brazzaville/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Congo-Brazzaville/Assembly/names.csv",
+        "lastmod": "1466614823",
+        "person_count": 122,
+        "sha": "522f7c5",
+        "legislative_periods": [
+          {
+            "id": "term/13",
+            "name": "13ème législature",
+            "start_date": "2012-09-05",
+            "slug": "13",
+            "csv": "data/Congo-Brazzaville/Assembly/term-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/522f7c5/data/Congo-Brazzaville/Assembly/term-13.csv"
+          }
+        ],
+        "statement_count": 2672
+      }
+    ]
+  },
+  {
+    "name": "Congo-Kinshasa (DRC)",
+    "country": "Congo-Kinshasa (DRC)",
+    "code": "CD",
+    "slug": "Congo-Kinshasa",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Congo-Kinshasa/Assembly/sources",
+        "popolo": "data/Congo-Kinshasa/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/da5d69d/data/Congo-Kinshasa/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Congo-Kinshasa/Assembly/names.csv",
+        "lastmod": "1467714758",
+        "person_count": 498,
+        "sha": "da5d69d",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012–",
+            "start_date": "2012-02-16",
+            "slug": "2012",
+            "csv": "data/Congo-Kinshasa/Assembly/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/da5d69d/data/Congo-Kinshasa/Assembly/term-2012.csv"
+          }
+        ],
+        "statement_count": 6850
+      }
+    ]
+  },
+  {
+    "name": "Cook Islands",
+    "country": "Cook Islands",
+    "code": "CK",
+    "slug": "Cook-Islands",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Cook_Islands/Parliament/sources",
+        "popolo": "data/Cook_Islands/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8967442e/data/Cook_Islands/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Cook_Islands/Parliament/names.csv",
+        "lastmod": "1467152964",
+        "person_count": 49,
+        "sha": "8967442e",
+        "legislative_periods": [
+          {
+            "id": "term/14",
+            "name": "14th Parliament",
+            "start_date": "2014",
+            "slug": "14",
+            "csv": "data/Cook_Islands/Parliament/term-14.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8967442e/data/Cook_Islands/Parliament/term-14.csv"
+          },
+          {
+            "end_date": "2014-04-17",
+            "id": "term/13",
+            "name": "13th Parliament",
+            "start_date": "2011-02-18",
+            "slug": "13",
+            "csv": "data/Cook_Islands/Parliament/term-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8967442e/data/Cook_Islands/Parliament/term-13.csv"
+          },
+          {
+            "end_date": "2010-09-24",
+            "id": "term/12",
+            "name": "12th Parliament",
+            "start_date": "2006",
+            "slug": "12",
+            "csv": "data/Cook_Islands/Parliament/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8967442e/data/Cook_Islands/Parliament/term-12.csv"
+          }
+        ],
+        "statement_count": 2310
+      }
+    ]
+  },
+  {
+    "name": "Costa Rica",
+    "country": "Costa Rica",
+    "code": "CR",
+    "slug": "Costa-Rica",
+    "legislatures": [
+      {
+        "name": "Legislative Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Costa_Rica/Assembly/sources",
+        "popolo": "data/Costa_Rica/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7c72bf6/data/Costa_Rica/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Costa_Rica/Assembly/names.csv",
+        "lastmod": "1467667792",
+        "person_count": 57,
+        "sha": "7c72bf6",
+        "legislative_periods": [
+          {
+            "end_date": "2018-04-30",
+            "id": "term/2014",
+            "name": "2014–2018",
+            "start_date": "2014-05-01",
+            "slug": "2014",
+            "csv": "data/Costa_Rica/Assembly/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7c72bf6/data/Costa_Rica/Assembly/term-2014.csv"
+          }
+        ],
+        "statement_count": 2081
+      }
+    ]
+  },
+  {
+    "name": "Croatia",
+    "country": "Croatia",
+    "code": "HR",
+    "slug": "Croatia",
+    "legislatures": [
+      {
+        "name": "Sabor",
+        "slug": "Sabor",
+        "sources_directory": "data/Croatia/Sabor/sources",
+        "popolo": "data/Croatia/Sabor/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e39048/data/Croatia/Sabor/ep-popolo-v1.0.json",
+        "names": "data/Croatia/Sabor/names.csv",
+        "lastmod": "1467881090",
+        "person_count": 287,
+        "sha": "6e39048",
+        "legislative_periods": [
+          {
+            "id": "term/8",
+            "name": "8th Assembly",
+            "start_date": "2015-12-28",
+            "slug": "8",
+            "csv": "data/Croatia/Sabor/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e39048/data/Croatia/Sabor/term-8.csv"
+          },
+          {
+            "end_date": "2015-09-28",
+            "id": "term/7",
+            "name": "7th Assembly",
+            "start_date": "2011-12-22",
+            "slug": "7",
+            "csv": "data/Croatia/Sabor/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e39048/data/Croatia/Sabor/term-7.csv"
+          }
+        ],
+        "statement_count": 9573
+      }
+    ]
+  },
+  {
+    "name": "Curaçao",
+    "country": "Curaçao",
+    "code": "CW",
+    "slug": "Curacao",
+    "legislatures": [
+      {
+        "name": "Estates of Curaçao",
+        "slug": "Estates",
+        "sources_directory": "data/Curacao/Estates/sources",
+        "popolo": "data/Curacao/Estates/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a20e1f/data/Curacao/Estates/ep-popolo-v1.0.json",
+        "names": "data/Curacao/Estates/names.csv",
+        "lastmod": "1467821853",
+        "person_count": 21,
+        "sha": "4a20e1f",
+        "legislative_periods": [
+          {
+            "id": "term/2",
+            "name": "2nd Curaçaoan Estates",
+            "start_date": "2012-09-11",
+            "slug": "2",
+            "csv": "data/Curacao/Estates/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a20e1f/data/Curacao/Estates/term-2.csv"
+          }
+        ],
+        "statement_count": 522
+      }
+    ]
+  },
+  {
+    "name": "Cyprus",
+    "country": "Cyprus",
+    "code": "CY",
+    "slug": "Cyprus",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House-of-Representatives",
+        "sources_directory": "data/Cyprus/House_of_Representatives/sources",
+        "popolo": "data/Cyprus/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25c5b5d/data/Cyprus/House_of_Representatives/ep-popolo-v1.0.json",
+        "names": "data/Cyprus/House_of_Representatives/names.csv",
+        "lastmod": "1467955967",
+        "person_count": 91,
+        "sha": "25c5b5d",
+        "legislative_periods": [
+          {
+            "id": "term/11",
+            "name": "11th Term",
+            "start_date": "2016-06-02",
+            "slug": "11",
+            "csv": "data/Cyprus/House_of_Representatives/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25c5b5d/data/Cyprus/House_of_Representatives/term-11.csv"
+          },
+          {
+            "end_date": "2016-04-14",
+            "id": "term/10",
+            "name": "10th Term",
+            "start_date": "2011-06-02",
+            "slug": "10",
+            "csv": "data/Cyprus/House_of_Representatives/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25c5b5d/data/Cyprus/House_of_Representatives/term-10.csv"
+          }
+        ],
+        "statement_count": 5217
+      }
+    ]
+  },
+  {
+    "name": "Czech Republic",
+    "country": "Czech Republic",
+    "code": "CZ",
+    "slug": "Czech-Republic",
+    "legislatures": [
+      {
+        "name": "Chamber of Deputies",
+        "slug": "Deputies",
+        "sources_directory": "data/Czech_Republic/Deputies/sources",
+        "popolo": "data/Czech_Republic/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25d6fde/data/Czech_Republic/Deputies/ep-popolo-v1.0.json",
+        "names": "data/Czech_Republic/Deputies/names.csv",
+        "lastmod": "1467871980",
+        "person_count": 893,
+        "sha": "25d6fde",
+        "legislative_periods": [
+          {
+            "id": "term/7",
+            "name": "7. volební období",
+            "start_date": "2013-10-26",
+            "slug": "7",
+            "csv": "data/Czech_Republic/Deputies/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25d6fde/data/Czech_Republic/Deputies/term-7.csv"
+          },
+          {
+            "end_date": "2013-08-28",
+            "id": "term/6",
+            "name": "6. volební období",
+            "start_date": "2010-05-29",
+            "slug": "6",
+            "csv": "data/Czech_Republic/Deputies/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25d6fde/data/Czech_Republic/Deputies/term-6.csv"
+          },
+          {
+            "end_date": "2010-06-03",
+            "id": "term/5",
+            "name": "5. volební období",
+            "start_date": "2006-06-03",
+            "slug": "5",
+            "csv": "data/Czech_Republic/Deputies/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25d6fde/data/Czech_Republic/Deputies/term-5.csv"
+          },
+          {
+            "end_date": "2006-06-15",
+            "id": "term/4",
+            "name": "4. volební období",
+            "start_date": "2002-06-15",
+            "slug": "4",
+            "csv": "data/Czech_Republic/Deputies/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25d6fde/data/Czech_Republic/Deputies/term-4.csv"
+          },
+          {
+            "end_date": "2002-06-20",
+            "id": "term/3",
+            "name": "3. volební období",
+            "start_date": "1998-06-20",
+            "slug": "3",
+            "csv": "data/Czech_Republic/Deputies/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25d6fde/data/Czech_Republic/Deputies/term-3.csv"
+          },
+          {
+            "end_date": "1998-06-19",
+            "id": "term/2",
+            "name": "2. volební období",
+            "start_date": "1996-06-01",
+            "slug": "2",
+            "csv": "data/Czech_Republic/Deputies/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25d6fde/data/Czech_Republic/Deputies/term-2.csv"
+          },
+          {
+            "end_date": "1996-06-06",
+            "id": "term/1",
+            "name": "1. volební období",
+            "start_date": "1992-06-06",
+            "slug": "1",
+            "csv": "data/Czech_Republic/Deputies/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25d6fde/data/Czech_Republic/Deputies/term-1.csv"
+          }
+        ],
+        "statement_count": 153198
+      }
+    ]
+  },
+  {
+    "name": "Côte d'Ivoire",
+    "country": "Côte d'Ivoire",
+    "code": "CI",
+    "slug": "Ivory-Coast",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Ivory_Coast/Assembly/sources",
+        "popolo": "data/Ivory_Coast/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be39ba4/data/Ivory_Coast/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Ivory_Coast/Assembly/names.csv",
+        "lastmod": "1465981445",
+        "person_count": 241,
+        "sha": "be39ba4",
+        "legislative_periods": [
+          {
+            "id": "term/2.2",
+            "name": "2e législature de la 2e République",
+            "start_date": "2012-03-12",
+            "slug": "2.2",
+            "csv": "data/Ivory_Coast/Assembly/term-2.2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be39ba4/data/Ivory_Coast/Assembly/term-2.2.csv"
+          }
+        ],
+        "statement_count": 4271
+      }
+    ]
+  },
+  {
+    "name": "Denmark",
+    "country": "Denmark",
+    "code": "DK",
+    "slug": "Denmark",
+    "legislatures": [
+      {
+        "name": "Folketing",
+        "slug": "Folketing",
+        "sources_directory": "data/Denmark/Folketing/sources",
+        "popolo": "data/Denmark/Folketing/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/162421d/data/Denmark/Folketing/ep-popolo-v1.0.json",
+        "names": "data/Denmark/Folketing/names.csv",
+        "lastmod": "1467869845",
+        "person_count": 612,
+        "sha": "162421d",
+        "legislative_periods": [
+          {
+            "id": "term/2015",
+            "name": "Folketing 2015–",
+            "start_date": "2015-06-20",
+            "slug": "2015",
+            "csv": "data/Denmark/Folketing/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/162421d/data/Denmark/Folketing/term-2015.csv"
+          },
+          {
+            "end_date": "2015-06-19",
+            "id": "term/2011",
+            "name": "Folketing 2011–2015",
+            "start_date": "2011-09-15",
+            "slug": "2011",
+            "csv": "data/Denmark/Folketing/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/162421d/data/Denmark/Folketing/term-2011.csv"
+          },
+          {
+            "end_date": "2011-09-14",
+            "id": "term/2007",
+            "name": "Folketing 2007–2011",
+            "start_date": "2007-11-13",
+            "slug": "2007",
+            "csv": "data/Denmark/Folketing/term-2007.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/162421d/data/Denmark/Folketing/term-2007.csv"
+          },
+          {
+            "end_date": "2007-11-12",
+            "id": "term/2005",
+            "name": "Folketing 2005–2007",
+            "start_date": "2005-02-08",
+            "slug": "2005",
+            "csv": "data/Denmark/Folketing/term-2005.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/162421d/data/Denmark/Folketing/term-2005.csv"
+          },
+          {
+            "end_date": "2005-02-07",
+            "id": "term/2001",
+            "name": "Folketing 2001–2005",
+            "start_date": "2001-11-20",
+            "slug": "2001",
+            "csv": "data/Denmark/Folketing/term-2001.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/162421d/data/Denmark/Folketing/term-2001.csv"
+          },
+          {
+            "end_date": "2001-11-19",
+            "id": "term/1998",
+            "name": "Folketing 1998–2001",
+            "start_date": "1998-11-03",
+            "slug": "1998",
+            "csv": "data/Denmark/Folketing/term-1998.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/162421d/data/Denmark/Folketing/term-1998.csv"
+          },
+          {
+            "end_date": "1998-11-02",
+            "id": "term/1994",
+            "name": "Folketing 1994–1998",
+            "start_date": "1994-09-21",
+            "slug": "1994",
+            "csv": "data/Denmark/Folketing/term-1994.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/162421d/data/Denmark/Folketing/term-1994.csv"
+          },
+          {
+            "end_date": "1994-09-20",
+            "id": "term/1990",
+            "name": "Folketing 1990–1994",
+            "start_date": "1990-12-12",
+            "slug": "1990",
+            "csv": "data/Denmark/Folketing/term-1990.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/162421d/data/Denmark/Folketing/term-1990.csv"
+          }
+        ],
+        "statement_count": 39852
+      }
+    ]
+  },
+  {
+    "name": "Djibouti",
+    "country": "Djibouti",
+    "code": "DJ",
+    "slug": "Djibouti",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Djibouti/Assembly/sources",
+        "popolo": "data/Djibouti/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Djibouti/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Djibouti/Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 65,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/6",
+            "name": "6th National Assembly",
+            "start_date": "2013-03-05",
+            "slug": "6",
+            "csv": "data/Djibouti/Assembly/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Djibouti/Assembly/term-6.csv"
+          }
+        ],
+        "statement_count": 825
+      }
+    ]
+  },
+  {
+    "name": "Dominica",
+    "country": "Dominica",
+    "code": "DM",
+    "slug": "Dominica",
+    "legislatures": [
+      {
+        "name": "House of Assembly",
+        "slug": "House-of-Assembly",
+        "sources_directory": "data/Dominica/House_of_Assembly/sources",
+        "popolo": "data/Dominica/House_of_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c7d9c92/data/Dominica/House_of_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Dominica/House_of_Assembly/names.csv",
+        "lastmod": "1467889359",
+        "person_count": 21,
+        "sha": "c7d9c92",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "2014–",
+            "start_date": "2014",
+            "slug": "2014",
+            "csv": "data/Dominica/House_of_Assembly/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c7d9c92/data/Dominica/House_of_Assembly/term-2014.csv"
+          }
+        ],
+        "statement_count": 520
+      }
+    ]
+  },
+  {
+    "name": "Dominican Republic",
+    "country": "Dominican Republic",
+    "code": "DO",
+    "slug": "Dominican-Republic",
+    "legislatures": [
+      {
+        "name": "Chamber of Deputies",
+        "slug": "Diputados",
+        "sources_directory": "data/Dominican_Republic/Diputados/sources",
+        "popolo": "data/Dominican_Republic/Diputados/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6bb142c/data/Dominican_Republic/Diputados/ep-popolo-v1.0.json",
+        "names": "data/Dominican_Republic/Diputados/names.csv",
+        "lastmod": "1467667611",
+        "person_count": 190,
+        "sha": "6bb142c",
+        "legislative_periods": [
+          {
+            "end_date": "2016-08-15",
+            "id": "term/2010",
+            "name": "2010–2016",
+            "start_date": "2010",
+            "slug": "2010",
+            "csv": "data/Dominican_Republic/Diputados/term-2010.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6bb142c/data/Dominican_Republic/Diputados/term-2010.csv"
+          }
+        ],
+        "statement_count": 3772
+      }
+    ]
+  },
+  {
+    "name": "Ecuador",
+    "country": "Ecuador",
+    "code": "EC",
+    "slug": "Ecuador",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Asamblea",
+        "sources_directory": "data/Ecuador/Asamblea/sources",
+        "popolo": "data/Ecuador/Asamblea/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/798ec6a/data/Ecuador/Asamblea/ep-popolo-v1.0.json",
+        "names": "data/Ecuador/Asamblea/names.csv",
+        "lastmod": "1467073034",
+        "person_count": 140,
+        "sha": "798ec6a",
+        "legislative_periods": [
+          {
+            "id": "term/2013",
+            "name": "2013–",
+            "start_date": "2013-05-14",
+            "slug": "2013",
+            "csv": "data/Ecuador/Asamblea/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/798ec6a/data/Ecuador/Asamblea/term-2013.csv"
+          }
+        ],
+        "statement_count": 4342
+      }
+    ]
+  },
+  {
+    "name": "Egypt",
+    "country": "Egypt",
+    "code": "EG",
+    "slug": "Egypt",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Egypt/Parliament/sources",
+        "popolo": "data/Egypt/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2b34276/data/Egypt/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Egypt/Parliament/names.csv",
+        "lastmod": "1466353642",
+        "person_count": 599,
+        "sha": "2b34276",
+        "legislative_periods": [
+          {
+            "id": "term/2015",
+            "name": "2015–",
+            "start_date": "2016-01-10",
+            "slug": "2015",
+            "csv": "data/Egypt/Parliament/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2b34276/data/Egypt/Parliament/term-2015.csv"
+          }
+        ],
+        "statement_count": 7088
+      }
+    ]
+  },
+  {
+    "name": "El Salvador",
+    "country": "El Salvador",
+    "code": "SV",
+    "slug": "El-Salvador",
+    "legislatures": [
+      {
+        "name": "Legislative Assembly",
+        "slug": "Legislative-Assembly",
+        "sources_directory": "data/El_Salvador/Legislative_Assembly/sources",
+        "popolo": "data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d0997b/data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
+        "names": "data/El_Salvador/Legislative_Assembly/names.csv",
+        "lastmod": "1467668209",
+        "person_count": 84,
+        "sha": "2d0997b",
+        "legislative_periods": [
+          {
+            "end_date": "2018",
+            "id": "term/2015-2018",
+            "name": "2015–2018",
+            "start_date": "2015-05-14",
+            "slug": "2015-2018",
+            "csv": "data/El_Salvador/Legislative_Assembly/term-2015-2018.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d0997b/data/El_Salvador/Legislative_Assembly/term-2015-2018.csv"
+          }
+        ],
+        "statement_count": 1897
+      }
+    ]
+  },
+  {
+    "name": "Estonia",
+    "country": "Estonia",
+    "code": "EE",
+    "slug": "Estonia",
+    "legislatures": [
+      {
+        "name": "Riigikogu",
+        "slug": "Riigikogu",
+        "sources_directory": "data/Estonia/Riigikogu/sources",
+        "popolo": "data/Estonia/Riigikogu/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f88ce37/data/Estonia/Riigikogu/ep-popolo-v1.0.json",
+        "names": "data/Estonia/Riigikogu/names.csv",
+        "lastmod": "1467963018",
+        "person_count": 194,
+        "sha": "f88ce37",
+        "legislative_periods": [
+          {
+            "id": "term/13",
+            "name": "13th Riigikogu",
+            "start_date": "2015-03-30",
+            "wikidata": "Q20530392",
+            "slug": "13",
+            "csv": "data/Estonia/Riigikogu/term-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f88ce37/data/Estonia/Riigikogu/term-13.csv"
+          },
+          {
+            "end_date": "2015-03-23",
+            "id": "term/12",
+            "name": "12th Riigikogu",
+            "start_date": "2011-03-27",
+            "wikidata": "Q967549",
+            "slug": "12",
+            "csv": "data/Estonia/Riigikogu/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f88ce37/data/Estonia/Riigikogu/term-12.csv"
+          }
+        ],
+        "statement_count": 15575
+      }
+    ]
+  },
+  {
+    "name": "Falkland Islands",
+    "country": "Falkland Islands",
+    "code": "FK",
+    "slug": "Falkland-Islands",
+    "legislatures": [
+      {
+        "name": "Legislative Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Falkland_Islands/Assembly/sources",
+        "popolo": "data/Falkland_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67c3ef0/data/Falkland_Islands/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Falkland_Islands/Assembly/names.csv",
+        "lastmod": "1467651972",
+        "person_count": 49,
+        "sha": "67c3ef0",
+        "legislative_periods": [
+          {
+            "end_date": "2017",
+            "id": "term/2013",
+            "name": "2013–2017",
+            "start_date": "2013-11-07",
+            "slug": "2013",
+            "csv": "data/Falkland_Islands/Assembly/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67c3ef0/data/Falkland_Islands/Assembly/term-2013.csv"
+          },
+          {
+            "end_date": "2013",
+            "id": "term/2009",
+            "name": "2009–2013",
+            "start_date": "2009",
+            "slug": "2009",
+            "csv": "data/Falkland_Islands/Assembly/term-2009.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67c3ef0/data/Falkland_Islands/Assembly/term-2009.csv"
+          },
+          {
+            "end_date": "2009",
+            "id": "term/2005",
+            "name": "2005–2009",
+            "start_date": "2005",
+            "slug": "2005",
+            "csv": "data/Falkland_Islands/Assembly/term-2005.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67c3ef0/data/Falkland_Islands/Assembly/term-2005.csv"
+          },
+          {
+            "end_date": "2005",
+            "id": "term/2001",
+            "name": "2001–2005",
+            "start_date": "2001",
+            "slug": "2001",
+            "csv": "data/Falkland_Islands/Assembly/term-2001.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67c3ef0/data/Falkland_Islands/Assembly/term-2001.csv"
+          },
+          {
+            "end_date": "2001",
+            "id": "term/1997",
+            "name": "1997–2001",
+            "start_date": "1997",
+            "slug": "1997",
+            "csv": "data/Falkland_Islands/Assembly/term-1997.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67c3ef0/data/Falkland_Islands/Assembly/term-1997.csv"
+          },
+          {
+            "end_date": "1997",
+            "id": "term/1993",
+            "name": "1993–1997",
+            "start_date": "1993",
+            "slug": "1993",
+            "csv": "data/Falkland_Islands/Assembly/term-1993.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67c3ef0/data/Falkland_Islands/Assembly/term-1993.csv"
+          },
+          {
+            "end_date": "1993",
+            "id": "term/1989",
+            "name": "1989–1993",
+            "start_date": "1989",
+            "slug": "1989",
+            "csv": "data/Falkland_Islands/Assembly/term-1989.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67c3ef0/data/Falkland_Islands/Assembly/term-1989.csv"
+          },
+          {
+            "end_date": "1989",
+            "id": "term/1985",
+            "name": "1985–1989",
+            "start_date": "1985",
+            "slug": "1985",
+            "csv": "data/Falkland_Islands/Assembly/term-1985.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67c3ef0/data/Falkland_Islands/Assembly/term-1985.csv"
+          },
+          {
+            "end_date": "1985",
+            "id": "term/1981",
+            "name": "1981–1985",
+            "start_date": "1981",
+            "slug": "1981",
+            "csv": "data/Falkland_Islands/Assembly/term-1981.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67c3ef0/data/Falkland_Islands/Assembly/term-1981.csv"
+          },
+          {
+            "end_date": "1981",
+            "id": "term/1977",
+            "name": "1977–1981",
+            "start_date": "1977",
+            "slug": "1977",
+            "csv": "data/Falkland_Islands/Assembly/term-1977.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67c3ef0/data/Falkland_Islands/Assembly/term-1977.csv"
+          }
+        ],
+        "statement_count": 2061
+      }
+    ]
+  },
+  {
+    "name": "Faroe Islands",
+    "country": "Faroe Islands",
+    "code": "FO",
+    "slug": "Faroe-Islands",
+    "legislatures": [
+      {
+        "name": "Løgting",
+        "slug": "Logting",
+        "sources_directory": "data/Faroe_Islands/Logting/sources",
+        "popolo": "data/Faroe_Islands/Logting/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/483f6ad/data/Faroe_Islands/Logting/ep-popolo-v1.0.json",
+        "names": "data/Faroe_Islands/Logting/names.csv",
+        "lastmod": "1467691649",
+        "person_count": 104,
+        "sha": "483f6ad",
+        "legislative_periods": [
+          {
+            "id": "term/2015",
+            "name": "Løgting 2015–",
+            "start_date": "2015-09-01",
+            "slug": "2015",
+            "csv": "data/Faroe_Islands/Logting/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/483f6ad/data/Faroe_Islands/Logting/term-2015.csv"
+          },
+          {
+            "end_date": "2015-09-01",
+            "id": "term/2011",
+            "name": "Løgting 2011–2015",
+            "start_date": "2011-10-29",
+            "slug": "2011",
+            "csv": "data/Faroe_Islands/Logting/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/483f6ad/data/Faroe_Islands/Logting/term-2011.csv"
+          },
+          {
+            "end_date": "2011-10-29",
+            "id": "term/2008",
+            "name": "Løgting 2008–2011",
+            "start_date": "2008-01-19",
+            "slug": "2008",
+            "csv": "data/Faroe_Islands/Logting/term-2008.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/483f6ad/data/Faroe_Islands/Logting/term-2008.csv"
+          },
+          {
+            "end_date": "2008-01-19",
+            "id": "term/2004",
+            "name": "Løgting 2004–2008",
+            "start_date": "2004",
+            "slug": "2004",
+            "csv": "data/Faroe_Islands/Logting/term-2004.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/483f6ad/data/Faroe_Islands/Logting/term-2004.csv"
+          },
+          {
+            "end_date": "2004",
+            "id": "term/2002",
+            "name": "Løgting 2002–2004",
+            "start_date": "2002",
+            "slug": "2002",
+            "csv": "data/Faroe_Islands/Logting/term-2002.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/483f6ad/data/Faroe_Islands/Logting/term-2002.csv"
+          },
+          {
+            "end_date": "2002",
+            "id": "term/1998",
+            "name": "Løgting 1998–2002",
+            "start_date": "1998",
+            "slug": "1998",
+            "csv": "data/Faroe_Islands/Logting/term-1998.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/483f6ad/data/Faroe_Islands/Logting/term-1998.csv"
+          },
+          {
+            "end_date": "1998",
+            "id": "term/1994",
+            "name": "Løgting 1994–1998",
+            "start_date": "1994",
+            "slug": "1994",
+            "csv": "data/Faroe_Islands/Logting/term-1994.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/483f6ad/data/Faroe_Islands/Logting/term-1994.csv"
+          },
+          {
+            "end_date": "1994",
+            "id": "term/1990",
+            "name": "Løgting 1990–1994",
+            "start_date": "1990",
+            "slug": "1990",
+            "csv": "data/Faroe_Islands/Logting/term-1990.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/483f6ad/data/Faroe_Islands/Logting/term-1990.csv"
+          }
+        ],
+        "statement_count": 7235
+      }
+    ]
+  },
+  {
+    "name": "Fiji",
+    "country": "Fiji",
+    "code": "FJ",
+    "slug": "Fiji",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Fiji/Parliament/sources",
+        "popolo": "data/Fiji/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca896cb/data/Fiji/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Fiji/Parliament/names.csv",
+        "lastmod": "1467083003",
+        "person_count": 54,
+        "sha": "ca896cb",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "2014",
+            "start_date": "2014-10-06",
+            "slug": "2014",
+            "csv": "data/Fiji/Parliament/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca896cb/data/Fiji/Parliament/term-2014.csv"
+          }
+        ],
+        "statement_count": 897
+      }
+    ]
+  },
+  {
+    "name": "Finland",
+    "country": "Finland",
+    "code": "FI",
+    "slug": "Finland",
+    "legislatures": [
+      {
+        "name": "Eduskunta",
+        "slug": "Eduskunta",
+        "sources_directory": "data/Finland/Eduskunta/sources",
+        "popolo": "data/Finland/Eduskunta/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/ep-popolo-v1.0.json",
+        "names": "data/Finland/Eduskunta/names.csv",
+        "lastmod": "1467761043",
+        "person_count": 492,
+        "sha": "ba4fa22",
+        "legislative_periods": [
+          {
+            "end_date": "2019",
+            "id": "term/37",
+            "name": "Eduskunta 37",
+            "start_date": "2015-04-28",
+            "slug": "37",
+            "csv": "data/Finland/Eduskunta/term-37.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/term-37.csv"
+          },
+          {
+            "end_date": "2015-03-14",
+            "id": "term/36",
+            "name": "Eduskunta 36",
+            "start_date": "2011-04-20",
+            "slug": "36",
+            "csv": "data/Finland/Eduskunta/term-36.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/term-36.csv"
+          },
+          {
+            "end_date": "2011-04-19",
+            "id": "term/35",
+            "name": "Eduskunta 35",
+            "start_date": "2007-03-21",
+            "slug": "35",
+            "csv": "data/Finland/Eduskunta/term-35.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/term-35.csv"
+          },
+          {
+            "end_date": "2007-03-20",
+            "id": "term/34",
+            "name": "Eduskunta 34",
+            "start_date": "2003-03-19",
+            "slug": "34",
+            "csv": "data/Finland/Eduskunta/term-34.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/term-34.csv"
+          },
+          {
+            "end_date": "2003-03-18",
+            "id": "term/33",
+            "name": "Eduskunta 33",
+            "start_date": "1999-03-24",
+            "slug": "33",
+            "csv": "data/Finland/Eduskunta/term-33.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/term-33.csv"
+          },
+          {
+            "end_date": "1999-03-23",
+            "id": "term/32",
+            "name": "Eduskunta 32",
+            "start_date": "1995-03-24",
+            "slug": "32",
+            "csv": "data/Finland/Eduskunta/term-32.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/term-32.csv"
+          },
+          {
+            "end_date": "1995-03-23",
+            "id": "term/31",
+            "name": "Eduskunta 31",
+            "start_date": "1991-03-22",
+            "slug": "31",
+            "csv": "data/Finland/Eduskunta/term-31.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/term-31.csv"
+          },
+          {
+            "end_date": "1991-03-21",
+            "id": "term/30",
+            "name": "Eduskunta 30",
+            "start_date": "1987-03-21",
+            "slug": "30",
+            "csv": "data/Finland/Eduskunta/term-30.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/term-30.csv"
+          },
+          {
+            "end_date": "1987-03-20",
+            "id": "term/29",
+            "name": "Eduskunta 29",
+            "start_date": "1983-03-26",
+            "slug": "29",
+            "csv": "data/Finland/Eduskunta/term-29.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/term-29.csv"
+          },
+          {
+            "end_date": "1983-03-25",
+            "id": "term/28",
+            "name": "Eduskunta 28",
+            "start_date": "1979-03-24",
+            "slug": "28",
+            "csv": "data/Finland/Eduskunta/term-28.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/term-28.csv"
+          },
+          {
+            "end_date": "1979-03-23",
+            "id": "term/27",
+            "name": "Eduskunta 27",
+            "start_date": "1975-09-27",
+            "slug": "27",
+            "csv": "data/Finland/Eduskunta/term-27.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/term-27.csv"
+          },
+          {
+            "end_date": "1975-09-26",
+            "id": "term/26",
+            "name": "Eduskunta 26",
+            "start_date": "1972-01-22",
+            "slug": "26",
+            "csv": "data/Finland/Eduskunta/term-26.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/term-26.csv"
+          },
+          {
+            "end_date": "1972-01-21",
+            "id": "term/25",
+            "name": "Eduskunta 25",
+            "start_date": "1970-03-23",
+            "slug": "25",
+            "csv": "data/Finland/Eduskunta/term-25.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba4fa22/data/Finland/Eduskunta/term-25.csv"
+          }
+        ],
+        "statement_count": 37311
+      }
+    ]
+  },
+  {
+    "name": "France",
+    "country": "France",
+    "code": "FR",
+    "slug": "France",
+    "legislatures": [
+      {
+        "name": "Assemblée nationale",
+        "slug": "National-Assembly",
+        "sources_directory": "data/France/National_Assembly/sources",
+        "popolo": "data/France/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ae7696f/data/France/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/France/National_Assembly/names.csv",
+        "lastmod": "1467962276",
+        "person_count": 1053,
+        "sha": "ae7696f",
+        "legislative_periods": [
+          {
+            "id": "term/14",
+            "name": "XIVe législature de la Ve République",
+            "start_date": "2012-06-20",
+            "wikidata": "Q3570385",
+            "slug": "14",
+            "csv": "data/France/National_Assembly/term-14.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ae7696f/data/France/National_Assembly/term-14.csv"
+          },
+          {
+            "end_date": "2012-06-19",
+            "id": "term/13",
+            "name": "XIIIe législature de la Ve République",
+            "start_date": "2007-06-20",
+            "wikidata": "Q3025921",
+            "slug": "13",
+            "csv": "data/France/National_Assembly/term-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ae7696f/data/France/National_Assembly/term-13.csv"
+          },
+          {
+            "end_date": "2007-06-19",
+            "id": "term/12",
+            "name": "XIIe législature de la Ve République",
+            "start_date": "2002-06-19",
+            "wikidata": "Q3570376",
+            "slug": "12",
+            "csv": "data/France/National_Assembly/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ae7696f/data/France/National_Assembly/term-12.csv"
+          }
+        ],
+        "statement_count": 89453
+      }
+    ]
+  },
+  {
+    "name": "French Polynesia",
+    "country": "French Polynesia",
+    "code": "PF",
+    "slug": "French-Polynesia",
+    "legislatures": [
+      {
+        "name": "Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/French_Polynesia/Assembly/sources",
+        "popolo": "data/French_Polynesia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a476fd3/data/French_Polynesia/Assembly/ep-popolo-v1.0.json",
+        "names": "data/French_Polynesia/Assembly/names.csv",
+        "lastmod": "1467881203",
+        "person_count": 59,
+        "sha": "a476fd3",
+        "legislative_periods": [
+          {
+            "id": "term/2013",
+            "name": "2013–",
+            "start_date": "2013-05-17",
+            "slug": "2013",
+            "csv": "data/French_Polynesia/Assembly/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a476fd3/data/French_Polynesia/Assembly/term-2013.csv"
+          }
+        ],
+        "statement_count": 1661
+      }
+    ]
+  },
+  {
+    "name": "Gabon",
+    "country": "Gabon",
+    "code": "GA",
+    "slug": "Gabon",
+    "legislatures": [
+      {
+        "name": "Assemblée nationale",
+        "slug": "Assembly",
+        "sources_directory": "data/Gabon/Assembly/sources",
+        "popolo": "data/Gabon/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e4672cc/data/Gabon/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Gabon/Assembly/names.csv",
+        "lastmod": "1466311812",
+        "person_count": 114,
+        "sha": "e4672cc",
+        "legislative_periods": [
+          {
+            "id": "term/12",
+            "name": "12 Législature",
+            "start_date": "2012-02-27",
+            "slug": "12",
+            "csv": "data/Gabon/Assembly/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e4672cc/data/Gabon/Assembly/term-12.csv"
+          }
+        ],
+        "statement_count": 1735
+      }
+    ]
+  },
+  {
+    "name": "Gambia",
+    "country": "Gambia",
+    "code": "GM",
+    "slug": "Gambia",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "National-Assembly",
+        "sources_directory": "data/Gambia/National_Assembly/sources",
+        "popolo": "data/Gambia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c2212b4/data/Gambia/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Gambia/National_Assembly/names.csv",
+        "lastmod": "1465845249",
+        "person_count": 53,
+        "sha": "c2212b4",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012–",
+            "start_date": "2012-04-20",
+            "slug": "2012",
+            "csv": "data/Gambia/National_Assembly/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c2212b4/data/Gambia/National_Assembly/term-2012.csv"
+          }
+        ],
+        "statement_count": 1296
+      }
+    ]
+  },
+  {
+    "name": "Georgia",
+    "country": "Georgia",
+    "code": "GE",
+    "slug": "Georgia",
+    "legislatures": [
+      {
+        "name": "Parliament of Georgia",
+        "slug": "Parliament",
+        "sources_directory": "data/Georgia/Parliament/sources",
+        "popolo": "data/Georgia/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e5fa28/data/Georgia/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Georgia/Parliament/names.csv",
+        "lastmod": "1467301249",
+        "person_count": 148,
+        "sha": "1e5fa28",
+        "legislative_periods": [
+          {
+            "end_date": "2016-10-01",
+            "id": "term/8",
+            "name": "8th Convocation",
+            "start_date": "2012-10-20",
+            "slug": "8",
+            "csv": "data/Georgia/Parliament/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e5fa28/data/Georgia/Parliament/term-8.csv"
+          }
+        ],
+        "statement_count": 4314
+      }
+    ]
+  },
+  {
+    "name": "Germany",
+    "country": "Germany",
+    "code": "DE",
+    "slug": "Germany",
+    "legislatures": [
+      {
+        "name": "Bundestag",
+        "slug": "Bundestag",
+        "sources_directory": "data/Germany/Bundestag/sources",
+        "popolo": "data/Germany/Bundestag/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/ep-popolo-v1.0.json",
+        "names": "data/Germany/Bundestag/names.csv",
+        "lastmod": "1467707136",
+        "person_count": 3813,
+        "sha": "d3c7ef1",
+        "legislative_periods": [
+          {
+            "id": "term/18",
+            "name": "18th Bundestag",
+            "start_date": "2013-10-22",
+            "wikidata": "Q15081430",
+            "slug": "18",
+            "csv": "data/Germany/Bundestag/term-18.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-18.csv"
+          },
+          {
+            "end_date": "2013-10-22",
+            "id": "term/17",
+            "name": "17th Bundestag",
+            "start_date": "2009-10-27",
+            "wikidata": "Q15081429",
+            "slug": "17",
+            "csv": "data/Germany/Bundestag/term-17.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-17.csv"
+          },
+          {
+            "end_date": "2009-10-27",
+            "id": "term/16",
+            "name": "16th Bundestag",
+            "start_date": "2005-10-18",
+            "wikidata": "Q15081428",
+            "slug": "16",
+            "csv": "data/Germany/Bundestag/term-16.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-16.csv"
+          },
+          {
+            "end_date": "2005-10-18",
+            "id": "term/15",
+            "name": "15th Bundestag",
+            "start_date": "2002-10-17",
+            "wikidata": "Q15081427",
+            "slug": "15",
+            "csv": "data/Germany/Bundestag/term-15.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-15.csv"
+          },
+          {
+            "end_date": "2002-10-17",
+            "id": "term/14",
+            "name": "14th Bundestag",
+            "start_date": "1998-10-26",
+            "wikidata": "Q15081426",
+            "slug": "14",
+            "csv": "data/Germany/Bundestag/term-14.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-14.csv"
+          },
+          {
+            "end_date": "1998-10-26",
+            "id": "term/13",
+            "name": "13th Bundestag",
+            "start_date": "1994-11-10",
+            "wikidata": "Q15081424",
+            "slug": "13",
+            "csv": "data/Germany/Bundestag/term-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-13.csv"
+          },
+          {
+            "end_date": "1994-11-10",
+            "id": "term/12",
+            "name": "12th Bundestag",
+            "start_date": "1990-12-20",
+            "wikidata": "Q15081421",
+            "slug": "12",
+            "csv": "data/Germany/Bundestag/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-12.csv"
+          },
+          {
+            "end_date": "1990-12-20",
+            "id": "term/11",
+            "name": "11th Bundestag",
+            "start_date": "1987-02-18",
+            "wikidata": "Q15741572",
+            "slug": "11",
+            "csv": "data/Germany/Bundestag/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-11.csv"
+          },
+          {
+            "end_date": "1987-02-18",
+            "id": "term/10",
+            "name": "10th Bundestag",
+            "start_date": "1983-03-29",
+            "wikidata": "Q15741566",
+            "slug": "10",
+            "csv": "data/Germany/Bundestag/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-10.csv"
+          },
+          {
+            "end_date": "1983-03-29",
+            "id": "term/9",
+            "name": "9th Bundestag",
+            "start_date": "1980-11-04",
+            "wikidata": "Q15781093",
+            "slug": "9",
+            "csv": "data/Germany/Bundestag/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-9.csv"
+          },
+          {
+            "end_date": "1980-11-04",
+            "id": "term/8",
+            "name": "8th Bundestag",
+            "start_date": "1976-12-14",
+            "wikidata": "Q15781086",
+            "slug": "8",
+            "csv": "data/Germany/Bundestag/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-8.csv"
+          },
+          {
+            "end_date": "1976-12-14",
+            "id": "term/7",
+            "name": "7th Bundestag",
+            "start_date": "1972-12-13",
+            "wikidata": "Q15781078",
+            "slug": "7",
+            "csv": "data/Germany/Bundestag/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-7.csv"
+          },
+          {
+            "end_date": "1972-12-13",
+            "id": "term/6",
+            "name": "6th Bundestag",
+            "start_date": "1969-10-20",
+            "wikidata": "Q15644627",
+            "slug": "6",
+            "csv": "data/Germany/Bundestag/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-6.csv"
+          },
+          {
+            "end_date": "1969-10-20",
+            "id": "term/5",
+            "name": "5th Bundestag",
+            "start_date": "1965-10-19",
+            "wikidata": "Q15781067",
+            "slug": "5",
+            "csv": "data/Germany/Bundestag/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-5.csv"
+          },
+          {
+            "end_date": "1965-10-19",
+            "id": "term/4",
+            "name": "4th Bundestag",
+            "start_date": "1961-10-17",
+            "wikidata": "Q15781058",
+            "slug": "4",
+            "csv": "data/Germany/Bundestag/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-4.csv"
+          },
+          {
+            "end_date": "1961-10-17",
+            "id": "term/3",
+            "name": "3rd Bundestag",
+            "start_date": "1957-10-15",
+            "wikidata": "Q15781041",
+            "slug": "3",
+            "csv": "data/Germany/Bundestag/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-3.csv"
+          },
+          {
+            "end_date": "1957-10-15",
+            "id": "term/2",
+            "name": "2nd Bundestag",
+            "start_date": "1953-10-06",
+            "wikidata": "Q7443318",
+            "slug": "2",
+            "csv": "data/Germany/Bundestag/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-2.csv"
+          },
+          {
+            "end_date": "1953-10-06",
+            "id": "term/1",
+            "name": "1st Bundestag",
+            "start_date": "1949-09-07",
+            "wikidata": "Q5453045",
+            "slug": "1",
+            "csv": "data/Germany/Bundestag/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c7ef1/data/Germany/Bundestag/term-1.csv"
+          }
+        ],
+        "statement_count": 291175
+      }
+    ]
+  },
+  {
+    "name": "Ghana",
+    "country": "Ghana",
+    "code": "GH",
+    "slug": "Ghana",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Ghana/Parliament/sources",
+        "popolo": "data/Ghana/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d8fe2f4/data/Ghana/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Ghana/Parliament/names.csv",
+        "lastmod": "1466376384",
+        "person_count": 272,
+        "sha": "d8fe2f4",
+        "legislative_periods": [
+          {
+            "id": "term/6",
+            "name": "Sixth Parliament of the Fourth Republic",
+            "start_date": "2013-01-07",
+            "slug": "6",
+            "csv": "data/Ghana/Parliament/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d8fe2f4/data/Ghana/Parliament/term-6.csv"
+          }
+        ],
+        "statement_count": 5422
+      }
+    ]
+  },
+  {
+    "name": "Gibraltar",
+    "country": "Gibraltar",
+    "code": "GI",
+    "slug": "Gibraltar",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Gibraltar/Parliament/sources",
+        "popolo": "data/Gibraltar/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Gibraltar/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Gibraltar/Parliament/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 83,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "end_date": "2015-10-20",
+            "id": "term/12",
+            "name": "Twelfth Gibraltar Parliament",
+            "start_date": "2011-12-21",
+            "slug": "12",
+            "csv": "data/Gibraltar/Parliament/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Gibraltar/Parliament/term-12.csv"
+          },
+          {
+            "end_date": "2011-11-03",
+            "id": "term/11",
+            "name": "Eleventh Gibraltar Parliament",
+            "start_date": "2007-11-08",
+            "slug": "11",
+            "csv": "data/Gibraltar/Parliament/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Gibraltar/Parliament/term-11.csv"
+          },
+          {
+            "end_date": "2007-09-07",
+            "id": "term/10",
+            "name": "Tenth House of Assembly",
+            "start_date": "2003-12-18",
+            "slug": "10",
+            "csv": "data/Gibraltar/Parliament/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Gibraltar/Parliament/term-10.csv"
+          },
+          {
+            "end_date": "2003-10-24",
+            "id": "term/9",
+            "name": "Ninth House of Assembly",
+            "start_date": "2000-02-23",
+            "slug": "9",
+            "csv": "data/Gibraltar/Parliament/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Gibraltar/Parliament/term-9.csv"
+          },
+          {
+            "end_date": "2000",
+            "id": "term/8",
+            "name": "Eighth House of Assembly",
+            "start_date": "1996",
+            "slug": "8",
+            "csv": "data/Gibraltar/Parliament/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Gibraltar/Parliament/term-8.csv"
+          },
+          {
+            "end_date": "1996",
+            "id": "term/7",
+            "name": "Seventh House of Assembly",
+            "start_date": "1992",
+            "slug": "7",
+            "csv": "data/Gibraltar/Parliament/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Gibraltar/Parliament/term-7.csv"
+          },
+          {
+            "end_date": "1992",
+            "id": "term/6",
+            "name": "Sixth House of Assembly",
+            "start_date": "1988",
+            "slug": "6",
+            "csv": "data/Gibraltar/Parliament/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Gibraltar/Parliament/term-6.csv"
+          },
+          {
+            "end_date": "1988",
+            "id": "term/5",
+            "name": "Fifth House of Assembly",
+            "start_date": "1984",
+            "slug": "5",
+            "csv": "data/Gibraltar/Parliament/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Gibraltar/Parliament/term-5.csv"
+          },
+          {
+            "end_date": "1984",
+            "id": "term/4",
+            "name": "Fourth House of Assembly",
+            "start_date": "1980",
+            "slug": "4",
+            "csv": "data/Gibraltar/Parliament/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Gibraltar/Parliament/term-4.csv"
+          },
+          {
+            "end_date": "1980",
+            "id": "term/3",
+            "name": "Third House of Assembly",
+            "start_date": "1976",
+            "slug": "3",
+            "csv": "data/Gibraltar/Parliament/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Gibraltar/Parliament/term-3.csv"
+          },
+          {
+            "end_date": "1976",
+            "id": "term/2",
+            "name": "Second House of Assembly",
+            "start_date": "1972",
+            "slug": "2",
+            "csv": "data/Gibraltar/Parliament/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Gibraltar/Parliament/term-2.csv"
+          },
+          {
+            "end_date": "1972",
+            "id": "term/1",
+            "name": "First House of Assembly",
+            "start_date": "1969",
+            "slug": "1",
+            "csv": "data/Gibraltar/Parliament/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Gibraltar/Parliament/term-1.csv"
+          }
+        ],
+        "statement_count": 2938
+      }
+    ]
+  },
+  {
+    "name": "Greece",
+    "country": "Greece",
+    "code": "GR",
+    "slug": "Greece",
+    "legislatures": [
+      {
+        "name": "Hellenic Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Greece/Parliament/sources",
+        "popolo": "data/Greece/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Greece/Parliament/names.csv",
+        "lastmod": "1467954969",
+        "person_count": 1783,
+        "sha": "37d3163",
+        "legislative_periods": [
+          {
+            "id": "term/17",
+            "name": "17th Hellenic Parliament",
+            "start_date": "2015-09-20",
+            "slug": "17",
+            "csv": "data/Greece/Parliament/term-17.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-17.csv"
+          },
+          {
+            "end_date": "2015-08-28",
+            "id": "term/16",
+            "name": "16th Hellenic Parliament",
+            "start_date": "2015-01-25",
+            "slug": "16",
+            "csv": "data/Greece/Parliament/term-16.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-16.csv"
+          },
+          {
+            "end_date": "2014-12-31",
+            "id": "term/15",
+            "name": "15th Hellenic Parliament",
+            "start_date": "2012-06-17",
+            "slug": "15",
+            "csv": "data/Greece/Parliament/term-15.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-15.csv"
+          },
+          {
+            "end_date": "2012-05-19",
+            "id": "term/14",
+            "name": "14th Hellenic Parliament",
+            "start_date": "2012-05-06",
+            "slug": "14",
+            "csv": "data/Greece/Parliament/term-14.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-14.csv"
+          },
+          {
+            "end_date": "2012-04-11",
+            "id": "term/13",
+            "name": "13th Hellenic Parliament",
+            "start_date": "2009-10-04",
+            "slug": "13",
+            "csv": "data/Greece/Parliament/term-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-13.csv"
+          },
+          {
+            "end_date": "2009-09-07",
+            "id": "term/12",
+            "name": "12th Hellenic Parliament",
+            "start_date": "2007-09-16",
+            "slug": "12",
+            "csv": "data/Greece/Parliament/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-12.csv"
+          },
+          {
+            "end_date": "2007-08-18",
+            "id": "term/11",
+            "name": "11th Hellenic Parliament",
+            "start_date": "2004-03-07",
+            "slug": "11",
+            "csv": "data/Greece/Parliament/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-11.csv"
+          },
+          {
+            "end_date": "2004-02-11",
+            "id": "term/10",
+            "name": "10th Hellenic Parliament",
+            "start_date": "2000-04-09",
+            "slug": "10",
+            "csv": "data/Greece/Parliament/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-10.csv"
+          },
+          {
+            "end_date": "2000-03-14",
+            "id": "term/9",
+            "name": "9th Hellenic Parliament",
+            "start_date": "1996-09-22",
+            "slug": "9",
+            "csv": "data/Greece/Parliament/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-9.csv"
+          },
+          {
+            "end_date": "1996-08-24",
+            "id": "term/8",
+            "name": "8th Hellenic Parliament",
+            "start_date": "1993-10-10",
+            "slug": "8",
+            "csv": "data/Greece/Parliament/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-8.csv"
+          },
+          {
+            "end_date": "1993-09-11",
+            "id": "term/7",
+            "name": "7th Hellenic Parliament",
+            "start_date": "1990-04-08",
+            "slug": "7",
+            "csv": "data/Greece/Parliament/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-7.csv"
+          },
+          {
+            "end_date": "1990-03-12",
+            "id": "term/6",
+            "name": "6th Hellenic Parliament",
+            "start_date": "1989-11-05",
+            "slug": "6",
+            "csv": "data/Greece/Parliament/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-6.csv"
+          },
+          {
+            "end_date": "1989-10-12",
+            "id": "term/5",
+            "name": "5th Hellenic Parliament",
+            "start_date": "1989-06-18",
+            "slug": "5",
+            "csv": "data/Greece/Parliament/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-5.csv"
+          },
+          {
+            "end_date": "1989-06-02",
+            "id": "term/4",
+            "name": "4th Hellenic Parliament",
+            "start_date": "1985-06-02",
+            "slug": "4",
+            "csv": "data/Greece/Parliament/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-4.csv"
+          },
+          {
+            "end_date": "1985-05-07",
+            "id": "term/3",
+            "name": "3nd Hellenic Parliament",
+            "start_date": "1981-10-18",
+            "slug": "3",
+            "csv": "data/Greece/Parliament/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-3.csv"
+          },
+          {
+            "end_date": "1981-09-19",
+            "id": "term/2",
+            "name": "2nd Hellenic Parliament",
+            "start_date": "1977-11-20",
+            "slug": "2",
+            "csv": "data/Greece/Parliament/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-2.csv"
+          },
+          {
+            "end_date": "1977-10-22",
+            "id": "term/1",
+            "name": "1st Hellenic Parliament",
+            "start_date": "1974-11-17",
+            "slug": "1",
+            "csv": "data/Greece/Parliament/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37d3163/data/Greece/Parliament/term-1.csv"
+          }
+        ],
+        "statement_count": 62710
+      }
+    ]
+  },
+  {
+    "name": "Greenland",
+    "country": "Greenland",
+    "code": "GL",
+    "slug": "Greenland",
+    "legislatures": [
+      {
+        "name": "Inatsisartut",
+        "slug": "Inatsisartut",
+        "sources_directory": "data/Greenland/Inatsisartut/sources",
+        "popolo": "data/Greenland/Inatsisartut/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c23a66/data/Greenland/Inatsisartut/ep-popolo-v1.0.json",
+        "names": "data/Greenland/Inatsisartut/names.csv",
+        "lastmod": "1467359551",
+        "person_count": 149,
+        "sha": "1c23a66",
+        "legislative_periods": [
+          {
+            "id": "term/12",
+            "name": "Inatsisartut 12",
+            "start_date": "2014-11-28",
+            "slug": "12",
+            "csv": "data/Greenland/Inatsisartut/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c23a66/data/Greenland/Inatsisartut/term-12.csv"
+          },
+          {
+            "end_date": "2014-11-27",
+            "id": "term/11",
+            "name": "Inatsisartut 11",
+            "start_date": "2013-03-12",
+            "slug": "11",
+            "csv": "data/Greenland/Inatsisartut/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c23a66/data/Greenland/Inatsisartut/term-11.csv"
+          },
+          {
+            "end_date": "2013-03-11",
+            "id": "term/10",
+            "name": "Inatsisartut 10",
+            "start_date": "2009-06-02",
+            "slug": "10",
+            "csv": "data/Greenland/Inatsisartut/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c23a66/data/Greenland/Inatsisartut/term-10.csv"
+          },
+          {
+            "end_date": "2009-06-01",
+            "id": "term/9",
+            "name": "Landsting 9",
+            "start_date": "2005-11-15",
+            "slug": "9",
+            "csv": "data/Greenland/Inatsisartut/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c23a66/data/Greenland/Inatsisartut/term-9.csv"
+          },
+          {
+            "end_date": "2005-11-14",
+            "id": "term/8",
+            "name": "Landsting 8",
+            "start_date": "2002-12-03",
+            "slug": "8",
+            "csv": "data/Greenland/Inatsisartut/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c23a66/data/Greenland/Inatsisartut/term-8.csv"
+          },
+          {
+            "end_date": "2002-12-02",
+            "id": "term/7",
+            "name": "Landsting 7",
+            "start_date": "1999-02-16",
+            "slug": "7",
+            "csv": "data/Greenland/Inatsisartut/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c23a66/data/Greenland/Inatsisartut/term-7.csv"
+          },
+          {
+            "end_date": "1999-02-15",
+            "id": "term/6",
+            "name": "Landsting 6",
+            "start_date": "1995-03-04",
+            "slug": "6",
+            "csv": "data/Greenland/Inatsisartut/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c23a66/data/Greenland/Inatsisartut/term-6.csv"
+          },
+          {
+            "end_date": "1995-03-03",
+            "id": "term/5",
+            "name": "Landsting 5",
+            "start_date": "1991-03-05",
+            "slug": "5",
+            "csv": "data/Greenland/Inatsisartut/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c23a66/data/Greenland/Inatsisartut/term-5.csv"
+          },
+          {
+            "end_date": "1991-03-04",
+            "id": "term/4",
+            "name": "Landsting 4",
+            "start_date": "1987-05-26",
+            "slug": "4",
+            "csv": "data/Greenland/Inatsisartut/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c23a66/data/Greenland/Inatsisartut/term-4.csv"
+          },
+          {
+            "end_date": "1987-05-25",
+            "id": "term/3",
+            "name": "Landsting 3",
+            "start_date": "1984-06-06",
+            "slug": "3",
+            "csv": "data/Greenland/Inatsisartut/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c23a66/data/Greenland/Inatsisartut/term-3.csv"
+          },
+          {
+            "end_date": "1984-06-05",
+            "id": "term/2",
+            "name": "Landsting 2",
+            "start_date": "1983-04-12",
+            "slug": "2",
+            "csv": "data/Greenland/Inatsisartut/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c23a66/data/Greenland/Inatsisartut/term-2.csv"
+          },
+          {
+            "end_date": "1983-04-11",
+            "id": "term/1",
+            "name": "Landsting 1",
+            "start_date": "1979-04-04",
+            "slug": "1",
+            "csv": "data/Greenland/Inatsisartut/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c23a66/data/Greenland/Inatsisartut/term-1.csv"
+          }
+        ],
+        "statement_count": 5350
+      }
+    ]
+  },
+  {
+    "name": "Grenada",
+    "country": "Grenada",
+    "code": "GD",
+    "slug": "Grenada",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House-of-Representatives",
+        "sources_directory": "data/Grenada/House_of_Representatives/sources",
+        "popolo": "data/Grenada/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fee7b46/data/Grenada/House_of_Representatives/ep-popolo-v1.0.json",
+        "names": "data/Grenada/House_of_Representatives/names.csv",
+        "lastmod": "1467882723",
+        "person_count": 15,
+        "sha": "fee7b46",
+        "legislative_periods": [
+          {
+            "id": "term/2013",
+            "name": "2013",
+            "start_date": "2013-03-27",
+            "slug": "2013",
+            "csv": "data/Grenada/House_of_Representatives/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fee7b46/data/Grenada/House_of_Representatives/term-2013.csv"
+          }
+        ],
+        "statement_count": 389
+      }
+    ]
+  },
+  {
+    "name": "Guam",
+    "country": "Guam",
+    "code": "GU",
+    "slug": "Guam",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Guam/Parliament/sources",
+        "popolo": "data/Guam/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/116ec86/data/Guam/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Guam/Parliament/names.csv",
+        "lastmod": "1467821571",
+        "person_count": 28,
+        "sha": "116ec86",
+        "legislative_periods": [
+          {
+            "id": "term/33",
+            "name": "33rd Guam Legislature",
+            "start_date": "2015-02-16",
+            "slug": "33",
+            "csv": "data/Guam/Parliament/term-33.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/116ec86/data/Guam/Parliament/term-33.csv"
+          },
+          {
+            "end_date": "2015-01-02",
+            "id": "term/32",
+            "name": "32nd Guam Legislature",
+            "start_date": "2013-01-11",
+            "slug": "32",
+            "csv": "data/Guam/Parliament/term-32.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/116ec86/data/Guam/Parliament/term-32.csv"
+          },
+          {
+            "end_date": "2013-01-04",
+            "id": "term/31",
+            "name": "31st Guam Legislature",
+            "start_date": "2011-02-21",
+            "slug": "31",
+            "csv": "data/Guam/Parliament/term-31.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/116ec86/data/Guam/Parliament/term-31.csv"
+          },
+          {
+            "end_date": "2010-12-22",
+            "id": "term/30",
+            "name": "30th Guam Legislature",
+            "start_date": "2009-02-16",
+            "slug": "30",
+            "csv": "data/Guam/Parliament/term-30.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/116ec86/data/Guam/Parliament/term-30.csv"
+          }
+        ],
+        "statement_count": 1205
+      }
+    ]
+  },
+  {
+    "name": "Guatemala",
+    "country": "Guatemala",
+    "code": "GT",
+    "slug": "Guatemala",
+    "legislatures": [
+      {
+        "name": "Congress",
+        "slug": "Congress",
+        "sources_directory": "data/Guatemala/Congress/sources",
+        "popolo": "data/Guatemala/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65b167f/data/Guatemala/Congress/ep-popolo-v1.0.json",
+        "names": "data/Guatemala/Congress/names.csv",
+        "lastmod": "1466583212",
+        "person_count": 244,
+        "sha": "65b167f",
+        "legislative_periods": [
+          {
+            "end_date": "2020-01-14",
+            "id": "term/8",
+            "name": "VIII Legislatura",
+            "start_date": "2016-01-14",
+            "wikidata": "Q23051910",
+            "slug": "8",
+            "csv": "data/Guatemala/Congress/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65b167f/data/Guatemala/Congress/term-8.csv"
+          },
+          {
+            "end_date": "2016-01-14",
+            "id": "term/7",
+            "name": "VII Legislatura",
+            "start_date": "2012-01-14",
+            "wikidata": "Q16644987",
+            "slug": "7",
+            "csv": "data/Guatemala/Congress/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65b167f/data/Guatemala/Congress/term-7.csv"
+          }
+        ],
+        "statement_count": 5576
+      }
+    ]
+  },
+  {
+    "name": "Guernsey",
+    "country": "Guernsey",
+    "code": "GG",
+    "slug": "Guernsey",
+    "legislatures": [
+      {
+        "name": "States",
+        "slug": "States",
+        "sources_directory": "data/Guernsey/States/sources",
+        "popolo": "data/Guernsey/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d9b61aa/data/Guernsey/States/ep-popolo-v1.0.json",
+        "names": "data/Guernsey/States/names.csv",
+        "lastmod": "1467879898",
+        "person_count": 49,
+        "sha": "d9b61aa",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012–",
+            "start_date": "2012",
+            "slug": "2012",
+            "csv": "data/Guernsey/States/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d9b61aa/data/Guernsey/States/term-2012.csv"
+          }
+        ],
+        "statement_count": 1300
+      }
+    ]
+  },
+  {
+    "name": "Guinea-Bissau",
+    "country": "Guinea-Bissau",
+    "code": "GW",
+    "slug": "Guinea-Bissau",
+    "legislatures": [
+      {
+        "name": "National People's Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Guinea-Bissau/Assembly/sources",
+        "popolo": "data/Guinea-Bissau/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3a28845/data/Guinea-Bissau/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Guinea-Bissau/Assembly/names.csv",
+        "lastmod": "1465854365",
+        "person_count": 100,
+        "sha": "3a28845",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "2014-",
+            "start_date": "2014-06-16",
+            "slug": "2014",
+            "csv": "data/Guinea-Bissau/Assembly/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3a28845/data/Guinea-Bissau/Assembly/term-2014.csv"
+          }
+        ],
+        "statement_count": 1394
+      }
+    ]
+  },
+  {
+    "name": "Guyana",
+    "country": "Guyana",
+    "code": "GY",
+    "slug": "Guyana",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "National-Assembly",
+        "sources_directory": "data/Guyana/National_Assembly/sources",
+        "popolo": "data/Guyana/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a5a7b75/data/Guyana/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Guyana/National_Assembly/names.csv",
+        "lastmod": "1467741214",
+        "person_count": 55,
+        "sha": "a5a7b75",
+        "legislative_periods": [
+          {
+            "id": "term/11",
+            "name": "11th Parliament",
+            "start_date": "2015-06-10",
+            "slug": "11",
+            "csv": "data/Guyana/National_Assembly/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a5a7b75/data/Guyana/National_Assembly/term-11.csv"
+          }
+        ],
+        "statement_count": 925
+      }
+    ]
+  },
+  {
+    "name": "Haiti",
+    "country": "Haiti",
+    "code": "HT",
+    "slug": "Haiti",
+    "legislatures": [
+      {
+        "name": "Chamber of Deputies",
+        "slug": "Deputies",
+        "sources_directory": "data/Haiti/Deputies/sources",
+        "popolo": "data/Haiti/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fde07c/data/Haiti/Deputies/ep-popolo-v1.0.json",
+        "names": "data/Haiti/Deputies/names.csv",
+        "lastmod": "1467655793",
+        "person_count": 99,
+        "sha": "9fde07c",
+        "legislative_periods": [
+          {
+            "end_date": "2015-01-12",
+            "id": "term/2011",
+            "name": "2011-2015",
+            "start_date": "2011-05-14",
+            "slug": "2011",
+            "csv": "data/Haiti/Deputies/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fde07c/data/Haiti/Deputies/term-2011.csv"
+          }
+        ],
+        "statement_count": 1935
+      }
+    ]
+  },
+  {
+    "name": "Honduras",
+    "country": "Honduras",
+    "code": "HN",
+    "slug": "Honduras",
+    "legislatures": [
+      {
+        "name": "National Congress",
+        "slug": "Congreso-Nacional",
+        "sources_directory": "data/Honduras/Congreso_Nacional/sources",
+        "popolo": "data/Honduras/Congreso_Nacional/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3e06af3/data/Honduras/Congreso_Nacional/ep-popolo-v1.0.json",
+        "names": "data/Honduras/Congreso_Nacional/names.csv",
+        "lastmod": "1467816949",
+        "person_count": 129,
+        "sha": "3e06af3",
+        "legislative_periods": [
+          {
+            "end_date": "2018",
+            "id": "term/8",
+            "name": "VIII Legislatura",
+            "start_date": "2014-01-21",
+            "slug": "8",
+            "csv": "data/Honduras/Congreso_Nacional/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3e06af3/data/Honduras/Congreso_Nacional/term-8.csv"
+          }
+        ],
+        "statement_count": 2073
+      }
+    ]
+  },
+  {
+    "name": "Hong Kong",
+    "country": "Hong Kong",
+    "code": "HK",
+    "slug": "Hong-Kong",
+    "legislatures": [
+      {
+        "name": "Legislative Council",
+        "slug": "Legislative-Council",
+        "sources_directory": "data/Hong_Kong/Legislative_Council/sources",
+        "popolo": "data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a35bc37/data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
+        "names": "data/Hong_Kong/Legislative_Council/names.csv",
+        "lastmod": "1467650025",
+        "person_count": 71,
+        "sha": "a35bc37",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "Fifth Legislative Council",
+            "start_date": "2012-09-12",
+            "slug": "5",
+            "csv": "data/Hong_Kong/Legislative_Council/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a35bc37/data/Hong_Kong/Legislative_Council/term-5.csv"
+          }
+        ],
+        "statement_count": 5827
+      }
+    ]
+  },
+  {
+    "name": "Hungary",
+    "country": "Hungary",
+    "code": "HU",
+    "slug": "Hungary",
+    "legislatures": [
+      {
+        "name": "Országgyűlés",
+        "slug": "Assembly",
+        "sources_directory": "data/Hungary/Assembly/sources",
+        "popolo": "data/Hungary/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bcd88f3/data/Hungary/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Hungary/Assembly/names.csv",
+        "lastmod": "1467292788",
+        "person_count": 199,
+        "sha": "bcd88f3",
+        "legislative_periods": [
+          {
+            "id": "term/40",
+            "name": "2014–",
+            "start_date": "2014-05-10",
+            "slug": "40",
+            "csv": "data/Hungary/Assembly/term-40.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bcd88f3/data/Hungary/Assembly/term-40.csv"
+          }
+        ],
+        "statement_count": 9900
+      }
+    ]
+  },
+  {
+    "name": "Iceland",
+    "country": "Iceland",
+    "code": "IS",
+    "slug": "Iceland",
+    "legislatures": [
+      {
+        "name": "Alþingi",
+        "slug": "Assembly",
+        "sources_directory": "data/Iceland/Assembly/sources",
+        "popolo": "data/Iceland/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/765cbe5/data/Iceland/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Iceland/Assembly/names.csv",
+        "lastmod": "1467793706",
+        "person_count": 205,
+        "sha": "765cbe5",
+        "legislative_periods": [
+          {
+            "id": "term/2013",
+            "name": "Alþingi 2013",
+            "start_date": "2013-04-27",
+            "slug": "2013",
+            "csv": "data/Iceland/Assembly/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/765cbe5/data/Iceland/Assembly/term-2013.csv"
+          },
+          {
+            "end_date": "2013-04-27",
+            "id": "term/2009",
+            "name": "Alþingi 2009",
+            "start_date": "2009",
+            "slug": "2009",
+            "csv": "data/Iceland/Assembly/term-2009.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/765cbe5/data/Iceland/Assembly/term-2009.csv"
+          },
+          {
+            "end_date": "2009",
+            "id": "term/2007",
+            "name": "Alþingi 2007",
+            "start_date": "2007",
+            "slug": "2007",
+            "csv": "data/Iceland/Assembly/term-2007.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/765cbe5/data/Iceland/Assembly/term-2007.csv"
+          },
+          {
+            "end_date": "2007",
+            "id": "term/2003",
+            "name": "Alþingi 2003",
+            "start_date": "2003",
+            "slug": "2003",
+            "csv": "data/Iceland/Assembly/term-2003.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/765cbe5/data/Iceland/Assembly/term-2003.csv"
+          },
+          {
+            "end_date": "2003",
+            "id": "term/1999",
+            "name": "Alþingi 1999",
+            "start_date": "1999",
+            "slug": "1999",
+            "csv": "data/Iceland/Assembly/term-1999.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/765cbe5/data/Iceland/Assembly/term-1999.csv"
+          },
+          {
+            "end_date": "1999",
+            "id": "term/1995",
+            "name": "Alþingi 1995",
+            "start_date": "1995",
+            "slug": "1995",
+            "csv": "data/Iceland/Assembly/term-1995.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/765cbe5/data/Iceland/Assembly/term-1995.csv"
+          }
+        ],
+        "statement_count": 13274
+      }
+    ]
+  },
+  {
+    "name": "India",
+    "country": "India",
+    "code": "IN",
+    "slug": "India",
+    "legislatures": [
+      {
+        "name": "Lok Sabha",
+        "slug": "Lok-Sabha",
+        "sources_directory": "data/India/Lok_Sabha/sources",
+        "popolo": "data/India/Lok_Sabha/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90decc1/data/India/Lok_Sabha/ep-popolo-v1.0.json",
+        "names": "data/India/Lok_Sabha/names.csv",
+        "lastmod": "1467716607",
+        "person_count": 541,
+        "sha": "90decc1",
+        "legislative_periods": [
+          {
+            "id": "term/16",
+            "name": "XVI Lok Sabha",
+            "start_date": "2014-05-26",
+            "slug": "16",
+            "csv": "data/India/Lok_Sabha/term-16.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90decc1/data/India/Lok_Sabha/term-16.csv"
+          }
+        ],
+        "statement_count": 38491
+      }
+    ]
+  },
+  {
+    "name": "Indonesia",
+    "country": "Indonesia",
+    "code": "ID",
+    "slug": "Indonesia",
+    "legislatures": [
+      {
+        "name": "Dewan Perwakilan Rakyat",
+        "slug": "Council",
+        "sources_directory": "data/Indonesia/Council/sources",
+        "popolo": "data/Indonesia/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bfe501a/data/Indonesia/Council/ep-popolo-v1.0.json",
+        "names": "data/Indonesia/Council/names.csv",
+        "lastmod": "1467438452",
+        "person_count": 574,
+        "sha": "bfe501a",
+        "legislative_periods": [
+          {
+            "id": "term/18",
+            "name": "The Indonesian House - 11th General Election",
+            "start_date": "2014-10-01",
+            "slug": "18",
+            "csv": "data/Indonesia/Council/term-18.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bfe501a/data/Indonesia/Council/term-18.csv"
+          }
+        ],
+        "statement_count": 12398
+      }
+    ]
+  },
+  {
+    "name": "Iran",
+    "country": "Iran",
+    "code": "IR",
+    "slug": "Iran",
+    "legislatures": [
+      {
+        "name": "Majles",
+        "slug": "Assembly",
+        "sources_directory": "data/Iran/Assembly/sources",
+        "popolo": "data/Iran/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66a6127/data/Iran/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Iran/Assembly/names.csv",
+        "lastmod": "1467841665",
+        "person_count": 289,
+        "sha": "66a6127",
+        "legislative_periods": [
+          {
+            "id": "term/9",
+            "name": "9th Assembly",
+            "start_date": "2012-05-27",
+            "slug": "9",
+            "csv": "data/Iran/Assembly/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66a6127/data/Iran/Assembly/term-9.csv"
+          }
+        ],
+        "statement_count": 4771
+      }
+    ]
+  },
+  {
+    "name": "Iraq",
+    "country": "Iraq",
+    "code": "IQ",
+    "slug": "Iraq",
+    "legislatures": [
+      {
+        "name": "Council of Representatives",
+        "slug": "Majlis",
+        "sources_directory": "data/Iraq/Majlis/sources",
+        "popolo": "data/Iraq/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Iraq/Majlis/ep-popolo-v1.0.json",
+        "names": "data/Iraq/Majlis/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 328,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "2nd Council",
+            "start_date": "2014-07-01",
+            "slug": "2014",
+            "csv": "data/Iraq/Majlis/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Iraq/Majlis/term-2014.csv"
+          }
+        ],
+        "statement_count": 4101
+      }
+    ]
+  },
+  {
+    "name": "Ireland",
+    "country": "Ireland",
+    "code": "IE",
+    "slug": "Ireland",
+    "legislatures": [
+      {
+        "name": "Dáil Éireann",
+        "slug": "Dail",
+        "sources_directory": "data/Ireland/Dail/sources",
+        "popolo": "data/Ireland/Dail/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f546f22/data/Ireland/Dail/ep-popolo-v1.0.json",
+        "names": "data/Ireland/Dail/names.csv",
+        "lastmod": "1467822281",
+        "person_count": 226,
+        "sha": "f546f22",
+        "legislative_periods": [
+          {
+            "id": "term/32",
+            "name": "32nd Dáil",
+            "start_date": "2016-03-10",
+            "slug": "32",
+            "csv": "data/Ireland/Dail/term-32.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f546f22/data/Ireland/Dail/term-32.csv"
+          },
+          {
+            "end_date": "2016-03-02",
+            "id": "term/31",
+            "name": "31st Dáil",
+            "start_date": "2011-03-09",
+            "slug": "31",
+            "csv": "data/Ireland/Dail/term-31.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f546f22/data/Ireland/Dail/term-31.csv"
+          }
+        ],
+        "statement_count": 13165
+      }
+    ]
+  },
+  {
+    "name": "Isle of Man",
+    "country": "Isle of Man",
+    "code": "IM",
+    "slug": "Isle-of-Man",
+    "legislatures": [
+      {
+        "name": "House of Keys",
+        "slug": "House-of-Keys",
+        "sources_directory": "data/Isle_of_Man/House_of_Keys/sources",
+        "popolo": "data/Isle_of_Man/House_of_Keys/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/306498c/data/Isle_of_Man/House_of_Keys/ep-popolo-v1.0.json",
+        "names": "data/Isle_of_Man/House_of_Keys/names.csv",
+        "lastmod": "1467868709",
+        "person_count": 29,
+        "sha": "306498c",
+        "legislative_periods": [
+          {
+            "id": "term/2011",
+            "name": "2011–",
+            "start_date": "2011-10-04",
+            "slug": "2011",
+            "csv": "data/Isle_of_Man/House_of_Keys/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/306498c/data/Isle_of_Man/House_of_Keys/term-2011.csv"
+          }
+        ],
+        "statement_count": 1452
+      }
+    ]
+  },
+  {
+    "name": "Israel",
+    "country": "Israel",
+    "code": "IL",
+    "slug": "Israel",
+    "legislatures": [
+      {
+        "name": "Knesset",
+        "slug": "Knesset",
+        "sources_directory": "data/Israel/Knesset/sources",
+        "popolo": "data/Israel/Knesset/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/ep-popolo-v1.0.json",
+        "names": "data/Israel/Knesset/names.csv",
+        "lastmod": "1467923793",
+        "person_count": 933,
+        "sha": "02fb7f2",
+        "legislative_periods": [
+          {
+            "end_date": "2016-06-01",
+            "id": "term/20",
+            "name": "Knesset 20",
+            "start_date": "2015-03-31",
+            "slug": "20",
+            "csv": "data/Israel/Knesset/term-20.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-20.csv"
+          },
+          {
+            "end_date": "2015-03-31",
+            "id": "term/19",
+            "name": "Knesset 19",
+            "start_date": "2013-02-05",
+            "slug": "19",
+            "csv": "data/Israel/Knesset/term-19.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-19.csv"
+          },
+          {
+            "end_date": "2013-02-05",
+            "id": "term/18",
+            "name": "Knesset 18",
+            "start_date": "2009-02-24",
+            "slug": "18",
+            "csv": "data/Israel/Knesset/term-18.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-18.csv"
+          },
+          {
+            "end_date": "2009-02-24",
+            "id": "term/17",
+            "name": "Knesset 17",
+            "start_date": "2006-04-17",
+            "slug": "17",
+            "csv": "data/Israel/Knesset/term-17.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-17.csv"
+          },
+          {
+            "end_date": "2006-04-17",
+            "id": "term/16",
+            "name": "Knesset 16",
+            "start_date": "2003-02-17",
+            "slug": "16",
+            "csv": "data/Israel/Knesset/term-16.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-16.csv"
+          },
+          {
+            "end_date": "2003-02-17",
+            "id": "term/15",
+            "name": "Knesset 15",
+            "start_date": "1999-06-07",
+            "slug": "15",
+            "csv": "data/Israel/Knesset/term-15.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-15.csv"
+          },
+          {
+            "end_date": "1999-06-07",
+            "id": "term/14",
+            "name": "Knesset 14",
+            "start_date": "1996-06-17",
+            "slug": "14",
+            "csv": "data/Israel/Knesset/term-14.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-14.csv"
+          },
+          {
+            "end_date": "1996-06-17",
+            "id": "term/13",
+            "name": "Knesset 13",
+            "start_date": "1992-07-13",
+            "slug": "13",
+            "csv": "data/Israel/Knesset/term-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-13.csv"
+          },
+          {
+            "end_date": "1992-07-13",
+            "id": "term/12",
+            "name": "Knesset 12",
+            "start_date": "1988-11-21",
+            "slug": "12",
+            "csv": "data/Israel/Knesset/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-12.csv"
+          },
+          {
+            "end_date": "1988-11-21",
+            "id": "term/11",
+            "name": "Knesset 11",
+            "start_date": "1984-08-13",
+            "slug": "11",
+            "csv": "data/Israel/Knesset/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-11.csv"
+          },
+          {
+            "end_date": "1984-08-13",
+            "id": "term/10",
+            "name": "Knesset 10",
+            "start_date": "1981-07-20",
+            "slug": "10",
+            "csv": "data/Israel/Knesset/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-10.csv"
+          },
+          {
+            "end_date": "1981-07-20",
+            "id": "term/9",
+            "name": "Knesset 9",
+            "start_date": "1977-06-13",
+            "slug": "9",
+            "csv": "data/Israel/Knesset/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-9.csv"
+          },
+          {
+            "end_date": "1977-06-13",
+            "id": "term/8",
+            "name": "Knesset 8",
+            "start_date": "1974-01-21",
+            "slug": "8",
+            "csv": "data/Israel/Knesset/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-8.csv"
+          },
+          {
+            "end_date": "1974-01-21",
+            "id": "term/7",
+            "name": "Knesset 7",
+            "start_date": "1969-11-17",
+            "slug": "7",
+            "csv": "data/Israel/Knesset/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-7.csv"
+          },
+          {
+            "end_date": "1969-11-17",
+            "id": "term/6",
+            "name": "Knesset 6",
+            "start_date": "1965-11-22",
+            "slug": "6",
+            "csv": "data/Israel/Knesset/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-6.csv"
+          },
+          {
+            "end_date": "1965-11-22",
+            "id": "term/5",
+            "name": "Knesset 5",
+            "start_date": "1961-09-04",
+            "slug": "5",
+            "csv": "data/Israel/Knesset/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-5.csv"
+          },
+          {
+            "end_date": "1961-09-04",
+            "id": "term/4",
+            "name": "Knesset 4",
+            "start_date": "1959-11-30",
+            "slug": "4",
+            "csv": "data/Israel/Knesset/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-4.csv"
+          },
+          {
+            "end_date": "1959-11-30",
+            "id": "term/3",
+            "name": "Knesset 3",
+            "start_date": "1955-08-15",
+            "slug": "3",
+            "csv": "data/Israel/Knesset/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-3.csv"
+          },
+          {
+            "end_date": "1955-08-15",
+            "id": "term/2",
+            "name": "Knesset 2",
+            "start_date": "1951-08-20",
+            "slug": "2",
+            "csv": "data/Israel/Knesset/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-2.csv"
+          },
+          {
+            "end_date": "1951-08-20",
+            "id": "term/1",
+            "name": "Knesset 1",
+            "start_date": "1949-02-14",
+            "slug": "1",
+            "csv": "data/Israel/Knesset/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fb7f2/data/Israel/Knesset/term-1.csv"
+          }
+        ],
+        "statement_count": 80530
+      }
+    ]
+  },
+  {
+    "name": "Italy",
+    "country": "Italy",
+    "code": "IT",
+    "slug": "Italy",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House",
+        "sources_directory": "data/Italy/House/sources",
+        "popolo": "data/Italy/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/94b5e0c/data/Italy/House/ep-popolo-v1.0.json",
+        "names": "data/Italy/House/names.csv",
+        "lastmod": "1467866115",
+        "person_count": 664,
+        "sha": "94b5e0c",
+        "legislative_periods": [
+          {
+            "id": "term/17",
+            "name": "XVII Legislatura",
+            "start_date": "2013-03-19",
+            "slug": "17",
+            "csv": "data/Italy/House/term-17.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/94b5e0c/data/Italy/House/term-17.csv"
+          }
+        ],
+        "statement_count": 45075
+      },
+      {
+        "name": "Senate",
+        "slug": "Senate",
+        "sources_directory": "data/Italy/Senate/sources",
+        "popolo": "data/Italy/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/72421da/data/Italy/Senate/ep-popolo-v1.0.json",
+        "names": "data/Italy/Senate/names.csv",
+        "lastmod": "1467633365",
+        "person_count": 322,
+        "sha": "72421da",
+        "legislative_periods": [
+          {
+            "id": "term/17",
+            "name": "XVII Legislatura",
+            "start_date": "2013-03-15",
+            "slug": "17",
+            "csv": "data/Italy/Senate/term-17.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/72421da/data/Italy/Senate/term-17.csv"
+          }
+        ],
+        "statement_count": 21859
+      }
+    ]
+  },
+  {
+    "name": "Jamaica",
+    "country": "Jamaica",
+    "code": "JM",
+    "slug": "Jamaica",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House-of-Representatives",
+        "sources_directory": "data/Jamaica/House_of_Representatives/sources",
+        "popolo": "data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4812288/data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json",
+        "names": "data/Jamaica/House_of_Representatives/names.csv",
+        "lastmod": "1467669180",
+        "person_count": 80,
+        "sha": "4812288",
+        "legislative_periods": [
+          {
+            "id": "term/2016",
+            "name": "2016–",
+            "start_date": "2016-03-10",
+            "slug": "2016",
+            "csv": "data/Jamaica/House_of_Representatives/term-2016.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4812288/data/Jamaica/House_of_Representatives/term-2016.csv"
+          },
+          {
+            "end_date": "2016-02-25",
+            "id": "term/2011",
+            "name": "2011–2016",
+            "start_date": "2012-01-17",
+            "slug": "2011",
+            "csv": "data/Jamaica/House_of_Representatives/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4812288/data/Jamaica/House_of_Representatives/term-2011.csv"
+          }
+        ],
+        "statement_count": 3162
+      }
+    ]
+  },
+  {
+    "name": "Japan",
+    "country": "Japan",
+    "code": "JP",
+    "slug": "Japan",
+    "legislatures": [
+      {
+        "name": "Shūgiin",
+        "slug": "House-of-Representatives",
+        "sources_directory": "data/Japan/House_of_Representatives/sources",
+        "popolo": "data/Japan/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc49434/data/Japan/House_of_Representatives/ep-popolo-v1.0.json",
+        "names": "data/Japan/House_of_Representatives/names.csv",
+        "lastmod": "1467918121",
+        "person_count": 477,
+        "sha": "cc49434",
+        "legislative_periods": [
+          {
+            "id": "term/46",
+            "name": "The 46th House of Representatives",
+            "start_date": "2014-12-14",
+            "slug": "46",
+            "csv": "data/Japan/House_of_Representatives/term-46.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc49434/data/Japan/House_of_Representatives/term-46.csv"
+          }
+        ],
+        "statement_count": 23883
+      }
+    ]
+  },
+  {
+    "name": "Jersey",
+    "country": "Jersey",
+    "code": "JE",
+    "slug": "Jersey",
+    "legislatures": [
+      {
+        "name": "States",
+        "slug": "States",
+        "sources_directory": "data/Jersey/States/sources",
+        "popolo": "data/Jersey/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4bce540/data/Jersey/States/ep-popolo-v1.0.json",
+        "names": "data/Jersey/States/names.csv",
+        "lastmod": "1467810995",
+        "person_count": 61,
+        "sha": "4bce540",
+        "legislative_periods": [
+          {
+            "id": "term/2011",
+            "name": "Assembly 2014–",
+            "start_date": "2014-11-03",
+            "slug": "2011",
+            "csv": "data/Jersey/States/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4bce540/data/Jersey/States/term-2011.csv"
+          }
+        ],
+        "statement_count": 1638
+      }
+    ]
+  },
+  {
+    "name": "Jordan",
+    "country": "Jordan",
+    "code": "JO",
+    "slug": "Jordan",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House-of-Representatives",
+        "sources_directory": "data/Jordan/House_of_Representatives/sources",
+        "popolo": "data/Jordan/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd1c214/data/Jordan/House_of_Representatives/ep-popolo-v1.0.json",
+        "names": "data/Jordan/House_of_Representatives/names.csv",
+        "lastmod": "1467738858",
+        "person_count": 150,
+        "sha": "fd1c214",
+        "legislative_periods": [
+          {
+            "id": "term/2013",
+            "name": "2013–",
+            "start_date": "2013-02-10",
+            "slug": "2013",
+            "csv": "data/Jordan/House_of_Representatives/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd1c214/data/Jordan/House_of_Representatives/term-2013.csv"
+          }
+        ],
+        "statement_count": 2023
+      }
+    ]
+  },
+  {
+    "name": "Kazakhstan",
+    "country": "Kazakhstan",
+    "code": "KZ",
+    "slug": "Kazakhstan",
+    "legislatures": [
+      {
+        "name": "Mazhilis",
+        "slug": "Assembly",
+        "sources_directory": "data/Kazakhstan/Assembly/sources",
+        "popolo": "data/Kazakhstan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Kazakhstan/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Kazakhstan/Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 107,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "Fifth Convocation",
+            "start_date": "2012-01-15",
+            "slug": "5",
+            "csv": "data/Kazakhstan/Assembly/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Kazakhstan/Assembly/term-5.csv"
+          }
+        ],
+        "statement_count": 2255
+      }
+    ]
+  },
+  {
+    "name": "Kenya",
+    "country": "Kenya",
+    "code": "KE",
+    "slug": "Kenya",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Kenya/Assembly/sources",
+        "popolo": "data/Kenya/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3fa6f31/data/Kenya/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Kenya/Assembly/names.csv",
+        "lastmod": "1466353692",
+        "person_count": 352,
+        "sha": "3fa6f31",
+        "legislative_periods": [
+          {
+            "id": "term/11",
+            "name": "11th Parliament",
+            "start_date": "2013-03-28",
+            "slug": "11",
+            "csv": "data/Kenya/Assembly/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3fa6f31/data/Kenya/Assembly/term-11.csv"
+          }
+        ],
+        "statement_count": 9821
+      }
+    ]
+  },
+  {
+    "name": "Kiribati",
+    "country": "Kiribati",
+    "code": "KI",
+    "slug": "Kiribati",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Kiribati/Parliament/sources",
+        "popolo": "data/Kiribati/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4721b4f/data/Kiribati/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Kiribati/Parliament/names.csv",
+        "lastmod": "1466996111",
+        "person_count": 62,
+        "sha": "4721b4f",
+        "legislative_periods": [
+          {
+            "end_date": "2015-11-25",
+            "id": "term/10",
+            "name": "10th Parliament",
+            "start_date": "2011-11-25",
+            "slug": "10",
+            "csv": "data/Kiribati/Parliament/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4721b4f/data/Kiribati/Parliament/term-10.csv"
+          },
+          {
+            "end_date": "2011-10-20",
+            "id": "term/9",
+            "name": "9th Parliament",
+            "start_date": "2007-09-17",
+            "slug": "9",
+            "csv": "data/Kiribati/Parliament/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4721b4f/data/Kiribati/Parliament/term-9.csv"
+          }
+        ],
+        "statement_count": 2048
+      }
+    ]
+  },
+  {
+    "name": "Kosovo",
+    "country": "Kosovo",
+    "code": "XK",
+    "slug": "Kosovo",
+    "legislatures": [
+      {
+        "name": "Kuvendit",
+        "slug": "Assembly",
+        "sources_directory": "data/Kosovo/Assembly/sources",
+        "popolo": "data/Kosovo/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7d681b3/data/Kosovo/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Kosovo/Assembly/names.csv",
+        "lastmod": "1466579326",
+        "person_count": 399,
+        "sha": "7d681b3",
+        "legislative_periods": [
+          {
+            "id": "term/chamber_2014-07-17",
+            "name": "Periudha e pestë Legjislative",
+            "start_date": "2014-07-17",
+            "slug": "chamber_2014-07-17",
+            "csv": "data/Kosovo/Assembly/term-chamber_2014-07-17.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7d681b3/data/Kosovo/Assembly/term-chamber_2014-07-17.csv"
+          },
+          {
+            "end_date": "2014-05-07",
+            "id": "term/chamber_2010-12-12",
+            "name": "Periudha e katërt Legjislative",
+            "start_date": "2010-12-12",
+            "slug": "chamber_2010-12-12",
+            "csv": "data/Kosovo/Assembly/term-chamber_2010-12-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7d681b3/data/Kosovo/Assembly/term-chamber_2010-12-12.csv"
+          },
+          {
+            "end_date": "2010-11-03",
+            "id": "term/chamber_2007-12-13",
+            "name": "Periudha e tretë Legjislative",
+            "start_date": "2007-12-13",
+            "slug": "chamber_2007-12-13",
+            "csv": "data/Kosovo/Assembly/term-chamber_2007-12-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7d681b3/data/Kosovo/Assembly/term-chamber_2007-12-13.csv"
+          },
+          {
+            "end_date": "2007-12-12",
+            "id": "term/chamber_2004-11-23",
+            "name": "Periudha e dytë Legjislative",
+            "start_date": "2004-11-23",
+            "slug": "chamber_2004-11-23",
+            "csv": "data/Kosovo/Assembly/term-chamber_2004-11-23.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7d681b3/data/Kosovo/Assembly/term-chamber_2004-11-23.csv"
+          },
+          {
+            "end_date": "2004-11-23",
+            "id": "term/chamber_2001-11-17",
+            "name": "Periudha e parë Legjislative",
+            "start_date": "2001-11-17",
+            "slug": "chamber_2001-11-17",
+            "csv": "data/Kosovo/Assembly/term-chamber_2001-11-17.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7d681b3/data/Kosovo/Assembly/term-chamber_2001-11-17.csv"
+          }
+        ],
+        "statement_count": 9359
+      }
+    ]
+  },
+  {
+    "name": "Kuwait",
+    "country": "Kuwait",
+    "code": "KW",
+    "slug": "Kuwait",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "National-Assembly",
+        "sources_directory": "data/Kuwait/National_Assembly/sources",
+        "popolo": "data/Kuwait/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5218052/data/Kuwait/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Kuwait/National_Assembly/names.csv",
+        "lastmod": "1467889598",
+        "person_count": 45,
+        "sha": "5218052",
+        "legislative_periods": [
+          {
+            "id": "term/14",
+            "name": "14th Legislative Session",
+            "start_date": "2013-08-06",
+            "slug": "14",
+            "csv": "data/Kuwait/National_Assembly/term-14.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5218052/data/Kuwait/National_Assembly/term-14.csv"
+          }
+        ],
+        "statement_count": 1340
+      }
+    ]
+  },
+  {
+    "name": "Kyrgyzstan",
+    "country": "Kyrgyzstan",
+    "code": "KG",
+    "slug": "Kyrgyzstan",
+    "legislatures": [
+      {
+        "name": "Supreme Council",
+        "slug": "Council",
+        "sources_directory": "data/Kyrgyzstan/Council/sources",
+        "popolo": "data/Kyrgyzstan/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc30ba0/data/Kyrgyzstan/Council/ep-popolo-v1.0.json",
+        "names": "data/Kyrgyzstan/Council/names.csv",
+        "lastmod": "1467604438",
+        "person_count": 209,
+        "sha": "cc30ba0",
+        "legislative_periods": [
+          {
+            "id": "term/6",
+            "name": "6th Convocation",
+            "start_date": "2015-10-28",
+            "slug": "6",
+            "csv": "data/Kyrgyzstan/Council/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc30ba0/data/Kyrgyzstan/Council/term-6.csv"
+          },
+          {
+            "end_date": "2015-10-15",
+            "id": "term/5",
+            "name": "5th Convocation",
+            "start_date": "2010",
+            "slug": "5",
+            "csv": "data/Kyrgyzstan/Council/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc30ba0/data/Kyrgyzstan/Council/term-5.csv"
+          }
+        ],
+        "statement_count": 3621
+      }
+    ]
+  },
+  {
+    "name": "Laos",
+    "country": "Laos",
+    "code": "LA",
+    "slug": "Laos",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Laos/Assembly/sources",
+        "popolo": "data/Laos/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/686d768/data/Laos/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Laos/Assembly/names.csv",
+        "lastmod": "1467669315",
+        "person_count": 132,
+        "sha": "686d768",
+        "legislative_periods": [
+          {
+            "end_date": "2016-03-20",
+            "id": "term/2011",
+            "name": "2011–2016",
+            "start_date": "2011-06-15",
+            "slug": "2011",
+            "csv": "data/Laos/Assembly/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/686d768/data/Laos/Assembly/term-2011.csv"
+          }
+        ],
+        "statement_count": 1896
+      }
+    ]
+  },
+  {
+    "name": "Latvia",
+    "country": "Latvia",
+    "code": "LV",
+    "slug": "Latvia",
+    "legislatures": [
+      {
+        "name": "Saeima",
+        "slug": "Saeima",
+        "sources_directory": "data/Latvia/Saeima/sources",
+        "popolo": "data/Latvia/Saeima/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/87e65f0/data/Latvia/Saeima/ep-popolo-v1.0.json",
+        "names": "data/Latvia/Saeima/names.csv",
+        "lastmod": "1467338877",
+        "person_count": 203,
+        "sha": "87e65f0",
+        "legislative_periods": [
+          {
+            "id": "term/12",
+            "name": "12th Saeima",
+            "start_date": "2014-11-04",
+            "wikidata": "Q20557340",
+            "slug": "12",
+            "csv": "data/Latvia/Saeima/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/87e65f0/data/Latvia/Saeima/term-12.csv"
+          },
+          {
+            "end_date": "2014-11-03",
+            "id": "term/11",
+            "name": "11th Saeima",
+            "start_date": "2011-10-17",
+            "wikidata": "Q13098708",
+            "slug": "11",
+            "csv": "data/Latvia/Saeima/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/87e65f0/data/Latvia/Saeima/term-11.csv"
+          },
+          {
+            "end_date": "2011-10-16",
+            "id": "term/10",
+            "name": "10th Saeima",
+            "start_date": "2010-11-02",
+            "wikidata": "Q16347625",
+            "slug": "10",
+            "csv": "data/Latvia/Saeima/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/87e65f0/data/Latvia/Saeima/term-10.csv"
+          }
+        ],
+        "statement_count": 27032
+      }
+    ]
+  },
+  {
+    "name": "Lebanon",
+    "country": "Lebanon",
+    "code": "LB",
+    "slug": "Lebanon",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Lebanon/Parliament/sources",
+        "popolo": "data/Lebanon/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d961a2/data/Lebanon/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Lebanon/Parliament/names.csv",
+        "lastmod": "1466586676",
+        "person_count": 131,
+        "sha": "2d961a2",
+        "legislative_periods": [
+          {
+            "end_date": "2017-06-20",
+            "id": "term/2009",
+            "name": "2009–2017",
+            "start_date": "2009-06-20",
+            "slug": "2009",
+            "csv": "data/Lebanon/Parliament/term-2009.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d961a2/data/Lebanon/Parliament/term-2009.csv"
+          }
+        ],
+        "statement_count": 7666
+      }
+    ]
+  },
+  {
+    "name": "Lesotho",
+    "country": "Lesotho",
+    "code": "LS",
+    "slug": "Lesotho",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Lesotho/Assembly/sources",
+        "popolo": "data/Lesotho/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/58cc9fb/data/Lesotho/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Lesotho/Assembly/names.csv",
+        "lastmod": "1467828374",
+        "person_count": 120,
+        "sha": "58cc9fb",
+        "legislative_periods": [
+          {
+            "id": "term/9",
+            "name": "9th Parliament",
+            "start_date": "2015-03-10",
+            "slug": "9",
+            "csv": "data/Lesotho/Assembly/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/58cc9fb/data/Lesotho/Assembly/term-9.csv"
+          }
+        ],
+        "statement_count": 2182
+      }
+    ]
+  },
+  {
+    "name": "Liberia",
+    "country": "Liberia",
+    "code": "LR",
+    "slug": "Liberia",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House",
+        "sources_directory": "data/Liberia/House/sources",
+        "popolo": "data/Liberia/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/570e189/data/Liberia/House/ep-popolo-v1.0.json",
+        "names": "data/Liberia/House/names.csv",
+        "lastmod": "1465852619",
+        "person_count": 73,
+        "sha": "570e189",
+        "legislative_periods": [
+          {
+            "id": "term/53",
+            "name": "53rd Session",
+            "start_date": "2012-01-09",
+            "slug": "53",
+            "csv": "data/Liberia/House/term-53.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/570e189/data/Liberia/House/term-53.csv"
+          }
+        ],
+        "statement_count": 2008
+      }
+    ]
+  },
+  {
+    "name": "Libya",
+    "country": "Libya",
+    "code": "LY",
+    "slug": "Libya",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House-of-Representatives",
+        "sources_directory": "data/Libya/House_of_Representatives/sources",
+        "popolo": "data/Libya/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Libya/House_of_Representatives/ep-popolo-v1.0.json",
+        "names": "data/Libya/House_of_Representatives/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 189,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/1",
+            "name": "1st House of Representatives",
+            "start_date": "2014-08-04",
+            "slug": "1",
+            "csv": "data/Libya/House_of_Representatives/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Libya/House_of_Representatives/term-1.csv"
+          }
+        ],
+        "statement_count": 3087
+      }
+    ]
+  },
+  {
+    "name": "Liechtenstein",
+    "country": "Liechtenstein",
+    "code": "LI",
+    "slug": "Liechtenstein",
+    "legislatures": [
+      {
+        "name": "Landtag",
+        "slug": "Landtag",
+        "sources_directory": "data/Liechtenstein/Landtag/sources",
+        "popolo": "data/Liechtenstein/Landtag/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c3e78b/data/Liechtenstein/Landtag/ep-popolo-v1.0.json",
+        "names": "data/Liechtenstein/Landtag/names.csv",
+        "lastmod": "1466353703",
+        "person_count": 51,
+        "sha": "6c3e78b",
+        "legislative_periods": [
+          {
+            "end_date": "2017",
+            "id": "term/2013",
+            "name": "2013-2017",
+            "start_date": "2013-03-27",
+            "slug": "2013",
+            "csv": "data/Liechtenstein/Landtag/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c3e78b/data/Liechtenstein/Landtag/term-2013.csv"
+          },
+          {
+            "end_date": "2013-02-02",
+            "id": "term/2009",
+            "name": "2009-2013",
+            "start_date": "2009-03-18",
+            "slug": "2009",
+            "csv": "data/Liechtenstein/Landtag/term-2009.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c3e78b/data/Liechtenstein/Landtag/term-2009.csv"
+          },
+          {
+            "end_date": "2009-02-07",
+            "id": "term/2005",
+            "name": "2005-2009",
+            "start_date": "2005-04-14",
+            "slug": "2005",
+            "csv": "data/Liechtenstein/Landtag/term-2005.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c3e78b/data/Liechtenstein/Landtag/term-2005.csv"
+          }
+        ],
+        "statement_count": 2633
+      }
+    ]
+  },
+  {
+    "name": "Lithuania",
+    "country": "Lithuania",
+    "code": "LT",
+    "slug": "Lithuania",
+    "legislatures": [
+      {
+        "name": "Seimas",
+        "slug": "Seimas",
+        "sources_directory": "data/Lithuania/Seimas/sources",
+        "popolo": "data/Lithuania/Seimas/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/81857e6/data/Lithuania/Seimas/ep-popolo-v1.0.json",
+        "names": "data/Lithuania/Seimas/names.csv",
+        "lastmod": "1467822622",
+        "person_count": 150,
+        "sha": "81857e6",
+        "legislative_periods": [
+          {
+            "id": "term/11",
+            "name": "11th Seimas",
+            "start_date": "2012-11-17",
+            "slug": "11",
+            "csv": "data/Lithuania/Seimas/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/81857e6/data/Lithuania/Seimas/term-11.csv"
+          }
+        ],
+        "statement_count": 15476
+      }
+    ]
+  },
+  {
+    "name": "Luxembourg",
+    "country": "Luxembourg",
+    "code": "LU",
+    "slug": "Luxembourg",
+    "legislatures": [
+      {
+        "name": "Chamber of Deputies",
+        "slug": "Chamber",
+        "sources_directory": "data/Luxembourg/Chamber/sources",
+        "popolo": "data/Luxembourg/Chamber/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0c06f15/data/Luxembourg/Chamber/ep-popolo-v1.0.json",
+        "names": "data/Luxembourg/Chamber/names.csv",
+        "lastmod": "1467264488",
+        "person_count": 62,
+        "sha": "0c06f15",
+        "legislative_periods": [
+          {
+            "id": "term/2013",
+            "name": "2013–",
+            "start_date": "2013-11-13",
+            "slug": "2013",
+            "csv": "data/Luxembourg/Chamber/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0c06f15/data/Luxembourg/Chamber/term-2013.csv"
+          }
+        ],
+        "statement_count": 4065
+      }
+    ]
+  },
+  {
+    "name": "Macao",
+    "country": "Macao",
+    "code": "MO",
+    "slug": "Macao",
+    "legislatures": [
+      {
+        "name": "Legislative Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Macao/Assembly/sources",
+        "popolo": "data/Macao/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/88453bc/data/Macao/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Macao/Assembly/names.csv",
+        "lastmod": "1467818834",
+        "person_count": 33,
+        "sha": "88453bc",
+        "legislative_periods": [
+          {
+            "end_date": "2017",
+            "id": "term/10",
+            "name": "10th Legislative Assembly",
+            "start_date": "2013",
+            "slug": "10",
+            "csv": "data/Macao/Assembly/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/88453bc/data/Macao/Assembly/term-10.csv"
+          }
+        ],
+        "statement_count": 1032
+      }
+    ]
+  },
+  {
+    "name": "Macedonia",
+    "country": "Macedonia",
+    "code": "MK",
+    "slug": "Macedonia",
+    "legislatures": [
+      {
+        "name": "Sobranie",
+        "slug": "Sobranie",
+        "sources_directory": "data/Macedonia/Sobranie/sources",
+        "popolo": "data/Macedonia/Sobranie/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ccee228/data/Macedonia/Sobranie/ep-popolo-v1.0.json",
+        "names": "data/Macedonia/Sobranie/names.csv",
+        "lastmod": "1467972947",
+        "person_count": 92,
+        "sha": "ccee228",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "2014–2018",
+            "start_date": "2014-05-10",
+            "slug": "2014",
+            "csv": "data/Macedonia/Sobranie/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ccee228/data/Macedonia/Sobranie/term-2014.csv"
+          }
+        ],
+        "statement_count": 2013
+      }
+    ]
+  },
+  {
+    "name": "Madagascar",
+    "country": "Madagascar",
+    "code": "MG",
+    "slug": "Madagascar",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Madagascar/Assembly/sources",
+        "popolo": "data/Madagascar/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25de825/data/Madagascar/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Madagascar/Assembly/names.csv",
+        "lastmod": "1466578313",
+        "person_count": 152,
+        "sha": "25de825",
+        "legislative_periods": [
+          {
+            "end_date": "2018",
+            "id": "term/2013",
+            "name": "2013-2018",
+            "start_date": "2013-12-20",
+            "slug": "2013",
+            "csv": "data/Madagascar/Assembly/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25de825/data/Madagascar/Assembly/term-2013.csv"
+          }
+        ],
+        "statement_count": 3026
+      }
+    ]
+  },
+  {
+    "name": "Malawi",
+    "country": "Malawi",
+    "code": "MW",
+    "slug": "Malawi",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Malawi/Assembly/sources",
+        "popolo": "data/Malawi/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malawi/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Malawi/Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 193,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "2014–",
+            "start_date": "2014-06-19",
+            "slug": "2014",
+            "csv": "data/Malawi/Assembly/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malawi/Assembly/term-2014.csv"
+          }
+        ],
+        "statement_count": 2777
+      }
+    ]
+  },
+  {
+    "name": "Malaysia",
+    "country": "Malaysia",
+    "code": "MY",
+    "slug": "Malaysia",
+    "legislatures": [
+      {
+        "name": "Dewan Rakyat",
+        "slug": "Dewan-Rakyat",
+        "sources_directory": "data/Malaysia/Dewan_Rakyat/sources",
+        "popolo": "data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
+        "names": "data/Malaysia/Dewan_Rakyat/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 1152,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/13",
+            "name": "13th Parliament of Malaysia",
+            "start_date": "2013-06-24",
+            "slug": "13",
+            "csv": "data/Malaysia/Dewan_Rakyat/term-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/term-13.csv"
+          },
+          {
+            "end_date": "2013",
+            "id": "term/12",
+            "name": "12th Parliament of Malaysia",
+            "start_date": "2008",
+            "slug": "12",
+            "csv": "data/Malaysia/Dewan_Rakyat/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/term-12.csv"
+          },
+          {
+            "end_date": "2008",
+            "id": "term/11",
+            "name": "11th Parliament of Malaysia",
+            "start_date": "2004",
+            "slug": "11",
+            "csv": "data/Malaysia/Dewan_Rakyat/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/term-11.csv"
+          },
+          {
+            "end_date": "2004",
+            "id": "term/10",
+            "name": "10th Parliament of Malaysia",
+            "start_date": "1999",
+            "slug": "10",
+            "csv": "data/Malaysia/Dewan_Rakyat/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/term-10.csv"
+          },
+          {
+            "end_date": "1999",
+            "id": "term/9",
+            "name": "9th Parliament of Malaysia",
+            "start_date": "1995",
+            "slug": "9",
+            "csv": "data/Malaysia/Dewan_Rakyat/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/term-9.csv"
+          },
+          {
+            "end_date": "1995",
+            "id": "term/8",
+            "name": "8th Parliament of Malaysia",
+            "start_date": "1990",
+            "slug": "8",
+            "csv": "data/Malaysia/Dewan_Rakyat/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/term-8.csv"
+          },
+          {
+            "end_date": "1990",
+            "id": "term/7",
+            "name": "7th Parliament of Malaysia",
+            "start_date": "1986",
+            "slug": "7",
+            "csv": "data/Malaysia/Dewan_Rakyat/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/term-7.csv"
+          },
+          {
+            "end_date": "1986",
+            "id": "term/6",
+            "name": "6th Parliament of Malaysia",
+            "start_date": "1982",
+            "slug": "6",
+            "csv": "data/Malaysia/Dewan_Rakyat/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/term-6.csv"
+          },
+          {
+            "end_date": "1982",
+            "id": "term/5",
+            "name": "5th Parliament of Malaysia",
+            "start_date": "1978",
+            "slug": "5",
+            "csv": "data/Malaysia/Dewan_Rakyat/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/term-5.csv"
+          },
+          {
+            "end_date": "1978",
+            "id": "term/4",
+            "name": "4th Parliament of Malaysia",
+            "start_date": "1974",
+            "slug": "4",
+            "csv": "data/Malaysia/Dewan_Rakyat/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/term-4.csv"
+          },
+          {
+            "end_date": "1974",
+            "id": "term/3",
+            "name": "3rd Parliament of Malaysia",
+            "start_date": "1969",
+            "slug": "3",
+            "csv": "data/Malaysia/Dewan_Rakyat/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/term-3.csv"
+          },
+          {
+            "end_date": "1969",
+            "id": "term/2",
+            "name": "2nd Parliament of Malaysia",
+            "start_date": "1964",
+            "slug": "2",
+            "csv": "data/Malaysia/Dewan_Rakyat/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/term-2.csv"
+          },
+          {
+            "end_date": "1964",
+            "id": "term/1",
+            "name": "1st Parliament of Malaysia",
+            "start_date": "1959",
+            "slug": "1",
+            "csv": "data/Malaysia/Dewan_Rakyat/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/term-1.csv"
+          }
+        ],
+        "statement_count": 47826
+      }
+    ]
+  },
+  {
+    "name": "Maldives",
+    "country": "Maldives",
+    "code": "MV",
+    "slug": "Maldives",
+    "legislatures": [
+      {
+        "name": "Majlis",
+        "slug": "Majlis",
+        "sources_directory": "data/Maldives/Majlis/sources",
+        "popolo": "data/Maldives/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c72f0ab/data/Maldives/Majlis/ep-popolo-v1.0.json",
+        "names": "data/Maldives/Majlis/names.csv",
+        "lastmod": "1465844949",
+        "person_count": 85,
+        "sha": "c72f0ab",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "2014",
+            "start_date": "2014-05-28",
+            "slug": "2014",
+            "csv": "data/Maldives/Majlis/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c72f0ab/data/Maldives/Majlis/term-2014.csv"
+          }
+        ],
+        "statement_count": 1266
+      }
+    ]
+  },
+  {
+    "name": "Mali",
+    "country": "Mali",
+    "code": "ML",
+    "slug": "Mali",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Mali/Assembly/sources",
+        "popolo": "data/Mali/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5f67540/data/Mali/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Mali/Assembly/names.csv",
+        "lastmod": "1467672732",
+        "person_count": 142,
+        "sha": "5f67540",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "5th Legislature",
+            "start_date": "2014-01-01",
+            "slug": "2014",
+            "csv": "data/Mali/Assembly/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5f67540/data/Mali/Assembly/term-2014.csv"
+          }
+        ],
+        "statement_count": 2454
+      }
+    ]
+  },
+  {
+    "name": "Malta",
+    "country": "Malta",
+    "code": "MT",
+    "slug": "Malta",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Assembly",
+        "sources_directory": "data/Malta/Assembly/sources",
+        "popolo": "data/Malta/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4be1ad/data/Malta/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Malta/Assembly/names.csv",
+        "lastmod": "1467954375",
+        "person_count": 71,
+        "sha": "a4be1ad",
+        "legislative_periods": [
+          {
+            "id": "term/12",
+            "name": "12th Parliament",
+            "start_date": "2013-04-06",
+            "slug": "12",
+            "csv": "data/Malta/Assembly/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4be1ad/data/Malta/Assembly/term-12.csv"
+          }
+        ],
+        "statement_count": 2770
+      }
+    ]
+  },
+  {
+    "name": "Marshall Islands",
+    "country": "Marshall Islands",
+    "code": "MH",
+    "slug": "Marshall-Islands",
+    "legislatures": [
+      {
+        "name": "Nitijela",
+        "slug": "Nitijela",
+        "sources_directory": "data/Marshall_Islands/Nitijela/sources",
+        "popolo": "data/Marshall_Islands/Nitijela/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/82a7283/data/Marshall_Islands/Nitijela/ep-popolo-v1.0.json",
+        "names": "data/Marshall_Islands/Nitijela/names.csv",
+        "lastmod": "1465890602",
+        "person_count": 33,
+        "sha": "82a7283",
+        "legislative_periods": [
+          {
+            "end_date": "2015-11-30",
+            "id": "term/2012",
+            "name": "2012–2015",
+            "start_date": "2012-01-03",
+            "slug": "2012",
+            "csv": "data/Marshall_Islands/Nitijela/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/82a7283/data/Marshall_Islands/Nitijela/term-2012.csv"
+          }
+        ],
+        "statement_count": 547
+      }
+    ]
+  },
+  {
+    "name": "Mauritania",
+    "country": "Mauritania",
+    "code": "MR",
+    "slug": "Mauritania",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "National-Assembly",
+        "sources_directory": "data/Mauritania/National_Assembly/sources",
+        "popolo": "data/Mauritania/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Mauritania/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Mauritania/National_Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 147,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/12",
+            "name": "12th National Assembly",
+            "start_date": "2013-12-21",
+            "slug": "12",
+            "csv": "data/Mauritania/National_Assembly/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Mauritania/National_Assembly/term-12.csv"
+          }
+        ],
+        "statement_count": 1899
+      }
+    ]
+  },
+  {
+    "name": "Mauritius",
+    "country": "Mauritius",
+    "code": "MU",
+    "slug": "Mauritius",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "National-Assembly",
+        "sources_directory": "data/Mauritius/National_Assembly/sources",
+        "popolo": "data/Mauritius/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Mauritius/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Mauritius/National_Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 62,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "10th National Assembly",
+            "start_date": "2014-12-10",
+            "slug": "2014",
+            "csv": "data/Mauritius/National_Assembly/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Mauritius/National_Assembly/term-2014.csv"
+          }
+        ],
+        "statement_count": 1019
+      }
+    ]
+  },
+  {
+    "name": "Mexico",
+    "country": "Mexico",
+    "code": "MX",
+    "slug": "Mexico",
+    "legislatures": [
+      {
+        "name": "Chamber of Deputies",
+        "slug": "Deputies",
+        "sources_directory": "data/Mexico/Deputies/sources",
+        "popolo": "data/Mexico/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d4a823/data/Mexico/Deputies/ep-popolo-v1.0.json",
+        "names": "data/Mexico/Deputies/names.csv",
+        "lastmod": "1467804348",
+        "person_count": 1025,
+        "sha": "4d4a823",
+        "legislative_periods": [
+          {
+            "id": "term/63",
+            "name": "LXIII Legislature",
+            "start_date": "2015-09-01",
+            "slug": "63",
+            "csv": "data/Mexico/Deputies/term-63.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d4a823/data/Mexico/Deputies/term-63.csv"
+          },
+          {
+            "end_date": "2015-08-31",
+            "id": "term/62",
+            "name": "LXII Legislature",
+            "start_date": "2012-09-01",
+            "slug": "62",
+            "csv": "data/Mexico/Deputies/term-62.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d4a823/data/Mexico/Deputies/term-62.csv"
+          }
+        ],
+        "statement_count": 30255
+      }
+    ]
+  },
+  {
+    "name": "Micronesia",
+    "country": "Micronesia",
+    "code": "FM",
+    "slug": "Micronesia",
+    "legislatures": [
+      {
+        "name": "Congress",
+        "slug": "Congress",
+        "sources_directory": "data/Micronesia/Congress/sources",
+        "popolo": "data/Micronesia/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0d7650/data/Micronesia/Congress/ep-popolo-v1.0.json",
+        "names": "data/Micronesia/Congress/names.csv",
+        "lastmod": "1466353722",
+        "person_count": 24,
+        "sha": "c0d7650",
+        "legislative_periods": [
+          {
+            "id": "term/19",
+            "name": "19th Congress",
+            "start_date": "2015-05-11",
+            "slug": "19",
+            "csv": "data/Micronesia/Congress/term-19.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0d7650/data/Micronesia/Congress/term-19.csv"
+          },
+          {
+            "end_date": "2015-05-10",
+            "id": "term/18",
+            "name": "18th Congress",
+            "start_date": "2013-05-11",
+            "slug": "18",
+            "csv": "data/Micronesia/Congress/term-18.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0d7650/data/Micronesia/Congress/term-18.csv"
+          },
+          {
+            "end_date": "2013-05-10",
+            "id": "term/17",
+            "name": "17th Congress",
+            "start_date": "2011-05-11",
+            "slug": "17",
+            "csv": "data/Micronesia/Congress/term-17.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0d7650/data/Micronesia/Congress/term-17.csv"
+          }
+        ],
+        "statement_count": 1112
+      }
+    ]
+  },
+  {
+    "name": "Moldova",
+    "country": "Moldova",
+    "code": "MD",
+    "slug": "Moldova",
+    "legislatures": [
+      {
+        "name": "Parlament",
+        "slug": "Parlamentul",
+        "sources_directory": "data/Moldova/Parlamentul/sources",
+        "popolo": "data/Moldova/Parlamentul/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9727404/data/Moldova/Parlamentul/ep-popolo-v1.0.json",
+        "names": "data/Moldova/Parlamentul/names.csv",
+        "lastmod": "1467884993",
+        "person_count": 115,
+        "sha": "9727404",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "Legislatura XX",
+            "start_date": "2014-12-29",
+            "slug": "2014",
+            "csv": "data/Moldova/Parlamentul/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9727404/data/Moldova/Parlamentul/term-2014.csv"
+          }
+        ],
+        "statement_count": 5764
+      }
+    ]
+  },
+  {
+    "name": "Monaco",
+    "country": "Monaco",
+    "code": "MC",
+    "slug": "Monaco",
+    "legislatures": [
+      {
+        "name": "National Council",
+        "slug": "Council",
+        "sources_directory": "data/Monaco/Council/sources",
+        "popolo": "data/Monaco/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c26921b/data/Monaco/Council/ep-popolo-v1.0.json",
+        "names": "data/Monaco/Council/names.csv",
+        "lastmod": "1467673031",
+        "person_count": 50,
+        "sha": "c26921b",
+        "legislative_periods": [
+          {
+            "end_date": "2018",
+            "id": "term/2013",
+            "name": "2013",
+            "start_date": "2013-02-21",
+            "slug": "2013",
+            "csv": "data/Monaco/Council/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c26921b/data/Monaco/Council/term-2013.csv"
+          },
+          {
+            "end_date": "2013",
+            "id": "term/2008",
+            "name": "2008-2013",
+            "start_date": "2008",
+            "slug": "2008",
+            "csv": "data/Monaco/Council/term-2008.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c26921b/data/Monaco/Council/term-2008.csv"
+          },
+          {
+            "end_date": "2008",
+            "id": "term/2003",
+            "name": "2003-2008",
+            "start_date": "2003",
+            "slug": "2003",
+            "csv": "data/Monaco/Council/term-2003.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c26921b/data/Monaco/Council/term-2003.csv"
+          }
+        ],
+        "statement_count": 1059
+      }
+    ]
+  },
+  {
+    "name": "Mongolia",
+    "country": "Mongolia",
+    "code": "MN",
+    "slug": "Mongolia",
+    "legislatures": [
+      {
+        "name": "State Great Khural",
+        "slug": "Assembly",
+        "sources_directory": "data/Mongolia/Assembly/sources",
+        "popolo": "data/Mongolia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9268edf/data/Mongolia/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Mongolia/Assembly/names.csv",
+        "lastmod": "1467293629",
+        "person_count": 117,
+        "sha": "9268edf",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "State Grand Khural 2012–",
+            "start_date": "2012-06-28",
+            "slug": "2012",
+            "csv": "data/Mongolia/Assembly/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9268edf/data/Mongolia/Assembly/term-2012.csv"
+          },
+          {
+            "end_date": "2012-06-28",
+            "id": "term/2008",
+            "name": "State Grand Khural 2008–2012",
+            "start_date": "2008-07-23",
+            "slug": "2008",
+            "csv": "data/Mongolia/Assembly/term-2008.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9268edf/data/Mongolia/Assembly/term-2008.csv"
+          }
+        ],
+        "statement_count": 4983
+      }
+    ]
+  },
+  {
+    "name": "Montenegro",
+    "country": "Montenegro",
+    "code": "ME",
+    "slug": "Montenegro",
+    "legislatures": [
+      {
+        "name": "Skupština",
+        "slug": "Assembly",
+        "sources_directory": "data/Montenegro/Assembly/sources",
+        "popolo": "data/Montenegro/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a427edc/data/Montenegro/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Montenegro/Assembly/names.csv",
+        "lastmod": "1467917405",
+        "person_count": 82,
+        "sha": "a427edc",
+        "legislative_periods": [
+          {
+            "end_date": "2015",
+            "id": "term/25",
+            "name": "Skupština 2012-",
+            "start_date": "2012-11-06",
+            "slug": "25",
+            "csv": "data/Montenegro/Assembly/term-25.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a427edc/data/Montenegro/Assembly/term-25.csv"
+          }
+        ],
+        "statement_count": 2302
+      }
+    ]
+  },
+  {
+    "name": "Montserrat",
+    "country": "Montserrat",
+    "code": "MS",
+    "slug": "Montserrat",
+    "legislatures": [
+      {
+        "name": "Legislative Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Montserrat/Assembly/sources",
+        "popolo": "data/Montserrat/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/529e0c3/data/Montserrat/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Montserrat/Assembly/names.csv",
+        "lastmod": "1467890935",
+        "person_count": 9,
+        "sha": "529e0c3",
+        "legislative_periods": [
+          {
+            "id": "term/1",
+            "name": "1st Legislative Assembly",
+            "start_date": "2014",
+            "slug": "1",
+            "csv": "data/Montserrat/Assembly/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/529e0c3/data/Montserrat/Assembly/term-1.csv"
+          }
+        ],
+        "statement_count": 224
+      }
+    ]
+  },
+  {
+    "name": "Morocco",
+    "country": "Morocco",
+    "code": "MA",
+    "slug": "Morocco",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House",
+        "sources_directory": "data/Morocco/House/sources",
+        "popolo": "data/Morocco/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Morocco/House/ep-popolo-v1.0.json",
+        "names": "data/Morocco/House/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 401,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "end_date": "2016",
+            "id": "term/9",
+            "name": "9th Legislature",
+            "start_date": "2011-12-19",
+            "slug": "9",
+            "csv": "data/Morocco/House/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Morocco/House/term-9.csv"
+          }
+        ],
+        "statement_count": 5397
+      }
+    ]
+  },
+  {
+    "name": "Mozambique",
+    "country": "Mozambique",
+    "code": "MZ",
+    "slug": "Mozambique",
+    "legislatures": [
+      {
+        "name": "Assembleia da República",
+        "slug": "Assembly",
+        "sources_directory": "data/Mozambique/Assembly/sources",
+        "popolo": "data/Mozambique/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Mozambique/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Mozambique/Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 250,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/8",
+            "name": "VIII Legislature",
+            "start_date": "2015-01-12",
+            "slug": "8",
+            "csv": "data/Mozambique/Assembly/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Mozambique/Assembly/term-8.csv"
+          }
+        ],
+        "statement_count": 3353
+      }
+    ]
+  },
+  {
+    "name": "Myanmar",
+    "country": "Myanmar",
+    "code": "MM",
+    "slug": "Myanmar",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House-of-Representatives",
+        "sources_directory": "data/Myanmar/House_of_Representatives/sources",
+        "popolo": "data/Myanmar/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Myanmar/House_of_Representatives/ep-popolo-v1.0.json",
+        "names": "data/Myanmar/House_of_Representatives/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 314,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/1",
+            "name": "1st Pyithu Hluttaw",
+            "start_date": "2011-01-31",
+            "slug": "1",
+            "csv": "data/Myanmar/House_of_Representatives/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Myanmar/House_of_Representatives/term-1.csv"
+          }
+        ],
+        "statement_count": 5165
+      }
+    ]
+  },
+  {
+    "name": "Nagorno-Karabakh",
+    "country": "Nagorno-Karabakh",
+    "code": "AZ--NK",
+    "slug": "Nagorno-Karabakh",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Nagorno_Karabakh/Assembly/sources",
+        "popolo": "data/Nagorno_Karabakh/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/da8a909/data/Nagorno_Karabakh/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Nagorno_Karabakh/Assembly/names.csv",
+        "lastmod": "1467880478",
+        "person_count": 33,
+        "sha": "da8a909",
+        "legislative_periods": [
+          {
+            "id": "term/6",
+            "name": "6th Convocation",
+            "start_date": "2015-05-21",
+            "slug": "6",
+            "csv": "data/Nagorno_Karabakh/Assembly/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/da8a909/data/Nagorno_Karabakh/Assembly/term-6.csv"
+          }
+        ],
+        "statement_count": 1366
+      }
+    ]
+  },
+  {
+    "name": "Namibia",
+    "country": "Namibia",
+    "code": "NA",
+    "slug": "Namibia",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Namibia/Assembly/sources",
+        "popolo": "data/Namibia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef4aaed/data/Namibia/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Namibia/Assembly/names.csv",
+        "lastmod": "1467802024",
+        "person_count": 267,
+        "sha": "ef4aaed",
+        "legislative_periods": [
+          {
+            "end_date": "2020",
+            "id": "term/6",
+            "name": "6th National Assembly",
+            "start_date": "2015-03-20",
+            "slug": "6",
+            "csv": "data/Namibia/Assembly/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef4aaed/data/Namibia/Assembly/term-6.csv"
+          },
+          {
+            "end_date": "2015-03-19",
+            "id": "term/5",
+            "name": "5th National Assembly",
+            "start_date": "2010-03-19",
+            "slug": "5",
+            "csv": "data/Namibia/Assembly/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef4aaed/data/Namibia/Assembly/term-5.csv"
+          },
+          {
+            "end_date": "2010-03-19",
+            "id": "term/4",
+            "name": "4th National Assembly",
+            "start_date": "2005-03-20",
+            "slug": "4",
+            "csv": "data/Namibia/Assembly/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef4aaed/data/Namibia/Assembly/term-4.csv"
+          },
+          {
+            "end_date": "2005",
+            "id": "term/3",
+            "name": "3rd National Assembly",
+            "start_date": "2000",
+            "slug": "3",
+            "csv": "data/Namibia/Assembly/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef4aaed/data/Namibia/Assembly/term-3.csv"
+          },
+          {
+            "end_date": "2000",
+            "id": "term/2",
+            "name": "2nd National Assembly",
+            "start_date": "1995",
+            "slug": "2",
+            "csv": "data/Namibia/Assembly/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef4aaed/data/Namibia/Assembly/term-2.csv"
+          },
+          {
+            "end_date": "1995",
+            "id": "term/1",
+            "name": "1st National Assembly",
+            "start_date": "1990",
+            "slug": "1",
+            "csv": "data/Namibia/Assembly/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef4aaed/data/Namibia/Assembly/term-1.csv"
+          },
+          {
+            "end_date": "1990",
+            "id": "term/0",
+            "name": "Constituent Assembly",
+            "start_date": "1989",
+            "slug": "0",
+            "csv": "data/Namibia/Assembly/term-0.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef4aaed/data/Namibia/Assembly/term-0.csv"
+          }
+        ],
+        "statement_count": 9714
+      },
+      {
+        "name": "National Council",
+        "slug": "Council",
+        "sources_directory": "data/Namibia/Council/sources",
+        "popolo": "data/Namibia/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Namibia/Council/ep-popolo-v1.0.json",
+        "names": "data/Namibia/Council/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 115,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "5th National Council",
+            "start_date": "2015-12-18",
+            "slug": "5",
+            "csv": "data/Namibia/Council/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Namibia/Council/term-5.csv"
+          },
+          {
+            "end_date": "2015-12-17",
+            "id": "term/4",
+            "name": "4th National Council",
+            "start_date": "2010",
+            "slug": "4",
+            "csv": "data/Namibia/Council/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Namibia/Council/term-4.csv"
+          },
+          {
+            "end_date": "2010",
+            "id": "term/3",
+            "name": "3rd National Council",
+            "start_date": "2004",
+            "slug": "3",
+            "csv": "data/Namibia/Council/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Namibia/Council/term-3.csv"
+          },
+          {
+            "end_date": "2004",
+            "id": "term/2",
+            "name": "2nd National Council",
+            "start_date": "1998",
+            "slug": "2",
+            "csv": "data/Namibia/Council/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Namibia/Council/term-2.csv"
+          },
+          {
+            "end_date": "1998",
+            "id": "term/1",
+            "name": "1st National Council",
+            "start_date": "1993",
+            "slug": "1",
+            "csv": "data/Namibia/Council/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Namibia/Council/term-1.csv"
+          }
+        ],
+        "statement_count": 2072
+      }
+    ]
+  },
+  {
+    "name": "Nauru",
+    "country": "Nauru",
+    "code": "NR",
+    "slug": "Nauru",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Nauru/Parliament/sources",
+        "popolo": "data/Nauru/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3577226/data/Nauru/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Nauru/Parliament/names.csv",
+        "lastmod": "1467938108",
+        "person_count": 26,
+        "sha": "3577226",
+        "legislative_periods": [
+          {
+            "id": "term/21",
+            "name": "21st Parliament",
+            "start_date": "2013-06-11",
+            "slug": "21",
+            "csv": "data/Nauru/Parliament/term-21.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3577226/data/Nauru/Parliament/term-21.csv"
+          },
+          {
+            "end_date": "2013-05-23",
+            "id": "term/20",
+            "name": "20th Parliament",
+            "start_date": "2010-06-22",
+            "slug": "20",
+            "csv": "data/Nauru/Parliament/term-20.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3577226/data/Nauru/Parliament/term-20.csv"
+          },
+          {
+            "end_date": "2010-05-23",
+            "id": "term/19",
+            "name": "19th Parliament",
+            "start_date": "2000-06-19",
+            "slug": "19",
+            "csv": "data/Nauru/Parliament/term-19.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3577226/data/Nauru/Parliament/term-19.csv"
+          }
+        ],
+        "statement_count": 2361
+      }
+    ]
+  },
+  {
+    "name": "Nepal",
+    "country": "Nepal",
+    "code": "NP",
+    "slug": "Nepal",
+    "legislatures": [
+      {
+        "name": "Constituent Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Nepal/Assembly/sources",
+        "popolo": "data/Nepal/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee19985/data/Nepal/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Nepal/Assembly/names.csv",
+        "lastmod": "1466850354",
+        "person_count": 550,
+        "sha": "ee19985",
+        "legislative_periods": [
+          {
+            "id": "term/ca2",
+            "name": "2nd Constituent Assembly",
+            "start_date": "2014-01-22",
+            "slug": "ca2",
+            "csv": "data/Nepal/Assembly/term-ca2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee19985/data/Nepal/Assembly/term-ca2.csv"
+          }
+        ],
+        "statement_count": 12778
+      }
+    ]
+  },
+  {
+    "name": "Netherlands",
+    "country": "Netherlands",
+    "code": "NL",
+    "slug": "Netherlands",
+    "legislatures": [
+      {
+        "name": "Tweede Kamer",
+        "slug": "House-of-Representatives",
+        "sources_directory": "data/Netherlands/House_of_Representatives/sources",
+        "popolo": "data/Netherlands/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cee6cc1/data/Netherlands/House_of_Representatives/ep-popolo-v1.0.json",
+        "names": "data/Netherlands/House_of_Representatives/names.csv",
+        "lastmod": "1467907326",
+        "person_count": 190,
+        "sha": "cee6cc1",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012–",
+            "start_date": "2012-09-20",
+            "slug": "2012",
+            "csv": "data/Netherlands/House_of_Representatives/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cee6cc1/data/Netherlands/House_of_Representatives/term-2012.csv"
+          }
+        ],
+        "statement_count": 15410
+      }
+    ]
+  },
+  {
+    "name": "New Caledonia",
+    "country": "New Caledonia",
+    "code": "NC",
+    "slug": "New-Caledonia",
+    "legislatures": [
+      {
+        "name": "Congress",
+        "slug": "Congress",
+        "sources_directory": "data/New_Caledonia/Congress/sources",
+        "popolo": "data/New_Caledonia/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c133335/data/New_Caledonia/Congress/ep-popolo-v1.0.json",
+        "names": "data/New_Caledonia/Congress/names.csv",
+        "lastmod": "1467771530",
+        "person_count": 56,
+        "sha": "c133335",
+        "legislative_periods": [
+          {
+            "id": "term/4",
+            "name": "4e mandat",
+            "start_date": "2014",
+            "slug": "4",
+            "csv": "data/New_Caledonia/Congress/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c133335/data/New_Caledonia/Congress/term-4.csv"
+          }
+        ],
+        "statement_count": 1688
+      }
+    ]
+  },
+  {
+    "name": "New Zealand",
+    "country": "New Zealand",
+    "code": "NZ",
+    "slug": "New-Zealand",
+    "legislatures": [
+      {
+        "name": "New Zealand Parliament",
+        "slug": "House",
+        "sources_directory": "data/New_Zealand/House/sources",
+        "popolo": "data/New_Zealand/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/87859a2/data/New_Zealand/House/ep-popolo-v1.0.json",
+        "names": "data/New_Zealand/House/names.csv",
+        "lastmod": "1467781265",
+        "person_count": 230,
+        "sha": "87859a2",
+        "legislative_periods": [
+          {
+            "id": "term/51",
+            "name": "51st Parliament",
+            "start_date": "2014-10-20",
+            "wikidata": "Q4640115",
+            "slug": "51",
+            "csv": "data/New_Zealand/House/term-51.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/87859a2/data/New_Zealand/House/term-51.csv"
+          },
+          {
+            "end_date": "2014-09-19",
+            "id": "term/50",
+            "name": "50th Parliament",
+            "start_date": "2011-12-20",
+            "wikidata": "Q4120749",
+            "slug": "50",
+            "csv": "data/New_Zealand/House/term-50.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/87859a2/data/New_Zealand/House/term-50.csv"
+          },
+          {
+            "end_date": "2011-10-20",
+            "id": "term/49",
+            "name": "49th Parliament",
+            "start_date": "2008-12-08",
+            "wikidata": "Q11812120",
+            "slug": "49",
+            "csv": "data/New_Zealand/House/term-49.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/87859a2/data/New_Zealand/House/term-49.csv"
+          },
+          {
+            "end_date": "2008-10-03",
+            "id": "term/48",
+            "name": "48th Parliament",
+            "start_date": "2005-11-07",
+            "wikidata": "Q4638695",
+            "slug": "48",
+            "csv": "data/New_Zealand/House/term-48.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/87859a2/data/New_Zealand/House/term-48.csv"
+          }
+        ],
+        "statement_count": 16317
+      }
+    ]
+  },
+  {
+    "name": "Nicaragua",
+    "country": "Nicaragua",
+    "code": "NI",
+    "slug": "Nicaragua",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Asamblea",
+        "sources_directory": "data/Nicaragua/Asamblea/sources",
+        "popolo": "data/Nicaragua/Asamblea/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa0fd47/data/Nicaragua/Asamblea/ep-popolo-v1.0.json",
+        "names": "data/Nicaragua/Asamblea/names.csv",
+        "lastmod": "1466583584",
+        "person_count": 90,
+        "sha": "fa0fd47",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012–2017",
+            "start_date": "2012-01-09",
+            "slug": "2012",
+            "csv": "data/Nicaragua/Asamblea/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa0fd47/data/Nicaragua/Asamblea/term-2012.csv"
+          }
+        ],
+        "statement_count": 2195
+      }
+    ]
+  },
+  {
+    "name": "Niger",
+    "country": "Niger",
+    "code": "NE",
+    "slug": "Niger",
+    "legislatures": [
+      {
+        "name": "Assemblée nationale",
+        "slug": "Assembly",
+        "sources_directory": "data/Niger/Assembly/sources",
+        "popolo": "data/Niger/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Niger/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Niger/Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 113,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/7.1",
+            "name": "1ere Legislature de la 7eme Republique",
+            "start_date": "2011-10-06",
+            "slug": "7.1",
+            "csv": "data/Niger/Assembly/term-7.1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Niger/Assembly/term-7.1.csv"
+          }
+        ],
+        "statement_count": 1421
+      }
+    ]
+  },
+  {
+    "name": "Nigeria",
+    "country": "Nigeria",
+    "code": "NG",
+    "slug": "Nigeria",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Nigeria/Assembly/sources",
+        "popolo": "data/Nigeria/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Nigeria/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Nigeria/Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 362,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/2015",
+            "name": "2015–",
+            "start_date": "2015-06-09",
+            "slug": "2015",
+            "csv": "data/Nigeria/Assembly/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Nigeria/Assembly/term-2015.csv"
+          }
+        ],
+        "statement_count": 5963
+      }
+    ]
+  },
+  {
+    "name": "Niue",
+    "country": "Niue",
+    "code": "NU",
+    "slug": "Niue",
+    "legislatures": [
+      {
+        "name": "Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Niue/Assembly/sources",
+        "popolo": "data/Niue/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Niue/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Niue/Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 20,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/15",
+            "name": "15th Assembly",
+            "start_date": "2014-04-23",
+            "slug": "15",
+            "csv": "data/Niue/Assembly/term-15.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Niue/Assembly/term-15.csv"
+          }
+        ],
+        "statement_count": 939
+      }
+    ]
+  },
+  {
+    "name": "Norfolk Island",
+    "country": "Norfolk Island",
+    "code": "NF",
+    "slug": "Norfolk-Island",
+    "legislatures": [
+      {
+        "name": "Legislative Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Norfolk_Island/Assembly/sources",
+        "popolo": "data/Norfolk_Island/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/38c8130/data/Norfolk_Island/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Norfolk_Island/Assembly/names.csv",
+        "lastmod": "1467885658",
+        "person_count": 9,
+        "sha": "38c8130",
+        "legislative_periods": [
+          {
+            "end_date": "2015-06-17",
+            "id": "term/14",
+            "name": "14th Legislative Assembly",
+            "start_date": "2013-03-20",
+            "slug": "14",
+            "csv": "data/Norfolk_Island/Assembly/term-14.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/38c8130/data/Norfolk_Island/Assembly/term-14.csv"
+          }
+        ],
+        "statement_count": 472
+      }
+    ]
+  },
+  {
+    "name": "North Korea",
+    "country": "North Korea",
+    "code": "KP",
+    "slug": "North-Korea",
+    "legislatures": [
+      {
+        "name": "Supreme People’s Assembly",
+        "slug": "National-Assembly",
+        "sources_directory": "data/North_Korea/National_Assembly/sources",
+        "popolo": "data/North_Korea/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bd08b5e/data/North_Korea/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/North_Korea/National_Assembly/names.csv",
+        "lastmod": "1467631613",
+        "person_count": 687,
+        "sha": "bd08b5e",
+        "legislative_periods": [
+          {
+            "id": "term/13",
+            "name": "13th Assembly",
+            "start_date": "2014-03-09",
+            "slug": "13",
+            "csv": "data/North_Korea/National_Assembly/term-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bd08b5e/data/North_Korea/National_Assembly/term-13.csv"
+          }
+        ],
+        "statement_count": 12802
+      }
+    ]
+  },
+  {
+    "name": "Northern Cyprus",
+    "country": "Northern Cyprus",
+    "code": "CY-TRNC",
+    "slug": "Northern-Cyprus",
+    "legislatures": [
+      {
+        "name": "Assembly of the Republic",
+        "slug": "Assembly",
+        "sources_directory": "data/Northern_Cyprus/Assembly/sources",
+        "popolo": "data/Northern_Cyprus/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d371446/data/Northern_Cyprus/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Northern_Cyprus/Assembly/names.csv",
+        "lastmod": "1467741041",
+        "person_count": 50,
+        "sha": "d371446",
+        "legislative_periods": [
+          {
+            "id": "term/14",
+            "name": "8th Parliament",
+            "start_date": "2013-08-12",
+            "slug": "14",
+            "csv": "data/Northern_Cyprus/Assembly/term-14.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d371446/data/Northern_Cyprus/Assembly/term-14.csv"
+          }
+        ],
+        "statement_count": 1785
+      }
+    ]
+  },
+  {
+    "name": "Northern Ireland",
+    "country": "Northern Ireland",
+    "code": "GB-NIR",
+    "slug": "Northern-Ireland",
+    "legislatures": [
+      {
+        "name": "Northern Ireland Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Northern_Ireland/Assembly/sources",
+        "popolo": "data/Northern_Ireland/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1a17862/data/Northern_Ireland/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Northern_Ireland/Assembly/names.csv",
+        "lastmod": "1467872827",
+        "person_count": 271,
+        "sha": "1a17862",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "5th Assembly",
+            "start_date": "2016-05-05",
+            "wikidata": "Q24050037",
+            "slug": "5",
+            "csv": "data/Northern_Ireland/Assembly/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1a17862/data/Northern_Ireland/Assembly/term-5.csv"
+          },
+          {
+            "end_date": "2016-03-24",
+            "id": "term/4",
+            "name": "4th Assembly",
+            "start_date": "2011-05-06",
+            "wikidata": "Q21124329",
+            "slug": "4",
+            "csv": "data/Northern_Ireland/Assembly/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1a17862/data/Northern_Ireland/Assembly/term-4.csv"
+          },
+          {
+            "end_date": "2011-03-24",
+            "id": "term/3",
+            "name": "3rd Assembly",
+            "start_date": "2007-03-09",
+            "wikidata": "Q21128152",
+            "slug": "3",
+            "csv": "data/Northern_Ireland/Assembly/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1a17862/data/Northern_Ireland/Assembly/term-3.csv"
+          },
+          {
+            "end_date": "2007-01-30",
+            "id": "term/2",
+            "name": "2nd Assembly",
+            "start_date": "2003-11-26",
+            "wikidata": "Q21128144",
+            "slug": "2",
+            "csv": "data/Northern_Ireland/Assembly/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1a17862/data/Northern_Ireland/Assembly/term-2.csv"
+          },
+          {
+            "end_date": "2003-04-28",
+            "id": "term/1",
+            "name": "1st Assembly",
+            "start_date": "1998-06-25",
+            "wikidata": "Q21128140",
+            "slug": "1",
+            "csv": "data/Northern_Ireland/Assembly/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1a17862/data/Northern_Ireland/Assembly/term-1.csv"
+          }
+        ],
+        "statement_count": 16231
+      }
+    ]
+  },
+  {
+    "name": "Northern Mariana Islands",
+    "country": "Northern Mariana Islands",
+    "code": "MP",
+    "slug": "Northern-Mariana-Islands",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House",
+        "sources_directory": "data/Northern_Mariana_Islands/House/sources",
+        "popolo": "data/Northern_Mariana_Islands/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Northern_Mariana_Islands/House/ep-popolo-v1.0.json",
+        "names": "data/Northern_Mariana_Islands/House/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 20,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/19",
+            "name": "19th Commonwealth Legislature",
+            "start_date": "2014",
+            "slug": "19",
+            "csv": "data/Northern_Mariana_Islands/House/term-19.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Northern_Mariana_Islands/House/term-19.csv"
+          }
+        ],
+        "statement_count": 825
+      }
+    ]
+  },
+  {
+    "name": "Norway",
+    "country": "Norway",
+    "code": "NO",
+    "slug": "Norway",
+    "legislatures": [
+      {
+        "name": "Storting",
+        "slug": "Storting",
+        "sources_directory": "data/Norway/Storting/sources",
+        "popolo": "data/Norway/Storting/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/ep-popolo-v1.0.json",
+        "names": "data/Norway/Storting/names.csv",
+        "lastmod": "1467814174",
+        "person_count": 1141,
+        "sha": "fc369fc",
+        "legislative_periods": [
+          {
+            "end_date": "2017-09-30",
+            "id": "term/2013-2017",
+            "name": "2013-2017",
+            "start_date": "2013-10-01",
+            "slug": "2013-2017",
+            "csv": "data/Norway/Storting/term-2013-2017.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-2013-2017.csv"
+          },
+          {
+            "end_date": "2013-09-30",
+            "id": "term/2009-2013",
+            "name": "2009-2013",
+            "start_date": "2009-10-01",
+            "slug": "2009-2013",
+            "csv": "data/Norway/Storting/term-2009-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-2009-2013.csv"
+          },
+          {
+            "end_date": "2009-09-30",
+            "id": "term/2005-2009",
+            "name": "2005-2009",
+            "start_date": "2005-10-01",
+            "slug": "2005-2009",
+            "csv": "data/Norway/Storting/term-2005-2009.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-2005-2009.csv"
+          },
+          {
+            "end_date": "2005-09-30",
+            "id": "term/2001-2005",
+            "name": "2001-2005",
+            "start_date": "2001-10-01",
+            "slug": "2001-2005",
+            "csv": "data/Norway/Storting/term-2001-2005.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-2001-2005.csv"
+          },
+          {
+            "end_date": "2001-09-30",
+            "id": "term/1997-2001",
+            "name": "1997-2001",
+            "start_date": "1997-10-01",
+            "slug": "1997-2001",
+            "csv": "data/Norway/Storting/term-1997-2001.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1997-2001.csv"
+          },
+          {
+            "end_date": "1997-09-30",
+            "id": "term/1993-97",
+            "name": "1993-97",
+            "start_date": "1993-10-01",
+            "slug": "1993-97",
+            "csv": "data/Norway/Storting/term-1993-97.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1993-97.csv"
+          },
+          {
+            "end_date": "1993-09-30",
+            "id": "term/1989-93",
+            "name": "1989-93",
+            "start_date": "1989-10-01",
+            "slug": "1989-93",
+            "csv": "data/Norway/Storting/term-1989-93.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1989-93.csv"
+          },
+          {
+            "end_date": "1989-09-30",
+            "id": "term/1985-89",
+            "name": "1985-89",
+            "start_date": "1985-10-01",
+            "slug": "1985-89",
+            "csv": "data/Norway/Storting/term-1985-89.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1985-89.csv"
+          },
+          {
+            "end_date": "1985-09-30",
+            "id": "term/1981-85",
+            "name": "1981-85",
+            "start_date": "1981-10-01",
+            "slug": "1981-85",
+            "csv": "data/Norway/Storting/term-1981-85.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1981-85.csv"
+          },
+          {
+            "end_date": "1981-09-30",
+            "id": "term/1977-81",
+            "name": "1977-81",
+            "start_date": "1977-10-01",
+            "slug": "1977-81",
+            "csv": "data/Norway/Storting/term-1977-81.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1977-81.csv"
+          },
+          {
+            "end_date": "1977-09-30",
+            "id": "term/1973-77",
+            "name": "1973-77",
+            "start_date": "1973-10-01",
+            "slug": "1973-77",
+            "csv": "data/Norway/Storting/term-1973-77.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1973-77.csv"
+          },
+          {
+            "end_date": "1973-09-30",
+            "id": "term/1969-73",
+            "name": "1969-73",
+            "start_date": "1969-10-01",
+            "slug": "1969-73",
+            "csv": "data/Norway/Storting/term-1969-73.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1969-73.csv"
+          },
+          {
+            "end_date": "1969-09-30",
+            "id": "term/1965-69",
+            "name": "1965-69",
+            "start_date": "1965-10-01",
+            "slug": "1965-69",
+            "csv": "data/Norway/Storting/term-1965-69.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1965-69.csv"
+          },
+          {
+            "end_date": "1965-09-30",
+            "id": "term/1961-65",
+            "name": "1961-65",
+            "start_date": "1961-10-01",
+            "slug": "1961-65",
+            "csv": "data/Norway/Storting/term-1961-65.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1961-65.csv"
+          },
+          {
+            "end_date": "1961-09-30",
+            "id": "term/1958-61",
+            "name": "1958-61",
+            "start_date": "1958-01-11",
+            "slug": "1958-61",
+            "csv": "data/Norway/Storting/term-1958-61.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1958-61.csv"
+          },
+          {
+            "end_date": "1958-01-10",
+            "id": "term/1954-57",
+            "name": "1954-57",
+            "start_date": "1954-01-11",
+            "slug": "1954-57",
+            "csv": "data/Norway/Storting/term-1954-57.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1954-57.csv"
+          },
+          {
+            "end_date": "1954-01-10",
+            "id": "term/1950-53",
+            "name": "1950-53",
+            "start_date": "1950-01-11",
+            "slug": "1950-53",
+            "csv": "data/Norway/Storting/term-1950-53.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1950-53.csv"
+          },
+          {
+            "end_date": "1950-01-10",
+            "id": "term/1945-49",
+            "name": "1945-49",
+            "start_date": "1945-12-04",
+            "slug": "1945-49",
+            "csv": "data/Norway/Storting/term-1945-49.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fc369fc/data/Norway/Storting/term-1945-49.csv"
+          }
+        ],
+        "statement_count": 77596
+      }
+    ]
+  },
+  {
+    "name": "Oman",
+    "country": "Oman",
+    "code": "OM",
+    "slug": "Oman",
+    "legislatures": [
+      {
+        "name": "Majlis al-Shura",
+        "slug": "Majlis",
+        "sources_directory": "data/Oman/Majlis/sources",
+        "popolo": "data/Oman/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/682fc1f/data/Oman/Majlis/ep-popolo-v1.0.json",
+        "names": "data/Oman/Majlis/names.csv",
+        "lastmod": "1467813358",
+        "person_count": 84,
+        "sha": "682fc1f",
+        "legislative_periods": [
+          {
+            "end_date": "2015-10-28",
+            "id": "term/7",
+            "name": "7th Period",
+            "start_date": "2011-10-31",
+            "slug": "7",
+            "csv": "data/Oman/Majlis/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/682fc1f/data/Oman/Majlis/term-7.csv"
+          }
+        ],
+        "statement_count": 1514
+      }
+    ]
+  },
+  {
+    "name": "Pakistan",
+    "country": "Pakistan",
+    "code": "PK",
+    "slug": "Pakistan",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Pakistan/Assembly/sources",
+        "popolo": "data/Pakistan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/05780ac/data/Pakistan/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Pakistan/Assembly/names.csv",
+        "lastmod": "1467002522",
+        "person_count": 347,
+        "sha": "05780ac",
+        "legislative_periods": [
+          {
+            "id": "term/14",
+            "name": "14th National Assembly",
+            "start_date": "2013-06-01",
+            "slug": "14",
+            "csv": "data/Pakistan/Assembly/term-14.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/05780ac/data/Pakistan/Assembly/term-14.csv"
+          }
+        ],
+        "statement_count": 12872
+      }
+    ]
+  },
+  {
+    "name": "Palau",
+    "country": "Palau",
+    "code": "PW",
+    "slug": "Palau",
+    "legislatures": [
+      {
+        "name": "House of Delegates",
+        "slug": "House-of-Delegates",
+        "sources_directory": "data/Palau/House_of_Delegates/sources",
+        "popolo": "data/Palau/House_of_Delegates/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ec7c312/data/Palau/House_of_Delegates/ep-popolo-v1.0.json",
+        "names": "data/Palau/House_of_Delegates/names.csv",
+        "lastmod": "1465854470",
+        "person_count": 16,
+        "sha": "ec7c312",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "Ninth Olbiil Era Kelulau",
+            "start_date": "2013-01-17",
+            "slug": "2012",
+            "csv": "data/Palau/House_of_Delegates/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ec7c312/data/Palau/House_of_Delegates/term-2012.csv"
+          }
+        ],
+        "statement_count": 619
+      }
+    ]
+  },
+  {
+    "name": "Panama",
+    "country": "Panama",
+    "code": "PA",
+    "slug": "Panama",
+    "legislatures": [
+      {
+        "name": "Cámara de Representantes",
+        "slug": "Assembly",
+        "sources_directory": "data/Panama/Assembly/sources",
+        "popolo": "data/Panama/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c50bbc3/data/Panama/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Panama/Assembly/names.csv",
+        "lastmod": "1466582991",
+        "person_count": 74,
+        "sha": "c50bbc3",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "2014–",
+            "start_date": "2014-07-01",
+            "slug": "2014",
+            "csv": "data/Panama/Assembly/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c50bbc3/data/Panama/Assembly/term-2014.csv"
+          }
+        ],
+        "statement_count": 1715
+      }
+    ]
+  },
+  {
+    "name": "Papua New Guinea",
+    "country": "Papua New Guinea",
+    "code": "PG",
+    "slug": "Papua-New-Guinea",
+    "legislatures": [
+      {
+        "name": "National Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Papua_New_Guinea/Parliament/sources",
+        "popolo": "data/Papua_New_Guinea/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69b3322/data/Papua_New_Guinea/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Papua_New_Guinea/Parliament/names.csv",
+        "lastmod": "1466353748",
+        "person_count": 111,
+        "sha": "69b3322",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012-2017",
+            "start_date": "2012-08-03",
+            "slug": "2012",
+            "csv": "data/Papua_New_Guinea/Parliament/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69b3322/data/Papua_New_Guinea/Parliament/term-2012.csv"
+          }
+        ],
+        "statement_count": 3420
+      }
+    ]
+  },
+  {
+    "name": "Paraguay",
+    "country": "Paraguay",
+    "code": "PY",
+    "slug": "Paraguay",
+    "legislatures": [
+      {
+        "name": "Chamber of Deputies",
+        "slug": "Deputies",
+        "sources_directory": "data/Paraguay/Deputies/sources",
+        "popolo": "data/Paraguay/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e3fa620/data/Paraguay/Deputies/ep-popolo-v1.0.json",
+        "names": "data/Paraguay/Deputies/names.csv",
+        "lastmod": "1467732688",
+        "person_count": 80,
+        "sha": "e3fa620",
+        "legislative_periods": [
+          {
+            "id": "term/2013",
+            "name": "2013–2018",
+            "start_date": "2013-04-21",
+            "slug": "2013",
+            "csv": "data/Paraguay/Deputies/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e3fa620/data/Paraguay/Deputies/term-2013.csv"
+          }
+        ],
+        "statement_count": 2176
+      }
+    ]
+  },
+  {
+    "name": "Peru",
+    "country": "Peru",
+    "code": "PE",
+    "slug": "Peru",
+    "legislatures": [
+      {
+        "name": "Congress",
+        "slug": "Congreso",
+        "sources_directory": "data/Peru/Congreso/sources",
+        "popolo": "data/Peru/Congreso/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ccbe02c/data/Peru/Congreso/ep-popolo-v1.0.json",
+        "names": "data/Peru/Congreso/names.csv",
+        "lastmod": "1466583404",
+        "person_count": 127,
+        "sha": "ccbe02c",
+        "legislative_periods": [
+          {
+            "end_date": "2016-07-26",
+            "id": "term/2011",
+            "name": "Congress of 2011–2016",
+            "start_date": "2011-07-27",
+            "slug": "2011",
+            "csv": "data/Peru/Congreso/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ccbe02c/data/Peru/Congreso/term-2011.csv"
+          }
+        ],
+        "statement_count": 6010
+      }
+    ]
+  },
+  {
+    "name": "Philippines",
+    "country": "Philippines",
+    "code": "PH",
+    "slug": "Philippines",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House",
+        "sources_directory": "data/Philippines/House/sources",
+        "popolo": "data/Philippines/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba933fa/data/Philippines/House/ep-popolo-v1.0.json",
+        "names": "data/Philippines/House/names.csv",
+        "lastmod": "1467609052",
+        "person_count": 295,
+        "sha": "ba933fa",
+        "legislative_periods": [
+          {
+            "end_date": "2016-06-30",
+            "id": "term/16",
+            "name": "16th Congress of the Philippines",
+            "start_date": "2013-06-30",
+            "slug": "16",
+            "csv": "data/Philippines/House/term-16.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba933fa/data/Philippines/House/term-16.csv"
+          }
+        ],
+        "statement_count": 8632
+      }
+    ]
+  },
+  {
+    "name": "Pitcairn",
+    "country": "Pitcairn",
+    "code": "PN",
+    "slug": "Pitcairn",
+    "legislatures": [
+      {
+        "name": "Island Council",
+        "slug": "Island-Council",
+        "sources_directory": "data/Pitcairn/Island_Council/sources",
+        "popolo": "data/Pitcairn/Island_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Pitcairn/Island_Council/ep-popolo-v1.0.json",
+        "names": "data/Pitcairn/Island_Council/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 12,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/2013",
+            "name": "2013–",
+            "start_date": "2013-11-12",
+            "slug": "2013",
+            "csv": "data/Pitcairn/Island_Council/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Pitcairn/Island_Council/term-2013.csv"
+          },
+          {
+            "end_date": "2013-11-11",
+            "id": "term/2011",
+            "name": "2011–2013",
+            "start_date": "2011-12-12",
+            "slug": "2011",
+            "csv": "data/Pitcairn/Island_Council/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Pitcairn/Island_Council/term-2011.csv"
+          },
+          {
+            "end_date": "2011-12-11",
+            "id": "term/2009",
+            "name": "2009–2011",
+            "start_date": "2009-12-11",
+            "slug": "2009",
+            "csv": "data/Pitcairn/Island_Council/term-2009.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Pitcairn/Island_Council/term-2009.csv"
+          }
+        ],
+        "statement_count": 645
+      }
+    ]
+  },
+  {
+    "name": "Poland",
+    "country": "Poland",
+    "code": "PL",
+    "slug": "Poland",
+    "legislatures": [
+      {
+        "name": "Sejm",
+        "slug": "Sejm",
+        "sources_directory": "data/Poland/Sejm/sources",
+        "popolo": "data/Poland/Sejm/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/049e0eb/data/Poland/Sejm/ep-popolo-v1.0.json",
+        "names": "data/Poland/Sejm/names.csv",
+        "lastmod": "1467961549",
+        "person_count": 2179,
+        "sha": "049e0eb",
+        "legislative_periods": [
+          {
+            "id": "term/8",
+            "name": "VIII kadencja",
+            "start_date": "2015-11-12",
+            "slug": "8",
+            "csv": "data/Poland/Sejm/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/049e0eb/data/Poland/Sejm/term-8.csv"
+          },
+          {
+            "end_date": "2015-11-11",
+            "id": "term/7",
+            "name": "VII kadencja",
+            "start_date": "2011-11-08",
+            "slug": "7",
+            "csv": "data/Poland/Sejm/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/049e0eb/data/Poland/Sejm/term-7.csv"
+          },
+          {
+            "end_date": "2011-11-07",
+            "id": "term/6",
+            "name": "VI kadencja",
+            "start_date": "2007-11-05",
+            "slug": "6",
+            "csv": "data/Poland/Sejm/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/049e0eb/data/Poland/Sejm/term-6.csv"
+          },
+          {
+            "end_date": "2007-11-04",
+            "id": "term/5",
+            "name": "V kadencja",
+            "start_date": "2005-10-19",
+            "slug": "5",
+            "csv": "data/Poland/Sejm/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/049e0eb/data/Poland/Sejm/term-5.csv"
+          },
+          {
+            "end_date": "2005-10-18",
+            "id": "term/4",
+            "name": "IV kadencja",
+            "start_date": "2001-10-19",
+            "slug": "4",
+            "csv": "data/Poland/Sejm/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/049e0eb/data/Poland/Sejm/term-4.csv"
+          },
+          {
+            "end_date": "2001-10-18",
+            "id": "term/3",
+            "name": "III kadencja",
+            "start_date": "1997-10-20",
+            "slug": "3",
+            "csv": "data/Poland/Sejm/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/049e0eb/data/Poland/Sejm/term-3.csv"
+          },
+          {
+            "end_date": "1997-10-19",
+            "id": "term/2",
+            "name": "II kadencja",
+            "start_date": "1993-09-19",
+            "slug": "2",
+            "csv": "data/Poland/Sejm/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/049e0eb/data/Poland/Sejm/term-2.csv"
+          },
+          {
+            "end_date": "1993-09-18",
+            "id": "term/1",
+            "name": "I kadencja",
+            "start_date": "1991-11-25",
+            "slug": "1",
+            "csv": "data/Poland/Sejm/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/049e0eb/data/Poland/Sejm/term-1.csv"
+          }
+        ],
+        "statement_count": 122934
+      }
+    ]
+  },
+  {
+    "name": "Portugal",
+    "country": "Portugal",
+    "code": "PT",
+    "slug": "Portugal",
+    "legislatures": [
+      {
+        "name": "Assembleia da República",
+        "slug": "Assembly",
+        "sources_directory": "data/Portugal/Assembly/sources",
+        "popolo": "data/Portugal/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Portugal/Assembly/names.csv",
+        "lastmod": "1467567660",
+        "person_count": 1272,
+        "sha": "7acdc7a",
+        "legislative_periods": [
+          {
+            "id": "term/13",
+            "name": "13ª Legislatura",
+            "start_date": "2015-10-23",
+            "slug": "13",
+            "csv": "data/Portugal/Assembly/term-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/term-13.csv"
+          },
+          {
+            "end_date": "2015-10-22",
+            "id": "term/12",
+            "name": "12ª Legislatura",
+            "start_date": "2011-06-20",
+            "slug": "12",
+            "csv": "data/Portugal/Assembly/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/term-12.csv"
+          },
+          {
+            "end_date": "2011-06-19",
+            "id": "term/11",
+            "name": "11ª Legislatura",
+            "start_date": "2009-10-15",
+            "slug": "11",
+            "csv": "data/Portugal/Assembly/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/term-11.csv"
+          },
+          {
+            "end_date": "2009-09-14",
+            "id": "term/10",
+            "name": "10ª Legislatura",
+            "start_date": "2005-03-10",
+            "slug": "10",
+            "csv": "data/Portugal/Assembly/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/term-10.csv"
+          },
+          {
+            "end_date": "2005-03-09",
+            "id": "term/9",
+            "name": "9ª Legislatura",
+            "start_date": "2002-04-05",
+            "slug": "9",
+            "csv": "data/Portugal/Assembly/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/term-9.csv"
+          },
+          {
+            "end_date": "2002-04-04",
+            "id": "term/8",
+            "name": "8ª Legislatura",
+            "start_date": "1999-10-25",
+            "slug": "8",
+            "csv": "data/Portugal/Assembly/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/term-8.csv"
+          },
+          {
+            "end_date": "1999-10-14",
+            "id": "term/7",
+            "name": "7ª Legislatura",
+            "start_date": "1995-10-27",
+            "slug": "7",
+            "csv": "data/Portugal/Assembly/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/term-7.csv"
+          },
+          {
+            "end_date": "1995-10-26",
+            "id": "term/6",
+            "name": "6ª Legislatura",
+            "start_date": "1991-11-04",
+            "slug": "6",
+            "csv": "data/Portugal/Assembly/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/term-6.csv"
+          },
+          {
+            "end_date": "1991-11-03",
+            "id": "term/5",
+            "name": "5ª Legislatura",
+            "start_date": "1987-08-13",
+            "slug": "5",
+            "csv": "data/Portugal/Assembly/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/term-5.csv"
+          },
+          {
+            "end_date": "1987-08-12",
+            "id": "term/4",
+            "name": "4ª Legislatura",
+            "start_date": "1985-11-04",
+            "slug": "4",
+            "csv": "data/Portugal/Assembly/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/term-4.csv"
+          },
+          {
+            "end_date": "1985-11-03",
+            "id": "term/3",
+            "name": "3ª Legislatura",
+            "start_date": "1983-05-31",
+            "slug": "3",
+            "csv": "data/Portugal/Assembly/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/term-3.csv"
+          },
+          {
+            "end_date": "1983-05-30",
+            "id": "term/2",
+            "name": "2ª Legislatura",
+            "start_date": "1980-01-03",
+            "slug": "2",
+            "csv": "data/Portugal/Assembly/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/term-2.csv"
+          },
+          {
+            "end_date": "1980-01-02",
+            "id": "term/1",
+            "name": "1ª Legislatura",
+            "start_date": "1976-03-06",
+            "slug": "1",
+            "csv": "data/Portugal/Assembly/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7acdc7a/data/Portugal/Assembly/term-1.csv"
+          }
+        ],
+        "statement_count": 40420
+      }
+    ]
+  },
+  {
+    "name": "Puerto Rico",
+    "country": "Puerto Rico",
+    "code": "PR",
+    "slug": "Puerto-Rico",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House-of-Representatives",
+        "sources_directory": "data/Puerto_Rico/House_of_Representatives/sources",
+        "popolo": "data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6c83b2/data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
+        "names": "data/Puerto_Rico/House_of_Representatives/names.csv",
+        "lastmod": "1466584790",
+        "person_count": 53,
+        "sha": "b6c83b2",
+        "legislative_periods": [
+          {
+            "end_date": "2017-01-08",
+            "id": "term/29",
+            "name": "29th House of Representatives",
+            "start_date": "2013-01-14",
+            "slug": "29",
+            "csv": "data/Puerto_Rico/House_of_Representatives/term-29.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6c83b2/data/Puerto_Rico/House_of_Representatives/term-29.csv"
+          }
+        ],
+        "statement_count": 3083
+      }
+    ]
+  },
+  {
+    "name": "Romania",
+    "country": "Romania",
+    "code": "RO",
+    "slug": "Romania",
+    "legislatures": [
+      {
+        "name": "Chamber of Deputies",
+        "slug": "Deputies",
+        "sources_directory": "data/Romania/Deputies/sources",
+        "popolo": "data/Romania/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2b4f6/data/Romania/Deputies/ep-popolo-v1.0.json",
+        "names": "data/Romania/Deputies/names.csv",
+        "lastmod": "1466811571",
+        "person_count": 417,
+        "sha": "ef2b4f6",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "7th Legislature",
+            "start_date": "2012-12-12",
+            "slug": "2012",
+            "csv": "data/Romania/Deputies/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2b4f6/data/Romania/Deputies/term-2012.csv"
+          }
+        ],
+        "statement_count": 22197
+      }
+    ]
+  },
+  {
+    "name": "Russia",
+    "country": "Russia",
+    "code": "RU",
+    "slug": "Russia",
+    "legislatures": [
+      {
+        "name": "Duma",
+        "slug": "Duma",
+        "sources_directory": "data/Russia/Duma/sources",
+        "popolo": "data/Russia/Duma/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4fd6f5a/data/Russia/Duma/ep-popolo-v1.0.json",
+        "names": "data/Russia/Duma/names.csv",
+        "lastmod": "1467919201",
+        "person_count": 469,
+        "sha": "4fd6f5a",
+        "legislative_periods": [
+          {
+            "id": "term/6",
+            "name": "6th Convocation",
+            "start_date": "2011-12-04",
+            "slug": "6",
+            "csv": "data/Russia/Duma/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4fd6f5a/data/Russia/Duma/term-6.csv"
+          }
+        ],
+        "statement_count": 19588
+      }
+    ]
+  },
+  {
+    "name": "Rwanda",
+    "country": "Rwanda",
+    "code": "RW",
+    "slug": "Rwanda",
+    "legislatures": [
+      {
+        "name": "Chamber of Deputies",
+        "slug": "Deputies",
+        "sources_directory": "data/Rwanda/Deputies/sources",
+        "popolo": "data/Rwanda/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d42dbbb/data/Rwanda/Deputies/ep-popolo-v1.0.json",
+        "names": "data/Rwanda/Deputies/names.csv",
+        "lastmod": "1466148440",
+        "person_count": 77,
+        "sha": "d42dbbb",
+        "legislative_periods": [
+          {
+            "id": "term/3",
+            "name": "3rd Legislature",
+            "start_date": "2013-10-05",
+            "slug": "3",
+            "csv": "data/Rwanda/Deputies/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d42dbbb/data/Rwanda/Deputies/term-3.csv"
+          }
+        ],
+        "statement_count": 1740
+      }
+    ]
+  },
+  {
+    "name": "Saint Barthélemy",
+    "country": "Saint Barthélemy",
+    "code": "BL",
+    "slug": "Saint-Barthelemy",
+    "legislatures": [
+      {
+        "name": "Territorial Council",
+        "slug": "Council",
+        "sources_directory": "data/Saint_Barthelemy/Council/sources",
+        "popolo": "data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8ca13fb/data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
+        "names": "data/Saint_Barthelemy/Council/names.csv",
+        "lastmod": "1467825054",
+        "person_count": 19,
+        "sha": "8ca13fb",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012–2017",
+            "start_date": "2012",
+            "slug": "2012",
+            "csv": "data/Saint_Barthelemy/Council/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8ca13fb/data/Saint_Barthelemy/Council/term-2012.csv"
+          }
+        ],
+        "statement_count": 333
+      }
+    ]
+  },
+  {
+    "name": "Saint Helena",
+    "country": "Saint Helena",
+    "code": "SH",
+    "slug": "Saint-Helena",
+    "legislatures": [
+      {
+        "name": "Legislative Council",
+        "slug": "Legislative-Council",
+        "sources_directory": "data/Saint_Helena/Legislative_Council/sources",
+        "popolo": "data/Saint_Helena/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47ad82f/data/Saint_Helena/Legislative_Council/ep-popolo-v1.0.json",
+        "names": "data/Saint_Helena/Legislative_Council/names.csv",
+        "lastmod": "1467888662",
+        "person_count": 12,
+        "sha": "47ad82f",
+        "legislative_periods": [
+          {
+            "id": "term/2013",
+            "name": "2013–",
+            "start_date": "2013-07-17",
+            "slug": "2013",
+            "csv": "data/Saint_Helena/Legislative_Council/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47ad82f/data/Saint_Helena/Legislative_Council/term-2013.csv"
+          }
+        ],
+        "statement_count": 538
+      }
+    ]
+  },
+  {
+    "name": "Saint Kitts and Nevis",
+    "country": "Saint Kitts and Nevis",
+    "code": "KN",
+    "slug": "Saint-Kitts-and-Nevis",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Saint_Kitts_and_Nevis/Assembly/sources",
+        "popolo": "data/Saint_Kitts_and_Nevis/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb8f2db/data/Saint_Kitts_and_Nevis/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Saint_Kitts_and_Nevis/Assembly/names.csv",
+        "lastmod": "1467888499",
+        "person_count": 30,
+        "sha": "eb8f2db",
+        "legislative_periods": [
+          {
+            "id": "term/2015",
+            "name": "8th National Assembly",
+            "start_date": "2015-05-14",
+            "slug": "2015",
+            "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb8f2db/data/Saint_Kitts_and_Nevis/Assembly/term-2015.csv"
+          },
+          {
+            "end_date": "2015-01-16",
+            "id": "term/2010",
+            "name": "7th National Assembly",
+            "start_date": "2010-03-10",
+            "slug": "2010",
+            "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2010.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb8f2db/data/Saint_Kitts_and_Nevis/Assembly/term-2010.csv"
+          },
+          {
+            "end_date": "2010",
+            "id": "term/2004",
+            "name": "6th National Assembly",
+            "start_date": "2004-10-26",
+            "slug": "2004",
+            "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2004.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb8f2db/data/Saint_Kitts_and_Nevis/Assembly/term-2004.csv"
+          },
+          {
+            "end_date": "2004",
+            "id": "term/2000",
+            "name": "5th National Assembly",
+            "start_date": "2000",
+            "slug": "2000",
+            "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2000.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb8f2db/data/Saint_Kitts_and_Nevis/Assembly/term-2000.csv"
+          },
+          {
+            "end_date": "2000",
+            "id": "term/1995",
+            "name": "4th National Assembly",
+            "start_date": "1995",
+            "slug": "1995",
+            "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1995.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb8f2db/data/Saint_Kitts_and_Nevis/Assembly/term-1995.csv"
+          },
+          {
+            "end_date": "1995",
+            "id": "term/1993",
+            "name": "3rd National Assembly",
+            "start_date": "1993",
+            "slug": "1993",
+            "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1993.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb8f2db/data/Saint_Kitts_and_Nevis/Assembly/term-1993.csv"
+          },
+          {
+            "end_date": "1993",
+            "id": "term/1989",
+            "name": "2nd National Assembly",
+            "start_date": "1989",
+            "slug": "1989",
+            "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1989.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb8f2db/data/Saint_Kitts_and_Nevis/Assembly/term-1989.csv"
+          },
+          {
+            "end_date": "1989",
+            "id": "term/1984",
+            "name": "1st National Assembly",
+            "start_date": "1984",
+            "slug": "1984",
+            "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1984.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb8f2db/data/Saint_Kitts_and_Nevis/Assembly/term-1984.csv"
+          }
+        ],
+        "statement_count": 1545
+      }
+    ]
+  },
+  {
+    "name": "Saint Lucia",
+    "country": "Saint Lucia",
+    "code": "LC",
+    "slug": "Saint-Lucia",
+    "legislatures": [
+      {
+        "name": "House of Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Saint_Lucia/Assembly/sources",
+        "popolo": "data/Saint_Lucia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/34880bd/data/Saint_Lucia/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Saint_Lucia/Assembly/names.csv",
+        "lastmod": "1467881668",
+        "person_count": 23,
+        "sha": "34880bd",
+        "legislative_periods": [
+          {
+            "end_date": "2016-06-05",
+            "id": "term/9",
+            "name": "9th Parliament",
+            "start_date": "2012-01-05",
+            "slug": "9",
+            "csv": "data/Saint_Lucia/Assembly/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/34880bd/data/Saint_Lucia/Assembly/term-9.csv"
+          },
+          {
+            "end_date": "2011-11-27",
+            "id": "term/8",
+            "name": "8th Parliament",
+            "start_date": "2007-01-09",
+            "slug": "8",
+            "csv": "data/Saint_Lucia/Assembly/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/34880bd/data/Saint_Lucia/Assembly/term-8.csv"
+          }
+        ],
+        "statement_count": 1703
+      }
+    ]
+  },
+  {
+    "name": "Saint Martin",
+    "country": "Saint Martin",
+    "code": "MF",
+    "slug": "Saint-Martin",
+    "legislatures": [
+      {
+        "name": "Territorial Council",
+        "slug": "Council",
+        "sources_directory": "data/Saint_Martin/Council/sources",
+        "popolo": "data/Saint_Martin/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7abc5b0/data/Saint_Martin/Council/ep-popolo-v1.0.json",
+        "names": "data/Saint_Martin/Council/names.csv",
+        "lastmod": "1467882173",
+        "person_count": 23,
+        "sha": "7abc5b0",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012–",
+            "start_date": "2012",
+            "slug": "2012",
+            "csv": "data/Saint_Martin/Council/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7abc5b0/data/Saint_Martin/Council/term-2012.csv"
+          }
+        ],
+        "statement_count": 371
+      }
+    ]
+  },
+  {
+    "name": "Saint Pierre and Miquelon",
+    "country": "Saint Pierre and Miquelon",
+    "code": "PM",
+    "slug": "Saint-Pierre-and-Miquelon",
+    "legislatures": [
+      {
+        "name": "Territorial Council",
+        "slug": "Territorial-Council",
+        "sources_directory": "data/Saint_Pierre_and_Miquelon/Territorial_Council/sources",
+        "popolo": "data/Saint_Pierre_and_Miquelon/Territorial_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b4e0b93/data/Saint_Pierre_and_Miquelon/Territorial_Council/ep-popolo-v1.0.json",
+        "names": "data/Saint_Pierre_and_Miquelon/Territorial_Council/names.csv",
+        "lastmod": "1467884773",
+        "person_count": 31,
+        "sha": "b4e0b93",
+        "legislative_periods": [
+          {
+            "end_date": "2017",
+            "id": "term/2012",
+            "name": "2nd Territorial Council",
+            "start_date": "2012-03",
+            "slug": "2012",
+            "csv": "data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b4e0b93/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2012.csv"
+          },
+          {
+            "end_date": "2012-03",
+            "id": "term/2006",
+            "name": "1st Territorial Council",
+            "start_date": "2006-03",
+            "slug": "2006",
+            "csv": "data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2006.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b4e0b93/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2006.csv"
+          }
+        ],
+        "statement_count": 709
+      }
+    ]
+  },
+  {
+    "name": "Saint Vincent and the Grenadines",
+    "country": "Saint Vincent and the Grenadines",
+    "code": "VC",
+    "slug": "Saint-Vincent-and-the-Grenadines",
+    "legislatures": [
+      {
+        "name": "House of Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Saint_Vincent_and_the_Grenadines/Assembly/sources",
+        "popolo": "data/Saint_Vincent_and_the_Grenadines/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8045cf6/data/Saint_Vincent_and_the_Grenadines/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Saint_Vincent_and_the_Grenadines/Assembly/names.csv",
+        "lastmod": "1465901545",
+        "person_count": 15,
+        "sha": "8045cf6",
+        "legislative_periods": [
+          {
+            "end_date": "2015-11-07",
+            "id": "term/8",
+            "name": "8th Vincentian Assembly",
+            "start_date": "2010-12-30",
+            "slug": "8",
+            "csv": "data/Saint_Vincent_and_the_Grenadines/Assembly/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8045cf6/data/Saint_Vincent_and_the_Grenadines/Assembly/term-8.csv"
+          }
+        ],
+        "statement_count": 404
+      }
+    ]
+  },
+  {
+    "name": "Samoa",
+    "country": "Samoa",
+    "code": "WS",
+    "slug": "Samoa",
+    "legislatures": [
+      {
+        "name": "Fono",
+        "slug": "Parliament",
+        "sources_directory": "data/Samoa/Parliament/sources",
+        "popolo": "data/Samoa/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7e20ff7/data/Samoa/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Samoa/Parliament/names.csv",
+        "lastmod": "1467183125",
+        "person_count": 49,
+        "sha": "7e20ff7",
+        "legislative_periods": [
+          {
+            "end_date": "2016-01-29",
+            "id": "term/15",
+            "name": "15th Parliament",
+            "start_date": "2011-03-18",
+            "slug": "15",
+            "csv": "data/Samoa/Parliament/term-15.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7e20ff7/data/Samoa/Parliament/term-15.csv"
+          }
+        ],
+        "statement_count": 1751
+      }
+    ]
+  },
+  {
+    "name": "San Marino",
+    "country": "San Marino",
+    "code": "SM",
+    "slug": "San-Marino",
+    "legislatures": [
+      {
+        "name": "Grand and General Council",
+        "slug": "Council",
+        "sources_directory": "data/San_Marino/Council/sources",
+        "popolo": "data/San_Marino/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be63114/data/San_Marino/Council/ep-popolo-v1.0.json",
+        "names": "data/San_Marino/Council/names.csv",
+        "lastmod": "1467552608",
+        "person_count": 62,
+        "sha": "be63114",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "Council 2012–",
+            "start_date": "2012-12-26",
+            "slug": "2012",
+            "csv": "data/San_Marino/Council/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be63114/data/San_Marino/Council/term-2012.csv"
+          }
+        ],
+        "statement_count": 3617
+      }
+    ]
+  },
+  {
+    "name": "Sark",
+    "country": "Sark",
+    "code": "GG-SRK",
+    "slug": "Sark",
+    "legislatures": [
+      {
+        "name": "Chief Pleas",
+        "slug": "Chief-Pleas",
+        "sources_directory": "data/Sark/Chief_Pleas/sources",
+        "popolo": "data/Sark/Chief_Pleas/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/229bb39/data/Sark/Chief_Pleas/ep-popolo-v1.0.json",
+        "names": "data/Sark/Chief_Pleas/names.csv",
+        "lastmod": "1467880349",
+        "person_count": 46,
+        "sha": "229bb39",
+        "legislative_periods": [
+          {
+            "end_date": "2017",
+            "id": "term/2015",
+            "name": "2015-2017",
+            "start_date": "2015",
+            "slug": "2015",
+            "csv": "data/Sark/Chief_Pleas/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/229bb39/data/Sark/Chief_Pleas/term-2015.csv"
+          },
+          {
+            "end_date": "2015",
+            "id": "term/2013",
+            "name": "2013-2015",
+            "start_date": "2013",
+            "slug": "2013",
+            "csv": "data/Sark/Chief_Pleas/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/229bb39/data/Sark/Chief_Pleas/term-2013.csv"
+          },
+          {
+            "end_date": "2013",
+            "id": "term/2011",
+            "name": "2011-2013",
+            "start_date": "2011",
+            "slug": "2011",
+            "csv": "data/Sark/Chief_Pleas/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/229bb39/data/Sark/Chief_Pleas/term-2011.csv"
+          },
+          {
+            "end_date": "2011",
+            "id": "term/2009",
+            "name": "2009-2011",
+            "start_date": "2009",
+            "slug": "2009",
+            "csv": "data/Sark/Chief_Pleas/term-2009.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/229bb39/data/Sark/Chief_Pleas/term-2009.csv"
+          }
+        ],
+        "statement_count": 1195
+      }
+    ]
+  },
+  {
+    "name": "Saudi Arabia",
+    "country": "Saudi Arabia",
+    "code": "SA",
+    "slug": "Saudi-Arabia",
+    "legislatures": [
+      {
+        "name": "Shura Council",
+        "slug": "Shura",
+        "sources_directory": "data/Saudi_Arabia/Shura/sources",
+        "popolo": "data/Saudi_Arabia/Shura/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/34c9f9d/data/Saudi_Arabia/Shura/ep-popolo-v1.0.json",
+        "names": "data/Saudi_Arabia/Shura/names.csv",
+        "lastmod": "1466353770",
+        "person_count": 148,
+        "sha": "34c9f9d",
+        "legislative_periods": [
+          {
+            "id": "term/6",
+            "name": "6th Shura",
+            "start_date": "2013-02-24",
+            "slug": "6",
+            "csv": "data/Saudi_Arabia/Shura/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/34c9f9d/data/Saudi_Arabia/Shura/term-6.csv"
+          }
+        ],
+        "statement_count": 1959
+      }
+    ]
+  },
+  {
+    "name": "Scotland",
+    "country": "Scotland",
+    "code": "GB-SCT",
+    "slug": "Scotland",
+    "legislatures": [
+      {
+        "name": "Scottish Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Scotland/Parliament/sources",
+        "popolo": "data/Scotland/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5cc751d/data/Scotland/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Scotland/Parliament/names.csv",
+        "lastmod": "1467735656",
+        "person_count": 301,
+        "sha": "5cc751d",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "5th Parliament",
+            "start_date": "2016-05-05",
+            "slug": "5",
+            "csv": "data/Scotland/Parliament/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5cc751d/data/Scotland/Parliament/term-5.csv"
+          },
+          {
+            "end_date": "2016-03-24",
+            "id": "term/4",
+            "name": "4th Parliament",
+            "start_date": "2011-05-06",
+            "slug": "4",
+            "csv": "data/Scotland/Parliament/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5cc751d/data/Scotland/Parliament/term-4.csv"
+          },
+          {
+            "end_date": "2011-05-04",
+            "id": "term/3",
+            "name": "3rd Parliament",
+            "start_date": "2007-05-03",
+            "slug": "3",
+            "csv": "data/Scotland/Parliament/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5cc751d/data/Scotland/Parliament/term-3.csv"
+          },
+          {
+            "end_date": "2007-04-02",
+            "id": "term/2",
+            "name": "2nd Parliament",
+            "start_date": "2003-05-01",
+            "slug": "2",
+            "csv": "data/Scotland/Parliament/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5cc751d/data/Scotland/Parliament/term-2.csv"
+          },
+          {
+            "end_date": "2003-03-31",
+            "id": "term/1",
+            "name": "1st Parliament",
+            "start_date": "1999-05-06",
+            "slug": "1",
+            "csv": "data/Scotland/Parliament/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5cc751d/data/Scotland/Parliament/term-1.csv"
+          }
+        ],
+        "statement_count": 18144
+      }
+    ]
+  },
+  {
+    "name": "Senegal",
+    "country": "Senegal",
+    "code": "SN",
+    "slug": "Senegal",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Senegal/Assembly/sources",
+        "popolo": "data/Senegal/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b10fcf0/data/Senegal/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Senegal/Assembly/names.csv",
+        "lastmod": "1466150765",
+        "person_count": 149,
+        "sha": "b10fcf0",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012–",
+            "start_date": "2012-07-30",
+            "slug": "2012",
+            "csv": "data/Senegal/Assembly/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b10fcf0/data/Senegal/Assembly/term-2012.csv"
+          }
+        ],
+        "statement_count": 2208
+      }
+    ]
+  },
+  {
+    "name": "Serbia",
+    "country": "Serbia",
+    "code": "RS",
+    "slug": "Serbia",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "National-Assembly",
+        "sources_directory": "data/Serbia/National_Assembly/sources",
+        "popolo": "data/Serbia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/875c994/data/Serbia/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Serbia/National_Assembly/names.csv",
+        "lastmod": "1467881619",
+        "person_count": 385,
+        "sha": "875c994",
+        "legislative_periods": [
+          {
+            "id": "term/11",
+            "name": "11th legislature",
+            "start_date": "2016-06-03",
+            "slug": "11",
+            "csv": "data/Serbia/National_Assembly/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/875c994/data/Serbia/National_Assembly/term-11.csv"
+          },
+          {
+            "end_date": "2016-06-03",
+            "id": "term/10",
+            "name": "10th legislature",
+            "start_date": "2014-05-16",
+            "slug": "10",
+            "csv": "data/Serbia/National_Assembly/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/875c994/data/Serbia/National_Assembly/term-10.csv"
+          }
+        ],
+        "statement_count": 7807
+      }
+    ]
+  },
+  {
+    "name": "Seychelles",
+    "country": "Seychelles",
+    "code": "SC",
+    "slug": "Seychelles",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Seychelles/Assembly/sources",
+        "popolo": "data/Seychelles/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a613908/data/Seychelles/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Seychelles/Assembly/names.csv",
+        "lastmod": "1466580496",
+        "person_count": 32,
+        "sha": "a613908",
+        "legislative_periods": [
+          {
+            "id": "term/2011",
+            "name": "2011–2016",
+            "start_date": "2011-10-11",
+            "slug": "2011",
+            "csv": "data/Seychelles/Assembly/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a613908/data/Seychelles/Assembly/term-2011.csv"
+          }
+        ],
+        "statement_count": 776
+      }
+    ]
+  },
+  {
+    "name": "Sierra Leone",
+    "country": "Sierra Leone",
+    "code": "SL",
+    "slug": "Sierra-Leone",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Sierra_Leone/Parliament/sources",
+        "popolo": "data/Sierra_Leone/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2ddacc8/data/Sierra_Leone/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Sierra_Leone/Parliament/names.csv",
+        "lastmod": "1465843943",
+        "person_count": 124,
+        "sha": "2ddacc8",
+        "legislative_periods": [
+          {
+            "id": "term/2-4",
+            "name": "Fourth Parliament of the Second Republic",
+            "start_date": "2012-12-07",
+            "slug": "2-4",
+            "csv": "data/Sierra_Leone/Parliament/term-2-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2ddacc8/data/Sierra_Leone/Parliament/term-2-4.csv"
+          }
+        ],
+        "statement_count": 1719
+      }
+    ]
+  },
+  {
+    "name": "Singapore",
+    "country": "Singapore",
+    "code": "SG",
+    "slug": "Singapore",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Singapore/Parliament/sources",
+        "popolo": "data/Singapore/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Singapore/Parliament/names.csv",
+        "lastmod": "1467729774",
+        "person_count": 402,
+        "sha": "ad520d7",
+        "legislative_periods": [
+          {
+            "id": "term/13",
+            "name": "13th Parliament",
+            "start_date": "2016-01-15",
+            "slug": "13",
+            "csv": "data/Singapore/Parliament/term-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/term-13.csv"
+          },
+          {
+            "end_date": "2015-08-25",
+            "id": "term/12",
+            "name": "12th Parliament",
+            "start_date": "2011-10-10",
+            "slug": "12",
+            "csv": "data/Singapore/Parliament/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/term-12.csv"
+          },
+          {
+            "end_date": "2011-04-19",
+            "id": "term/11",
+            "name": "11th Parliament",
+            "start_date": "2006-11-02",
+            "slug": "11",
+            "csv": "data/Singapore/Parliament/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/term-11.csv"
+          },
+          {
+            "end_date": "2006-04-19",
+            "id": "term/10",
+            "name": "10th Parliament",
+            "start_date": "2002-03-25",
+            "slug": "10",
+            "csv": "data/Singapore/Parliament/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/term-10.csv"
+          },
+          {
+            "end_date": "2001-10-17",
+            "id": "term/9",
+            "name": "9th Parliament",
+            "start_date": "1997-05-26",
+            "slug": "9",
+            "csv": "data/Singapore/Parliament/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/term-9.csv"
+          },
+          {
+            "end_date": "1996-12-15",
+            "id": "term/8",
+            "name": "8th Parliament",
+            "start_date": "1992-01-06",
+            "slug": "8",
+            "csv": "data/Singapore/Parliament/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/term-8.csv"
+          },
+          {
+            "end_date": "1991-08-13",
+            "id": "term/7",
+            "name": "7th Parliament",
+            "start_date": "1989-01-09",
+            "slug": "7",
+            "csv": "data/Singapore/Parliament/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/term-7.csv"
+          },
+          {
+            "end_date": "1988-08-16",
+            "id": "term/6",
+            "name": "6th Parliament",
+            "start_date": "1985-02-25",
+            "slug": "6",
+            "csv": "data/Singapore/Parliament/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/term-6.csv"
+          },
+          {
+            "end_date": "1984-12-03",
+            "id": "term/5",
+            "name": "5th Parliament",
+            "start_date": "1981-02-03",
+            "slug": "5",
+            "csv": "data/Singapore/Parliament/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/term-5.csv"
+          },
+          {
+            "end_date": "1980-12-04",
+            "id": "term/4",
+            "name": "4th Parliament",
+            "start_date": "1977-02-07",
+            "slug": "4",
+            "csv": "data/Singapore/Parliament/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/term-4.csv"
+          },
+          {
+            "end_date": "1976-12-06",
+            "id": "term/3",
+            "name": "3rd Parliament",
+            "start_date": "1972-10-12",
+            "slug": "3",
+            "csv": "data/Singapore/Parliament/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/term-3.csv"
+          },
+          {
+            "end_date": "1972-08-16",
+            "id": "term/2",
+            "name": "2nd Parliament",
+            "start_date": "1968-05-06",
+            "slug": "2",
+            "csv": "data/Singapore/Parliament/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/term-2.csv"
+          },
+          {
+            "end_date": "1968-02-08",
+            "id": "term/1",
+            "name": "1st Parliament",
+            "start_date": "1965-12-08",
+            "slug": "1",
+            "csv": "data/Singapore/Parliament/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad520d7/data/Singapore/Parliament/term-1.csv"
+          }
+        ],
+        "statement_count": 15384
+      }
+    ]
+  },
+  {
+    "name": "Sint Maarten",
+    "country": "Sint Maarten",
+    "code": "SX",
+    "slug": "Sint-Maarten",
+    "legislatures": [
+      {
+        "name": "Estates",
+        "slug": "Estates",
+        "sources_directory": "data/Sint_Maarten/Estates/sources",
+        "popolo": "data/Sint_Maarten/Estates/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/06cc628/data/Sint_Maarten/Estates/ep-popolo-v1.0.json",
+        "names": "data/Sint_Maarten/Estates/names.csv",
+        "lastmod": "1467882454",
+        "person_count": 17,
+        "sha": "06cc628",
+        "legislative_periods": [
+          {
+            "id": "term/2",
+            "name": "2nd Estates",
+            "start_date": "2014",
+            "slug": "2",
+            "csv": "data/Sint_Maarten/Estates/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/06cc628/data/Sint_Maarten/Estates/term-2.csv"
+          }
+        ],
+        "statement_count": 692
+      }
+    ]
+  },
+  {
+    "name": "Slovakia",
+    "country": "Slovakia",
+    "code": "SK",
+    "slug": "Slovakia",
+    "legislatures": [
+      {
+        "name": "National Council",
+        "slug": "National-Council",
+        "sources_directory": "data/Slovakia/National_Council/sources",
+        "popolo": "data/Slovakia/National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/303b6bb/data/Slovakia/National_Council/ep-popolo-v1.0.json",
+        "names": "data/Slovakia/National_Council/names.csv",
+        "lastmod": "1467836721",
+        "person_count": 526,
+        "sha": "303b6bb",
+        "legislative_periods": [
+          {
+            "id": "term/6",
+            "name": "6. Národná rada 2012-",
+            "start_date": "2012-03-11",
+            "slug": "6",
+            "csv": "data/Slovakia/National_Council/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/303b6bb/data/Slovakia/National_Council/term-6.csv"
+          },
+          {
+            "end_date": "2012-03-10",
+            "id": "term/5",
+            "name": "5. Národná rada 2010-2012",
+            "start_date": "2010-06-13",
+            "slug": "5",
+            "csv": "data/Slovakia/National_Council/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/303b6bb/data/Slovakia/National_Council/term-5.csv"
+          },
+          {
+            "end_date": "2010-06-12",
+            "id": "term/4",
+            "name": "4. Národná rada 2006-2010",
+            "start_date": "2006-06-17",
+            "slug": "4",
+            "csv": "data/Slovakia/National_Council/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/303b6bb/data/Slovakia/National_Council/term-4.csv"
+          },
+          {
+            "end_date": "2006-06-16",
+            "id": "term/3",
+            "name": "3. Národná rada 2002-2006",
+            "start_date": "2002-09-22",
+            "slug": "3",
+            "csv": "data/Slovakia/National_Council/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/303b6bb/data/Slovakia/National_Council/term-3.csv"
+          },
+          {
+            "end_date": "2002-09-21",
+            "id": "term/2",
+            "name": "2. Národná rada 1998-2002",
+            "start_date": "1998-09-26",
+            "slug": "2",
+            "csv": "data/Slovakia/National_Council/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/303b6bb/data/Slovakia/National_Council/term-2.csv"
+          }
+        ],
+        "statement_count": 35140
+      }
+    ]
+  },
+  {
+    "name": "Slovenia",
+    "country": "Slovenia",
+    "code": "SI",
+    "slug": "Slovenia",
+    "legislatures": [
+      {
+        "name": "Državni zbor",
+        "slug": "National-Assembly",
+        "sources_directory": "data/Slovenia/National_Assembly/sources",
+        "popolo": "data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3a8fffe/data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Slovenia/National_Assembly/names.csv",
+        "lastmod": "1467319744",
+        "person_count": 91,
+        "sha": "3a8fffe",
+        "legislative_periods": [
+          {
+            "id": "term/7",
+            "name": "7th National Assembly",
+            "start_date": "2014-08-01",
+            "slug": "7",
+            "csv": "data/Slovenia/National_Assembly/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3a8fffe/data/Slovenia/National_Assembly/term-7.csv"
+          }
+        ],
+        "statement_count": 6890
+      }
+    ]
+  },
+  {
+    "name": "Solomon Islands",
+    "country": "Solomon Islands",
+    "code": "SB",
+    "slug": "Solomon-Islands",
+    "legislatures": [
+      {
+        "name": "National Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Solomon_Islands/Parliament/sources",
+        "popolo": "data/Solomon_Islands/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6bde04b/data/Solomon_Islands/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Solomon_Islands/Parliament/names.csv",
+        "lastmod": "1466345756",
+        "person_count": 50,
+        "sha": "6bde04b",
+        "legislative_periods": [
+          {
+            "id": "term/10",
+            "name": "10th Parliament",
+            "start_date": "2014-12-09",
+            "slug": "10",
+            "csv": "data/Solomon_Islands/Parliament/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6bde04b/data/Solomon_Islands/Parliament/term-10.csv"
+          }
+        ],
+        "statement_count": 2367
+      }
+    ]
+  },
+  {
+    "name": "Somalia",
+    "country": "Somalia",
+    "code": "SO",
+    "slug": "Somalia",
+    "legislatures": [
+      {
+        "name": "House of the People",
+        "slug": "Lower",
+        "sources_directory": "data/Somalia/Lower/sources",
+        "popolo": "data/Somalia/Lower/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e566b65/data/Somalia/Lower/ep-popolo-v1.0.json",
+        "names": "data/Somalia/Lower/names.csv",
+        "lastmod": "1466618059",
+        "person_count": 204,
+        "sha": "e566b65",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012–",
+            "start_date": "2012-08-20",
+            "slug": "2012",
+            "csv": "data/Somalia/Lower/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e566b65/data/Somalia/Lower/term-2012.csv"
+          }
+        ],
+        "statement_count": 2297
+      }
+    ]
+  },
+  {
+    "name": "Somaliland",
+    "country": "Somaliland",
+    "code": "SO-SOM",
+    "slug": "Somaliland",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "Representatives",
+        "sources_directory": "data/Somaliland/Representatives/sources",
+        "popolo": "data/Somaliland/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ffb7e5c/data/Somaliland/Representatives/ep-popolo-v1.0.json",
+        "names": "data/Somaliland/Representatives/names.csv",
+        "lastmod": "1467886763",
+        "person_count": 82,
+        "sha": "ffb7e5c",
+        "legislative_periods": [
+          {
+            "id": "term/2005",
+            "name": "First Parliament",
+            "start_date": "2005-09-29",
+            "slug": "2005",
+            "csv": "data/Somaliland/Representatives/term-2005.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ffb7e5c/data/Somaliland/Representatives/term-2005.csv"
+          }
+        ],
+        "statement_count": 946
+      }
+    ]
+  },
+  {
+    "name": "South Africa",
+    "country": "South Africa",
+    "code": "ZA",
+    "slug": "South-Africa",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/South_Africa/Assembly/sources",
+        "popolo": "data/South_Africa/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04e18b8/data/South_Africa/Assembly/ep-popolo-v1.0.json",
+        "names": "data/South_Africa/Assembly/names.csv",
+        "lastmod": "1467596455",
+        "person_count": 399,
+        "sha": "04e18b8",
+        "legislative_periods": [
+          {
+            "id": "term/26",
+            "name": "26th Parliament",
+            "start_date": "2014-05-21",
+            "slug": "26",
+            "csv": "data/South_Africa/Assembly/term-26.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04e18b8/data/South_Africa/Assembly/term-26.csv"
+          }
+        ],
+        "statement_count": 11523
+      }
+    ]
+  },
+  {
+    "name": "South Korea",
+    "country": "South Korea",
+    "code": "KR",
+    "slug": "South-Korea",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "National-Assembly",
+        "sources_directory": "data/South_Korea/National_Assembly/sources",
+        "popolo": "data/South_Korea/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/South_Korea/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/South_Korea/National_Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 298,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/19",
+            "name": "19th National Assembly",
+            "start_date": "2012-05-30",
+            "slug": "19",
+            "csv": "data/South_Korea/National_Assembly/term-19.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/South_Korea/National_Assembly/term-19.csv"
+          }
+        ],
+        "statement_count": 14996
+      }
+    ]
+  },
+  {
+    "name": "South Ossetia",
+    "country": "South Ossetia",
+    "code": "X-SO",
+    "slug": "South-Ossetia",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/South_Ossetia/Parliament/sources",
+        "popolo": "data/South_Ossetia/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f0a7193/data/South_Ossetia/Parliament/ep-popolo-v1.0.json",
+        "names": "data/South_Ossetia/Parliament/names.csv",
+        "lastmod": "1467807703",
+        "person_count": 34,
+        "sha": "f0a7193",
+        "legislative_periods": [
+          {
+            "id": "term/2014",
+            "name": "6th Convocation",
+            "start_date": "2014-06-09",
+            "slug": "2014",
+            "csv": "data/South_Ossetia/Parliament/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f0a7193/data/South_Ossetia/Parliament/term-2014.csv"
+          }
+        ],
+        "statement_count": 439
+      }
+    ]
+  },
+  {
+    "name": "South Sudan",
+    "country": "South Sudan",
+    "code": "SS",
+    "slug": "South-Sudan",
+    "legislatures": [
+      {
+        "name": "National Legislative Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/South_Sudan/Assembly/sources",
+        "popolo": "data/South_Sudan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/South_Sudan/Assembly/ep-popolo-v1.0.json",
+        "names": "data/South_Sudan/Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 167,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/1",
+            "name": "1st Parliament",
+            "start_date": "2011-07-09",
+            "slug": "1",
+            "csv": "data/South_Sudan/Assembly/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/South_Sudan/Assembly/term-1.csv"
+          }
+        ],
+        "statement_count": 2618
+      }
+    ]
+  },
+  {
+    "name": "Spain",
+    "country": "Spain",
+    "code": "ES",
+    "slug": "Spain",
+    "legislatures": [
+      {
+        "name": "Congreso de los Diputados",
+        "slug": "Congress",
+        "sources_directory": "data/Spain/Congress/sources",
+        "popolo": "data/Spain/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e359bab/data/Spain/Congress/ep-popolo-v1.0.json",
+        "names": "data/Spain/Congress/names.csv",
+        "lastmod": "1467900732",
+        "person_count": 621,
+        "sha": "e359bab",
+        "legislative_periods": [
+          {
+            "id": "term/11",
+            "name": "XI Legislatura",
+            "start_date": "2016-01-13",
+            "slug": "11",
+            "csv": "data/Spain/Congress/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e359bab/data/Spain/Congress/term-11.csv"
+          },
+          {
+            "end_date": "2015-10-27",
+            "id": "term/10",
+            "name": "X Legislatura",
+            "start_date": "2011-11-28",
+            "slug": "10",
+            "csv": "data/Spain/Congress/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e359bab/data/Spain/Congress/term-10.csv"
+          }
+        ],
+        "statement_count": 32081
+      }
+    ]
+  },
+  {
+    "name": "Sri Lanka",
+    "country": "Sri Lanka",
+    "code": "LK",
+    "slug": "Sri-Lanka",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Sri_Lanka/Parliament/sources",
+        "popolo": "data/Sri_Lanka/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6a1bf4a/data/Sri_Lanka/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Sri_Lanka/Parliament/names.csv",
+        "lastmod": "1467254567",
+        "person_count": 228,
+        "sha": "6a1bf4a",
+        "legislative_periods": [
+          {
+            "id": "term/15",
+            "name": "15th Parliament",
+            "start_date": "2015-09-01",
+            "slug": "15",
+            "csv": "data/Sri_Lanka/Parliament/term-15.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6a1bf4a/data/Sri_Lanka/Parliament/term-15.csv"
+          }
+        ],
+        "statement_count": 8998
+      }
+    ]
+  },
+  {
+    "name": "Suriname",
+    "country": "Suriname",
+    "code": "SR",
+    "slug": "Suriname",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Suriname/Assembly/sources",
+        "popolo": "data/Suriname/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/14ce6ef/data/Suriname/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Suriname/Assembly/names.csv",
+        "lastmod": "1466584536",
+        "person_count": 87,
+        "sha": "14ce6ef",
+        "legislative_periods": [
+          {
+            "id": "term/2015",
+            "name": "2015–",
+            "start_date": "2015-06-30",
+            "slug": "2015",
+            "csv": "data/Suriname/Assembly/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/14ce6ef/data/Suriname/Assembly/term-2015.csv"
+          },
+          {
+            "end_date": "2015-06-30",
+            "id": "term/2010",
+            "name": "2010–2015",
+            "start_date": "2010",
+            "slug": "2010",
+            "csv": "data/Suriname/Assembly/term-2010.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/14ce6ef/data/Suriname/Assembly/term-2010.csv"
+          }
+        ],
+        "statement_count": 3301
+      }
+    ]
+  },
+  {
+    "name": "Swaziland",
+    "country": "Swaziland",
+    "code": "SZ",
+    "slug": "Swaziland",
+    "legislatures": [
+      {
+        "name": "House of Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Swaziland/Assembly/sources",
+        "popolo": "data/Swaziland/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d69d8a/data/Swaziland/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Swaziland/Assembly/names.csv",
+        "lastmod": "1465852870",
+        "person_count": 93,
+        "sha": "4d69d8a",
+        "legislative_periods": [
+          {
+            "id": "term/10",
+            "name": "10th Parliament",
+            "start_date": "2013-08-17",
+            "slug": "10",
+            "csv": "data/Swaziland/Assembly/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d69d8a/data/Swaziland/Assembly/term-10.csv"
+          },
+          {
+            "end_date": "2013-09-19",
+            "id": "term/9",
+            "name": "9th Parliament",
+            "start_date": "2008-10-10",
+            "slug": "9",
+            "csv": "data/Swaziland/Assembly/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d69d8a/data/Swaziland/Assembly/term-9.csv"
+          }
+        ],
+        "statement_count": 1250
+      }
+    ]
+  },
+  {
+    "name": "Sweden",
+    "country": "Sweden",
+    "code": "SE",
+    "slug": "Sweden",
+    "legislatures": [
+      {
+        "name": "Riksdag",
+        "slug": "Riksdag",
+        "sources_directory": "data/Sweden/Riksdag/sources",
+        "popolo": "data/Sweden/Riksdag/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74f5f7f/data/Sweden/Riksdag/ep-popolo-v1.0.json",
+        "names": "data/Sweden/Riksdag/names.csv",
+        "lastmod": "1467809180",
+        "person_count": 1619,
+        "sha": "74f5f7f",
+        "legislative_periods": [
+          {
+            "end_date": "2018-09-24",
+            "id": "term/2014",
+            "name": "2014–2018",
+            "start_date": "2014-09-29",
+            "slug": "2014",
+            "csv": "data/Sweden/Riksdag/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74f5f7f/data/Sweden/Riksdag/term-2014.csv"
+          },
+          {
+            "end_date": "2014-09-29",
+            "id": "term/2010",
+            "name": "2010–2014",
+            "start_date": "2010-10-04",
+            "slug": "2010",
+            "csv": "data/Sweden/Riksdag/term-2010.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74f5f7f/data/Sweden/Riksdag/term-2010.csv"
+          },
+          {
+            "end_date": "2010-10-04",
+            "id": "term/2006",
+            "name": "2006–2010",
+            "start_date": "2006-10-02",
+            "slug": "2006",
+            "csv": "data/Sweden/Riksdag/term-2006.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74f5f7f/data/Sweden/Riksdag/term-2006.csv"
+          },
+          {
+            "end_date": "2006-10-02",
+            "id": "term/2002",
+            "name": "2002–2006",
+            "start_date": "2002-09-30",
+            "slug": "2002",
+            "csv": "data/Sweden/Riksdag/term-2002.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74f5f7f/data/Sweden/Riksdag/term-2002.csv"
+          },
+          {
+            "end_date": "2002-09-30",
+            "id": "term/1998",
+            "name": "1998–2002",
+            "start_date": "1998-10-05",
+            "slug": "1998",
+            "csv": "data/Sweden/Riksdag/term-1998.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74f5f7f/data/Sweden/Riksdag/term-1998.csv"
+          },
+          {
+            "end_date": "1998-10-05",
+            "id": "term/1994",
+            "name": "1994–1998",
+            "start_date": "1994-10-03",
+            "slug": "1994",
+            "csv": "data/Sweden/Riksdag/term-1994.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74f5f7f/data/Sweden/Riksdag/term-1994.csv"
+          },
+          {
+            "end_date": "1994-10-03",
+            "id": "term/1991",
+            "name": "1991–1994",
+            "start_date": "1991-09-30",
+            "slug": "1991",
+            "csv": "data/Sweden/Riksdag/term-1991.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74f5f7f/data/Sweden/Riksdag/term-1991.csv"
+          },
+          {
+            "end_date": "1991-09-30",
+            "id": "term/1988",
+            "name": "1988–1991",
+            "start_date": "1988-10-03",
+            "slug": "1988",
+            "csv": "data/Sweden/Riksdag/term-1988.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74f5f7f/data/Sweden/Riksdag/term-1988.csv"
+          },
+          {
+            "end_date": "1988-10-03",
+            "id": "term/1985",
+            "name": "1985–1988",
+            "start_date": "1985-09-30",
+            "slug": "1985",
+            "csv": "data/Sweden/Riksdag/term-1985.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74f5f7f/data/Sweden/Riksdag/term-1985.csv"
+          },
+          {
+            "end_date": "1985-09-30",
+            "id": "term/1982",
+            "name": "1982–1985",
+            "start_date": "1982-10-04",
+            "slug": "1982",
+            "csv": "data/Sweden/Riksdag/term-1982.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74f5f7f/data/Sweden/Riksdag/term-1982.csv"
+          },
+          {
+            "end_date": "1982-10-04",
+            "id": "term/1979",
+            "name": "1979–1982",
+            "start_date": "1979-10-01",
+            "slug": "1979",
+            "csv": "data/Sweden/Riksdag/term-1979.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74f5f7f/data/Sweden/Riksdag/term-1979.csv"
+          },
+          {
+            "end_date": "1979-10-01",
+            "id": "term/1976",
+            "name": "1976–1979",
+            "start_date": "1976-10-04",
+            "slug": "1976",
+            "csv": "data/Sweden/Riksdag/term-1976.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74f5f7f/data/Sweden/Riksdag/term-1976.csv"
+          }
+        ],
+        "statement_count": 94284
+      }
+    ]
+  },
+  {
+    "name": "Switzerland",
+    "country": "Switzerland",
+    "code": "CH",
+    "slug": "Switzerland",
+    "legislatures": [
+      {
+        "name": "National Council",
+        "slug": "National-Council",
+        "sources_directory": "data/Switzerland/National_Council/sources",
+        "popolo": "data/Switzerland/National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/ep-popolo-v1.0.json",
+        "names": "data/Switzerland/National_Council/names.csv",
+        "lastmod": "1467884655",
+        "person_count": 1216,
+        "sha": "f763f4c",
+        "legislative_periods": [
+          {
+            "end_date": "2019-11-29",
+            "id": "term/50",
+            "name": "50. Legislatur",
+            "start_date": "2015-11-30",
+            "slug": "50",
+            "csv": "data/Switzerland/National_Council/term-50.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-50.csv"
+          },
+          {
+            "end_date": "2015-11-29",
+            "id": "term/49",
+            "name": "49. Legislatur",
+            "start_date": "2011-12-05",
+            "slug": "49",
+            "csv": "data/Switzerland/National_Council/term-49.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-49.csv"
+          },
+          {
+            "end_date": "2011-12-02",
+            "id": "term/48",
+            "name": "48. Legislatur",
+            "start_date": "2007-12-03",
+            "slug": "48",
+            "csv": "data/Switzerland/National_Council/term-48.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-48.csv"
+          },
+          {
+            "end_date": "2007-11-30",
+            "id": "term/47",
+            "name": "47. Legislatur",
+            "start_date": "2003-12-01",
+            "slug": "47",
+            "csv": "data/Switzerland/National_Council/term-47.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-47.csv"
+          },
+          {
+            "end_date": "2003-11-30",
+            "id": "term/46",
+            "name": "46. Legislatur",
+            "start_date": "1999-12-06",
+            "slug": "46",
+            "csv": "data/Switzerland/National_Council/term-46.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-46.csv"
+          },
+          {
+            "end_date": "1999-11-30",
+            "id": "term/45",
+            "name": "45. Legislatur",
+            "start_date": "1995-12-04",
+            "slug": "45",
+            "csv": "data/Switzerland/National_Council/term-45.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-45.csv"
+          },
+          {
+            "end_date": "1995-12-03",
+            "id": "term/44",
+            "name": "44. Legislatur",
+            "start_date": "1991-11-25",
+            "slug": "44",
+            "csv": "data/Switzerland/National_Council/term-44.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-44.csv"
+          },
+          {
+            "end_date": "1991-11-24",
+            "id": "term/43",
+            "name": "43. Legislatur",
+            "start_date": "1987-11-30",
+            "slug": "43",
+            "csv": "data/Switzerland/National_Council/term-43.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-43.csv"
+          },
+          {
+            "end_date": "1987-11-29",
+            "id": "term/42",
+            "name": "42. Legislatur",
+            "start_date": "1983-11-28",
+            "slug": "42",
+            "csv": "data/Switzerland/National_Council/term-42.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-42.csv"
+          },
+          {
+            "end_date": "1983-11-27",
+            "id": "term/41",
+            "name": "41. Legislatur",
+            "start_date": "1979-11-26",
+            "slug": "41",
+            "csv": "data/Switzerland/National_Council/term-41.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-41.csv"
+          },
+          {
+            "end_date": "1979-11-25",
+            "id": "term/40",
+            "name": "40. Legislatur",
+            "start_date": "1975-12-01",
+            "slug": "40",
+            "csv": "data/Switzerland/National_Council/term-40.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-40.csv"
+          },
+          {
+            "end_date": "1975-11-30",
+            "id": "term/39",
+            "name": "39. Legislatur",
+            "start_date": "1971-11-29",
+            "slug": "39",
+            "csv": "data/Switzerland/National_Council/term-39.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-39.csv"
+          },
+          {
+            "end_date": "1971-11-28",
+            "id": "term/38",
+            "name": "38. Legislatur",
+            "start_date": "1967-12-04",
+            "slug": "38",
+            "csv": "data/Switzerland/National_Council/term-38.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-38.csv"
+          },
+          {
+            "end_date": "1967-12-03",
+            "id": "term/37",
+            "name": "37. Legislatur",
+            "start_date": "1963-12-02",
+            "slug": "37",
+            "csv": "data/Switzerland/National_Council/term-37.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f763f4c/data/Switzerland/National_Council/term-37.csv"
+          }
+        ],
+        "statement_count": 63603
+      }
+    ]
+  },
+  {
+    "name": "Syria",
+    "country": "Syria",
+    "code": "SY",
+    "slug": "Syria",
+    "legislatures": [
+      {
+        "name": "People’s Council",
+        "slug": "Majlis",
+        "sources_directory": "data/Syria/Majlis/sources",
+        "popolo": "data/Syria/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0bc84b9/data/Syria/Majlis/ep-popolo-v1.0.json",
+        "names": "data/Syria/Majlis/names.csv",
+        "lastmod": "1466619909",
+        "person_count": 274,
+        "sha": "0bc84b9",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012–",
+            "start_date": "2012-05-24",
+            "slug": "2012",
+            "csv": "data/Syria/Majlis/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0bc84b9/data/Syria/Majlis/term-2012.csv"
+          }
+        ],
+        "statement_count": 4145
+      }
+    ]
+  },
+  {
+    "name": "Taiwan",
+    "country": "Taiwan",
+    "code": "TW",
+    "slug": "Taiwan",
+    "legislatures": [
+      {
+        "name": "Legislative Yuan",
+        "slug": "Legislative-Yuan",
+        "sources_directory": "data/Taiwan/Legislative_Yuan/sources",
+        "popolo": "data/Taiwan/Legislative_Yuan/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6f00b55/data/Taiwan/Legislative_Yuan/ep-popolo-v1.0.json",
+        "names": "data/Taiwan/Legislative_Yuan/names.csv",
+        "lastmod": "1467840754",
+        "person_count": 166,
+        "sha": "6f00b55",
+        "legislative_periods": [
+          {
+            "id": "term/9",
+            "name": "9th Legislative Yuan",
+            "start_date": "2016-01-16",
+            "slug": "9",
+            "csv": "data/Taiwan/Legislative_Yuan/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6f00b55/data/Taiwan/Legislative_Yuan/term-9.csv"
+          },
+          {
+            "end_date": "2016-01-16",
+            "id": "term/8",
+            "name": "8th Legislative Yuan",
+            "start_date": "2012-02-01",
+            "slug": "8",
+            "csv": "data/Taiwan/Legislative_Yuan/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6f00b55/data/Taiwan/Legislative_Yuan/term-8.csv"
+          }
+        ],
+        "statement_count": 7291
+      }
+    ]
+  },
+  {
+    "name": "Tajikistan",
+    "country": "Tajikistan",
+    "code": "TJ",
+    "slug": "Tajikistan",
+    "legislatures": [
+      {
+        "name": "Assembly of Representatives",
+        "slug": "Representatives",
+        "sources_directory": "data/Tajikistan/Representatives/sources",
+        "popolo": "data/Tajikistan/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ddfcd1d/data/Tajikistan/Representatives/ep-popolo-v1.0.json",
+        "names": "data/Tajikistan/Representatives/names.csv",
+        "lastmod": "1465845072",
+        "person_count": 62,
+        "sha": "ddfcd1d",
+        "legislative_periods": [
+          {
+            "id": "term/2015",
+            "name": "2015–",
+            "start_date": "2015-03-17",
+            "slug": "2015",
+            "csv": "data/Tajikistan/Representatives/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ddfcd1d/data/Tajikistan/Representatives/term-2015.csv"
+          }
+        ],
+        "statement_count": 973
+      }
+    ]
+  },
+  {
+    "name": "Tanzania",
+    "country": "Tanzania",
+    "code": "TZ",
+    "slug": "Tanzania",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Tanzania/Assembly/sources",
+        "popolo": "data/Tanzania/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/73e42bf/data/Tanzania/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Tanzania/Assembly/names.csv",
+        "lastmod": "1466795382",
+        "person_count": 889,
+        "sha": "73e42bf",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "5th Assembly",
+            "start_date": "2015-11-17",
+            "slug": "5",
+            "csv": "data/Tanzania/Assembly/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/73e42bf/data/Tanzania/Assembly/term-5.csv"
+          },
+          {
+            "end_date": "2015-06-18",
+            "id": "term/4",
+            "name": "4th Assembly",
+            "start_date": "2010-10-31",
+            "slug": "4",
+            "csv": "data/Tanzania/Assembly/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/73e42bf/data/Tanzania/Assembly/term-4.csv"
+          },
+          {
+            "end_date": "2010-10-30",
+            "id": "term/3",
+            "name": "3rd Assembly",
+            "start_date": "2005-10-30",
+            "slug": "3",
+            "csv": "data/Tanzania/Assembly/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/73e42bf/data/Tanzania/Assembly/term-3.csv"
+          },
+          {
+            "end_date": "2005-10-29",
+            "id": "term/2",
+            "name": "2nd Assembly",
+            "start_date": "2000-10-29",
+            "slug": "2",
+            "csv": "data/Tanzania/Assembly/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/73e42bf/data/Tanzania/Assembly/term-2.csv"
+          }
+        ],
+        "statement_count": 26280
+      }
+    ]
+  },
+  {
+    "name": "Thailand",
+    "country": "Thailand",
+    "code": "TH",
+    "slug": "Thailand",
+    "legislatures": [
+      {
+        "name": "National Legislative Assembly",
+        "slug": "National-Legislative-Assembly",
+        "sources_directory": "data/Thailand/National_Legislative_Assembly/sources",
+        "popolo": "data/Thailand/National_Legislative_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04ecc9e/data/Thailand/National_Legislative_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Thailand/National_Legislative_Assembly/names.csv",
+        "lastmod": "1467651698",
+        "person_count": 220,
+        "sha": "04ecc9e",
+        "legislative_periods": [
+          {
+            "id": "term/2557",
+            "name": "2557 (NCPO)",
+            "start_date": "2014-08-07",
+            "slug": "2557",
+            "csv": "data/Thailand/National_Legislative_Assembly/term-2557.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04ecc9e/data/Thailand/National_Legislative_Assembly/term-2557.csv"
+          }
+        ],
+        "statement_count": 3808
+      }
+    ]
+  },
+  {
+    "name": "Timor Leste",
+    "country": "Timor Leste",
+    "code": "TL",
+    "slug": "Timor-Leste",
+    "legislatures": [
+      {
+        "name": "Parlamento",
+        "slug": "Parlamento",
+        "sources_directory": "data/Timor_Leste/Parlamento/sources",
+        "popolo": "data/Timor_Leste/Parlamento/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee0a7a3/data/Timor_Leste/Parlamento/ep-popolo-v1.0.json",
+        "names": "data/Timor_Leste/Parlamento/names.csv",
+        "lastmod": "1467743061",
+        "person_count": 65,
+        "sha": "ee0a7a3",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "3rd Parliament",
+            "start_date": "2012-07-30",
+            "slug": "2012",
+            "csv": "data/Timor_Leste/Parlamento/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee0a7a3/data/Timor_Leste/Parlamento/term-2012.csv"
+          }
+        ],
+        "statement_count": 1223
+      }
+    ]
+  },
+  {
+    "name": "Togo",
+    "country": "Togo",
+    "code": "TG",
+    "slug": "Togo",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Togo/Assembly/sources",
+        "popolo": "data/Togo/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/909244e/data/Togo/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Togo/Assembly/names.csv",
+        "lastmod": "1467009064",
+        "person_count": 91,
+        "sha": "909244e",
+        "legislative_periods": [
+          {
+            "id": "term/2013",
+            "name": "2013–",
+            "start_date": "2013-08-20",
+            "slug": "2013",
+            "csv": "data/Togo/Assembly/term-2013.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/909244e/data/Togo/Assembly/term-2013.csv"
+          }
+        ],
+        "statement_count": 1862
+      }
+    ]
+  },
+  {
+    "name": "Tonga",
+    "country": "Tonga",
+    "code": "TO",
+    "slug": "Tonga",
+    "legislatures": [
+      {
+        "name": "Legislative Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Tonga/Assembly/sources",
+        "popolo": "data/Tonga/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02aaf2e/data/Tonga/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Tonga/Assembly/names.csv",
+        "lastmod": "1465854692",
+        "person_count": 26,
+        "sha": "02aaf2e",
+        "legislative_periods": [
+          {
+            "end_date": "2018",
+            "id": "term/2015",
+            "name": "2014-2018",
+            "start_date": "2014-12-29",
+            "slug": "2015",
+            "csv": "data/Tonga/Assembly/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02aaf2e/data/Tonga/Assembly/term-2015.csv"
+          }
+        ],
+        "statement_count": 537
+      }
+    ]
+  },
+  {
+    "name": "Transnistria",
+    "country": "Transnistria",
+    "code": "MD-PMR",
+    "slug": "Transnistria",
+    "legislatures": [
+      {
+        "name": "Supreme Council",
+        "slug": "Supreme-Council",
+        "sources_directory": "data/Transnistria/Supreme_Council/sources",
+        "popolo": "data/Transnistria/Supreme_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Transnistria/Supreme_Council/ep-popolo-v1.0.json",
+        "names": "data/Transnistria/Supreme_Council/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 65,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/6",
+            "name": "6th Convocation",
+            "start_date": "2015-12-23",
+            "slug": "6",
+            "csv": "data/Transnistria/Supreme_Council/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Transnistria/Supreme_Council/term-6.csv"
+          },
+          {
+            "end_date": "2015",
+            "id": "term/5",
+            "name": "5th Convocation",
+            "start_date": "2010",
+            "slug": "5",
+            "csv": "data/Transnistria/Supreme_Council/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Transnistria/Supreme_Council/term-5.csv"
+          }
+        ],
+        "statement_count": 1080
+      }
+    ]
+  },
+  {
+    "name": "Trinidad and Tobago",
+    "country": "Trinidad and Tobago",
+    "code": "TT",
+    "slug": "Trinidad-and-Tobago",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "Representatives",
+        "sources_directory": "data/Trinidad_and_Tobago/Representatives/sources",
+        "popolo": "data/Trinidad_and_Tobago/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/445316c/data/Trinidad_and_Tobago/Representatives/ep-popolo-v1.0.json",
+        "names": "data/Trinidad_and_Tobago/Representatives/names.csv",
+        "lastmod": "1467732277",
+        "person_count": 42,
+        "sha": "445316c",
+        "legislative_periods": [
+          {
+            "id": "term/11",
+            "name": "11th Republican Parliament",
+            "start_date": "2015-09-23",
+            "slug": "11",
+            "csv": "data/Trinidad_and_Tobago/Representatives/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/445316c/data/Trinidad_and_Tobago/Representatives/term-11.csv"
+          }
+        ],
+        "statement_count": 949
+      },
+      {
+        "name": "Senate",
+        "slug": "Senate",
+        "sources_directory": "data/Trinidad_and_Tobago/Senate/sources",
+        "popolo": "data/Trinidad_and_Tobago/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0feba6d/data/Trinidad_and_Tobago/Senate/ep-popolo-v1.0.json",
+        "names": "data/Trinidad_and_Tobago/Senate/names.csv",
+        "lastmod": "1466353792",
+        "person_count": 31,
+        "sha": "0feba6d",
+        "legislative_periods": [
+          {
+            "id": "term/11",
+            "name": "11th Republican Parliament",
+            "start_date": "2015-09-23",
+            "slug": "11",
+            "csv": "data/Trinidad_and_Tobago/Senate/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0feba6d/data/Trinidad_and_Tobago/Senate/term-11.csv"
+          }
+        ],
+        "statement_count": 511
+      }
+    ]
+  },
+  {
+    "name": "Tunisia",
+    "country": "Tunisia",
+    "code": "TN",
+    "slug": "Tunisia",
+    "legislatures": [
+      {
+        "name": "Assembly of the Representatives of the People",
+        "slug": "Majlis",
+        "sources_directory": "data/Tunisia/Majlis/sources",
+        "popolo": "data/Tunisia/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c249f4b/data/Tunisia/Majlis/ep-popolo-v1.0.json",
+        "names": "data/Tunisia/Majlis/names.csv",
+        "lastmod": "1466353793",
+        "person_count": 220,
+        "sha": "c249f4b",
+        "legislative_periods": [
+          {
+            "id": "term/1",
+            "name": "1st Legislature",
+            "start_date": "2014-12-02",
+            "slug": "1",
+            "csv": "data/Tunisia/Majlis/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c249f4b/data/Tunisia/Majlis/term-1.csv"
+          }
+        ],
+        "statement_count": 4736
+      }
+    ]
+  },
+  {
+    "name": "Turkey",
+    "country": "Turkey",
+    "code": "TR",
+    "slug": "Turkey",
+    "legislatures": [
+      {
+        "name": "Grand National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Turkey/Assembly/sources",
+        "popolo": "data/Turkey/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Turkey/Assembly/names.csv",
+        "lastmod": "1467709377",
+        "person_count": 6907,
+        "sha": "d463525",
+        "legislative_periods": [
+          {
+            "id": "term/26",
+            "name": "26th Parliament",
+            "start_date": "2015-11-17",
+            "slug": "26",
+            "csv": "data/Turkey/Assembly/term-26.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-26.csv"
+          },
+          {
+            "end_date": "2015-11-01",
+            "id": "term/25",
+            "name": "25th Parliament",
+            "start_date": "2015-06-23",
+            "slug": "25",
+            "csv": "data/Turkey/Assembly/term-25.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-25.csv"
+          },
+          {
+            "end_date": "2015-06-07",
+            "id": "term/24",
+            "name": "24th Parliament",
+            "start_date": "2011-06-28",
+            "slug": "24",
+            "csv": "data/Turkey/Assembly/term-24.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-24.csv"
+          },
+          {
+            "end_date": "2011-06-28",
+            "id": "term/23",
+            "name": "23rd Parliament",
+            "start_date": "2007-07-23",
+            "slug": "23",
+            "csv": "data/Turkey/Assembly/term-23.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-23.csv"
+          },
+          {
+            "end_date": "2007-07-23",
+            "id": "term/22",
+            "name": "22nd Parliament",
+            "start_date": "2002-11-14",
+            "slug": "22",
+            "csv": "data/Turkey/Assembly/term-22.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-22.csv"
+          },
+          {
+            "end_date": "2002-11-14",
+            "id": "term/21",
+            "name": "21st Parliament",
+            "start_date": "1999-04-18",
+            "slug": "21",
+            "csv": "data/Turkey/Assembly/term-21.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-21.csv"
+          },
+          {
+            "end_date": "1999-04-18",
+            "id": "term/20",
+            "name": "20th Parliament",
+            "start_date": "1996-01-08",
+            "slug": "20",
+            "csv": "data/Turkey/Assembly/term-20.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-20.csv"
+          },
+          {
+            "end_date": "1995-12-24",
+            "id": "term/19",
+            "name": "19th Parliament",
+            "start_date": "1991-11-06",
+            "slug": "19",
+            "csv": "data/Turkey/Assembly/term-19.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-19.csv"
+          },
+          {
+            "end_date": "1991-10-20",
+            "id": "term/18",
+            "name": "18th Parliament",
+            "start_date": "1987-12-14",
+            "slug": "18",
+            "csv": "data/Turkey/Assembly/term-18.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-18.csv"
+          },
+          {
+            "end_date": "1987-11-29",
+            "id": "term/17",
+            "name": "17th Parliament",
+            "start_date": "1983-11-24",
+            "slug": "17",
+            "csv": "data/Turkey/Assembly/term-17.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-17.csv"
+          },
+          {
+            "end_date": "1980-09-12",
+            "id": "term/16",
+            "name": "16th Parliament",
+            "start_date": "1977-06-13",
+            "slug": "16",
+            "csv": "data/Turkey/Assembly/term-16.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-16.csv"
+          },
+          {
+            "end_date": "1977-06-05",
+            "id": "term/15",
+            "name": "15th Parliament",
+            "start_date": "1973-10-24",
+            "slug": "15",
+            "csv": "data/Turkey/Assembly/term-15.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-15.csv"
+          },
+          {
+            "end_date": "1973-10-14",
+            "id": "term/14",
+            "name": "14th Parliament",
+            "start_date": "1969-10-22",
+            "slug": "14",
+            "csv": "data/Turkey/Assembly/term-14.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-14.csv"
+          },
+          {
+            "end_date": "1973-10-14",
+            "id": "term/13",
+            "name": "13th Parliament",
+            "start_date": "1965-10-22",
+            "slug": "13",
+            "csv": "data/Turkey/Assembly/term-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-13.csv"
+          },
+          {
+            "end_date": "1973-10-14",
+            "id": "term/12",
+            "name": "12th Parliament",
+            "start_date": "1961-10-25",
+            "slug": "12",
+            "csv": "data/Turkey/Assembly/term-12.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-12.csv"
+          },
+          {
+            "end_date": "1960-05-27",
+            "id": "term/11",
+            "name": "11th Parliament",
+            "start_date": "1957-11-01",
+            "slug": "11",
+            "csv": "data/Turkey/Assembly/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-11.csv"
+          },
+          {
+            "end_date": "1957-11-01",
+            "id": "term/10",
+            "name": "10th Parliament",
+            "start_date": "1954-05-14",
+            "slug": "10",
+            "csv": "data/Turkey/Assembly/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-10.csv"
+          },
+          {
+            "end_date": "1954-05-14",
+            "id": "term/9",
+            "name": "9th Parliament",
+            "start_date": "1950-05-22",
+            "slug": "9",
+            "csv": "data/Turkey/Assembly/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-9.csv"
+          },
+          {
+            "end_date": "1950-05-22",
+            "id": "term/8",
+            "name": "8th Parliament",
+            "start_date": "1946-08-05",
+            "slug": "8",
+            "csv": "data/Turkey/Assembly/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-8.csv"
+          },
+          {
+            "end_date": "1946-08-05",
+            "id": "term/7",
+            "name": "7th Parliament",
+            "start_date": "1943-03-08",
+            "slug": "7",
+            "csv": "data/Turkey/Assembly/term-7.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-7.csv"
+          },
+          {
+            "end_date": "1943-03-08",
+            "id": "term/6",
+            "name": "6th Parliament",
+            "start_date": "1939-04-03",
+            "slug": "6",
+            "csv": "data/Turkey/Assembly/term-6.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-6.csv"
+          },
+          {
+            "end_date": "1939-04-03",
+            "id": "term/5",
+            "name": "5th Parliament",
+            "start_date": "1935-03-01",
+            "slug": "5",
+            "csv": "data/Turkey/Assembly/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-5.csv"
+          },
+          {
+            "end_date": "1935-03-01",
+            "id": "term/4",
+            "name": "4th Parliament",
+            "start_date": "1931-05-04",
+            "slug": "4",
+            "csv": "data/Turkey/Assembly/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-4.csv"
+          },
+          {
+            "end_date": "1931-05-04",
+            "id": "term/3",
+            "name": "3rd Parliament",
+            "start_date": "1927-05-01",
+            "slug": "3",
+            "csv": "data/Turkey/Assembly/term-3.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-3.csv"
+          },
+          {
+            "end_date": "1927-11-01",
+            "id": "term/2",
+            "name": "2nd Parliament",
+            "start_date": "1923-08-11",
+            "slug": "2",
+            "csv": "data/Turkey/Assembly/term-2.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-2.csv"
+          },
+          {
+            "end_date": "1923-08-11",
+            "id": "term/1",
+            "name": "1st Parliament",
+            "start_date": "1920-04-23",
+            "slug": "1",
+            "csv": "data/Turkey/Assembly/term-1.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d463525/data/Turkey/Assembly/term-1.csv"
+          }
+        ],
+        "statement_count": 213930
+      }
+    ]
+  },
+  {
+    "name": "Turkmenistan",
+    "country": "Turkmenistan",
+    "code": "TM",
+    "slug": "Turkmenistan",
+    "legislatures": [
+      {
+        "name": "Mejlis",
+        "slug": "Mejlis",
+        "sources_directory": "data/Turkmenistan/Mejlis/sources",
+        "popolo": "data/Turkmenistan/Mejlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Turkmenistan/Mejlis/ep-popolo-v1.0.json",
+        "names": "data/Turkmenistan/Mejlis/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 237,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "5th Convocation",
+            "start_date": "2014-01-07",
+            "slug": "5",
+            "csv": "data/Turkmenistan/Mejlis/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Turkmenistan/Mejlis/term-5.csv"
+          },
+          {
+            "end_date": "2013",
+            "id": "term/4",
+            "name": "4th Convocation",
+            "start_date": "2009",
+            "slug": "4",
+            "csv": "data/Turkmenistan/Mejlis/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Turkmenistan/Mejlis/term-4.csv"
+          }
+        ],
+        "statement_count": 4144
+      }
+    ]
+  },
+  {
+    "name": "Turks and Caicos Islands",
+    "country": "Turks and Caicos Islands",
+    "code": "TC",
+    "slug": "Turks-and-Caicos-Islands",
+    "legislatures": [
+      {
+        "name": "House of Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Turks_and_Caicos_Islands/Assembly/sources",
+        "popolo": "data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ac3c179/data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Turks_and_Caicos_Islands/Assembly/names.csv",
+        "lastmod": "1466800504",
+        "person_count": 18,
+        "sha": "ac3c179",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "1st Assembly",
+            "start_date": "2012",
+            "slug": "2012",
+            "csv": "data/Turks_and_Caicos_Islands/Assembly/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ac3c179/data/Turks_and_Caicos_Islands/Assembly/term-2012.csv"
+          }
+        ],
+        "statement_count": 562
+      }
+    ]
+  },
+  {
+    "name": "Tuvalu",
+    "country": "Tuvalu",
+    "code": "TV",
+    "slug": "Tuvalu",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Tuvalu/Parliament/sources",
+        "popolo": "data/Tuvalu/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/23d5928/data/Tuvalu/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Tuvalu/Parliament/names.csv",
+        "lastmod": "1467669725",
+        "person_count": 27,
+        "sha": "23d5928",
+        "legislative_periods": [
+          {
+            "id": "term/11",
+            "name": "11th Parliament",
+            "start_date": "2015-03-31",
+            "slug": "11",
+            "csv": "data/Tuvalu/Parliament/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/23d5928/data/Tuvalu/Parliament/term-11.csv"
+          },
+          {
+            "end_date": "2015-03-30",
+            "id": "term/10",
+            "name": "10th Parliament",
+            "start_date": "2010-09-16",
+            "slug": "10",
+            "csv": "data/Tuvalu/Parliament/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/23d5928/data/Tuvalu/Parliament/term-10.csv"
+          },
+          {
+            "end_date": "2010-09-16",
+            "id": "term/9",
+            "name": "9th Parliament",
+            "start_date": "2006-08-03",
+            "slug": "9",
+            "csv": "data/Tuvalu/Parliament/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/23d5928/data/Tuvalu/Parliament/term-9.csv"
+          }
+        ],
+        "statement_count": 1841
+      }
+    ]
+  },
+  {
+    "name": "US Virgin Islands",
+    "country": "US Virgin Islands",
+    "code": "VI",
+    "slug": "US-Virgin-Islands",
+    "legislatures": [
+      {
+        "name": "Legislature",
+        "slug": "Legislature",
+        "sources_directory": "data/US_Virgin_Islands/Legislature/sources",
+        "popolo": "data/US_Virgin_Islands/Legislature/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5dcbaa3/data/US_Virgin_Islands/Legislature/ep-popolo-v1.0.json",
+        "names": "data/US_Virgin_Islands/Legislature/names.csv",
+        "lastmod": "1467652675",
+        "person_count": 15,
+        "sha": "5dcbaa3",
+        "legislative_periods": [
+          {
+            "end_date": "2016-12-31",
+            "id": "term/2014",
+            "name": "31st Legislature",
+            "start_date": "2015-01-12",
+            "slug": "2014",
+            "csv": "data/US_Virgin_Islands/Legislature/term-2014.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5dcbaa3/data/US_Virgin_Islands/Legislature/term-2014.csv"
+          }
+        ],
+        "statement_count": 660
+      }
+    ]
+  },
+  {
+    "name": "Uganda",
+    "country": "Uganda",
+    "code": "UG",
+    "slug": "Uganda",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Uganda/Parliament/sources",
+        "popolo": "data/Uganda/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0cef4ab/data/Uganda/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Uganda/Parliament/names.csv",
+        "lastmod": "1466099597",
+        "person_count": 647,
+        "sha": "0cef4ab",
+        "legislative_periods": [
+          {
+            "id": "term/10",
+            "name": "10th Parliament",
+            "start_date": "2016-05-16",
+            "slug": "10",
+            "csv": "data/Uganda/Parliament/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0cef4ab/data/Uganda/Parliament/term-10.csv"
+          },
+          {
+            "end_date": "2016-05-13",
+            "id": "term/9",
+            "name": "9th Parliament",
+            "start_date": "2011-05-16",
+            "slug": "9",
+            "csv": "data/Uganda/Parliament/term-9.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0cef4ab/data/Uganda/Parliament/term-9.csv"
+          }
+        ],
+        "statement_count": 18031
+      }
+    ]
+  },
+  {
+    "name": "Ukraine",
+    "country": "Ukraine",
+    "code": "UA",
+    "slug": "Ukraine",
+    "legislatures": [
+      {
+        "name": "Verkhovna Rada",
+        "slug": "Verkhovna-Rada",
+        "sources_directory": "data/Ukraine/Verkhovna_Rada/sources",
+        "popolo": "data/Ukraine/Verkhovna_Rada/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/024f1aa/data/Ukraine/Verkhovna_Rada/ep-popolo-v1.0.json",
+        "names": "data/Ukraine/Verkhovna_Rada/names.csv",
+        "lastmod": "1467874292",
+        "person_count": 451,
+        "sha": "024f1aa",
+        "legislative_periods": [
+          {
+            "id": "term/8",
+            "name": "8th Verkhovna Rada",
+            "start_date": "2014-11-27",
+            "slug": "8",
+            "csv": "data/Ukraine/Verkhovna_Rada/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/024f1aa/data/Ukraine/Verkhovna_Rada/term-8.csv"
+          }
+        ],
+        "statement_count": 21591
+      }
+    ]
+  },
+  {
+    "name": "United Arab Emirates",
+    "country": "United Arab Emirates",
+    "code": "AE",
+    "slug": "United-Arab-Emirates",
+    "legislatures": [
+      {
+        "name": "Federal National Council",
+        "slug": "Federal-National-Council",
+        "sources_directory": "data/United_Arab_Emirates/Federal_National_Council/sources",
+        "popolo": "data/United_Arab_Emirates/Federal_National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e88d9c/data/United_Arab_Emirates/Federal_National_Council/ep-popolo-v1.0.json",
+        "names": "data/United_Arab_Emirates/Federal_National_Council/names.csv",
+        "lastmod": "1466612816",
+        "person_count": 40,
+        "sha": "6e88d9c",
+        "legislative_periods": [
+          {
+            "end_date": "2015-10-03",
+            "id": "term/2011",
+            "name": "2011–2015",
+            "start_date": "2011-11-15",
+            "slug": "2011",
+            "csv": "data/United_Arab_Emirates/Federal_National_Council/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e88d9c/data/United_Arab_Emirates/Federal_National_Council/term-2011.csv"
+          }
+        ],
+        "statement_count": 709
+      }
+    ]
+  },
+  {
+    "name": "United Kingdom",
+    "country": "United Kingdom",
+    "code": "GB",
+    "slug": "UK",
+    "legislatures": [
+      {
+        "name": "House of Commons",
+        "slug": "Commons",
+        "sources_directory": "data/UK/Commons/sources",
+        "popolo": "data/UK/Commons/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04e515a/data/UK/Commons/ep-popolo-v1.0.json",
+        "names": "data/UK/Commons/names.csv",
+        "lastmod": "1467877966",
+        "person_count": 1341,
+        "sha": "04e515a",
+        "legislative_periods": [
+          {
+            "id": "term/56",
+            "name": "56th Parliament of the United Kingdom",
+            "start_date": "2015-05-08",
+            "wikidata": "Q21084473",
+            "slug": "56",
+            "csv": "data/UK/Commons/term-56.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04e515a/data/UK/Commons/term-56.csv"
+          },
+          {
+            "end_date": "2015-03-30",
+            "id": "term/55",
+            "name": "55th Parliament of the United Kingdom",
+            "start_date": "2010-05-06",
+            "wikidata": "Q21084472",
+            "slug": "55",
+            "csv": "data/UK/Commons/term-55.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04e515a/data/UK/Commons/term-55.csv"
+          },
+          {
+            "end_date": "2010-04-12",
+            "id": "term/54",
+            "name": "54th Parliament of the United Kingdom",
+            "start_date": "2005-05-05",
+            "wikidata": "Q21084471",
+            "slug": "54",
+            "csv": "data/UK/Commons/term-54.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04e515a/data/UK/Commons/term-54.csv"
+          },
+          {
+            "end_date": "2005-04-11",
+            "id": "term/53",
+            "name": "53rd Parliament of the United Kingdom",
+            "start_date": "2001-06-07",
+            "wikidata": "Q21084470",
+            "slug": "53",
+            "csv": "data/UK/Commons/term-53.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04e515a/data/UK/Commons/term-53.csv"
+          },
+          {
+            "end_date": "2001-05-14",
+            "id": "term/52",
+            "name": "52nd Parliament of the United Kingdom",
+            "start_date": "1997-05-01",
+            "wikidata": "Q21084469",
+            "slug": "52",
+            "csv": "data/UK/Commons/term-52.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04e515a/data/UK/Commons/term-52.csv"
+          }
+        ],
+        "statement_count": 130687
+      }
+    ]
+  },
+  {
+    "name": "United States of America",
+    "country": "United States of America",
+    "code": "US",
+    "slug": "United-States-of-America",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "House",
+        "sources_directory": "data/United_States_of_America/House/sources",
+        "popolo": "data/United_States_of_America/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/ep-popolo-v1.0.json",
+        "names": "data/United_States_of_America/House/names.csv",
+        "lastmod": "1467701128",
+        "person_count": 1585,
+        "sha": "735c68a",
+        "legislative_periods": [
+          {
+            "id": "term/114",
+            "name": "114th Congress",
+            "start_date": "2015-01-06",
+            "wikidata": "Q16146771",
+            "slug": "114",
+            "csv": "data/United_States_of_America/House/term-114.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-114.csv"
+          },
+          {
+            "end_date": "2015-01-03",
+            "id": "term/113",
+            "name": "113th Congress",
+            "start_date": "2013-01-06",
+            "wikidata": "Q71871",
+            "slug": "113",
+            "csv": "data/United_States_of_America/House/term-113.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-113.csv"
+          },
+          {
+            "end_date": "2013-01-03",
+            "id": "term/112",
+            "name": "112th Congress",
+            "start_date": "2011-01-06",
+            "wikidata": "Q170447",
+            "slug": "112",
+            "csv": "data/United_States_of_America/House/term-112.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-112.csv"
+          },
+          {
+            "end_date": "2011-01-03",
+            "id": "term/111",
+            "name": "111th Congress",
+            "start_date": "2009-01-06",
+            "wikidata": "Q170375",
+            "slug": "111",
+            "csv": "data/United_States_of_America/House/term-111.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-111.csv"
+          },
+          {
+            "end_date": "2009-01-03",
+            "id": "term/110",
+            "name": "110th Congress",
+            "start_date": "2007-01-06",
+            "wikidata": "Q170018",
+            "slug": "110",
+            "csv": "data/United_States_of_America/House/term-110.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-110.csv"
+          },
+          {
+            "end_date": "2007-01-03",
+            "id": "term/109",
+            "name": "109th Congress",
+            "start_date": "2005-01-06",
+            "wikidata": "Q168778",
+            "slug": "109",
+            "csv": "data/United_States_of_America/House/term-109.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-109.csv"
+          },
+          {
+            "end_date": "2005-01-03",
+            "id": "term/108",
+            "name": "108th Congress",
+            "start_date": "2003-01-06",
+            "wikidata": "Q168504",
+            "slug": "108",
+            "csv": "data/United_States_of_America/House/term-108.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-108.csv"
+          },
+          {
+            "end_date": "2003-01-03",
+            "id": "term/107",
+            "name": "107th Congress",
+            "start_date": "2001-01-06",
+            "wikidata": "Q2057259",
+            "slug": "107",
+            "csv": "data/United_States_of_America/House/term-107.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-107.csv"
+          },
+          {
+            "end_date": "2001-01-03",
+            "id": "term/106",
+            "name": "106th Congress",
+            "start_date": "1999-01-06",
+            "wikidata": "Q3596897",
+            "slug": "106",
+            "csv": "data/United_States_of_America/House/term-106.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-106.csv"
+          },
+          {
+            "end_date": "1999-01-03",
+            "id": "term/105",
+            "name": "105th Congress",
+            "start_date": "1997-01-06",
+            "wikidata": "Q3596884",
+            "slug": "105",
+            "csv": "data/United_States_of_America/House/term-105.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-105.csv"
+          },
+          {
+            "end_date": "1997-01-03",
+            "id": "term/104",
+            "name": "104th Congress",
+            "start_date": "1995-01-06",
+            "wikidata": "Q3596857",
+            "slug": "104",
+            "csv": "data/United_States_of_America/House/term-104.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-104.csv"
+          },
+          {
+            "end_date": "1995-01-03",
+            "id": "term/103",
+            "name": "103rd Congress",
+            "start_date": "1993-01-06",
+            "wikidata": "Q3556780",
+            "slug": "103",
+            "csv": "data/United_States_of_America/House/term-103.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-103.csv"
+          },
+          {
+            "end_date": "1993-01-03",
+            "id": "term/102",
+            "name": "102nd Congress",
+            "start_date": "1991-01-06",
+            "wikidata": "Q347346",
+            "slug": "102",
+            "csv": "data/United_States_of_America/House/term-102.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-102.csv"
+          },
+          {
+            "end_date": "1991-01-03",
+            "id": "term/101",
+            "name": "101st Congress",
+            "start_date": "1989-01-06",
+            "wikidata": "Q4546373",
+            "slug": "101",
+            "csv": "data/United_States_of_America/House/term-101.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-101.csv"
+          },
+          {
+            "end_date": "1989-01-03",
+            "id": "term/100",
+            "name": "100th Congress",
+            "start_date": "1987-01-06",
+            "wikidata": "Q4546248",
+            "slug": "100",
+            "csv": "data/United_States_of_America/House/term-100.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-100.csv"
+          },
+          {
+            "end_date": "1987-01-03",
+            "id": "term/99",
+            "name": "99th Congress",
+            "start_date": "1985-01-06",
+            "wikidata": "Q4646349",
+            "slug": "99",
+            "csv": "data/United_States_of_America/House/term-99.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-99.csv"
+          },
+          {
+            "end_date": "1983-01-03",
+            "id": "term/98",
+            "name": "98th Congress",
+            "start_date": "1983-01-06",
+            "wikidata": "Q4646254",
+            "slug": "98",
+            "csv": "data/United_States_of_America/House/term-98.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-98.csv"
+          },
+          {
+            "end_date": "1983-01-03",
+            "id": "term/97",
+            "name": "97th Congress",
+            "start_date": "1981-01-06",
+            "wikidata": "Q4646187",
+            "slug": "97",
+            "csv": "data/United_States_of_America/House/term-97.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/735c68a/data/United_States_of_America/House/term-97.csv"
+          }
+        ],
+        "statement_count": 218460
+      },
+      {
+        "name": "Senate",
+        "slug": "Senate",
+        "sources_directory": "data/United_States_of_America/Senate/sources",
+        "popolo": "data/United_States_of_America/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/ep-popolo-v1.0.json",
+        "names": "data/United_States_of_America/Senate/names.csv",
+        "lastmod": "1467957113",
+        "person_count": 310,
+        "sha": "cb4a755",
+        "legislative_periods": [
+          {
+            "id": "term/114",
+            "name": "114th Congress",
+            "start_date": "2015-01-06",
+            "wikidata": "Q16146771",
+            "slug": "114",
+            "csv": "data/United_States_of_America/Senate/term-114.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-114.csv"
+          },
+          {
+            "end_date": "2015-01-03",
+            "id": "term/113",
+            "name": "113th Congress",
+            "start_date": "2013-01-06",
+            "wikidata": "Q71871",
+            "slug": "113",
+            "csv": "data/United_States_of_America/Senate/term-113.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-113.csv"
+          },
+          {
+            "end_date": "2013-01-03",
+            "id": "term/112",
+            "name": "112th Congress",
+            "start_date": "2011-01-06",
+            "wikidata": "Q170447",
+            "slug": "112",
+            "csv": "data/United_States_of_America/Senate/term-112.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-112.csv"
+          },
+          {
+            "end_date": "2011-01-03",
+            "id": "term/111",
+            "name": "111th Congress",
+            "start_date": "2009-01-06",
+            "wikidata": "Q170375",
+            "slug": "111",
+            "csv": "data/United_States_of_America/Senate/term-111.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-111.csv"
+          },
+          {
+            "end_date": "2009-01-03",
+            "id": "term/110",
+            "name": "110th Congress",
+            "start_date": "2007-01-06",
+            "wikidata": "Q170018",
+            "slug": "110",
+            "csv": "data/United_States_of_America/Senate/term-110.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-110.csv"
+          },
+          {
+            "end_date": "2007-01-03",
+            "id": "term/109",
+            "name": "109th Congress",
+            "start_date": "2005-01-06",
+            "wikidata": "Q168778",
+            "slug": "109",
+            "csv": "data/United_States_of_America/Senate/term-109.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-109.csv"
+          },
+          {
+            "end_date": "2005-01-03",
+            "id": "term/108",
+            "name": "108th Congress",
+            "start_date": "2003-01-06",
+            "wikidata": "Q168504",
+            "slug": "108",
+            "csv": "data/United_States_of_America/Senate/term-108.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-108.csv"
+          },
+          {
+            "end_date": "2003-01-03",
+            "id": "term/107",
+            "name": "107th Congress",
+            "start_date": "2001-01-06",
+            "wikidata": "Q2057259",
+            "slug": "107",
+            "csv": "data/United_States_of_America/Senate/term-107.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-107.csv"
+          },
+          {
+            "end_date": "2001-01-03",
+            "id": "term/106",
+            "name": "106th Congress",
+            "start_date": "1999-01-06",
+            "wikidata": "Q3596897",
+            "slug": "106",
+            "csv": "data/United_States_of_America/Senate/term-106.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-106.csv"
+          },
+          {
+            "end_date": "1999-01-03",
+            "id": "term/105",
+            "name": "105th Congress",
+            "start_date": "1997-01-06",
+            "wikidata": "Q3596884",
+            "slug": "105",
+            "csv": "data/United_States_of_America/Senate/term-105.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-105.csv"
+          },
+          {
+            "end_date": "1997-01-03",
+            "id": "term/104",
+            "name": "104th Congress",
+            "start_date": "1995-01-06",
+            "wikidata": "Q3596857",
+            "slug": "104",
+            "csv": "data/United_States_of_America/Senate/term-104.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-104.csv"
+          },
+          {
+            "end_date": "1995-01-03",
+            "id": "term/103",
+            "name": "103rd Congress",
+            "start_date": "1993-01-06",
+            "wikidata": "Q3556780",
+            "slug": "103",
+            "csv": "data/United_States_of_America/Senate/term-103.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-103.csv"
+          },
+          {
+            "end_date": "1993-01-03",
+            "id": "term/102",
+            "name": "102nd Congress",
+            "start_date": "1991-01-06",
+            "wikidata": "Q347346",
+            "slug": "102",
+            "csv": "data/United_States_of_America/Senate/term-102.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-102.csv"
+          },
+          {
+            "end_date": "1991-01-03",
+            "id": "term/101",
+            "name": "101st Congress",
+            "start_date": "1989-01-06",
+            "wikidata": "Q4546373",
+            "slug": "101",
+            "csv": "data/United_States_of_America/Senate/term-101.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-101.csv"
+          },
+          {
+            "end_date": "1989-01-03",
+            "id": "term/100",
+            "name": "100th Congress",
+            "start_date": "1987-01-06",
+            "wikidata": "Q4546248",
+            "slug": "100",
+            "csv": "data/United_States_of_America/Senate/term-100.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-100.csv"
+          },
+          {
+            "end_date": "1987-01-03",
+            "id": "term/99",
+            "name": "99th Congress",
+            "start_date": "1985-01-06",
+            "wikidata": "Q4646349",
+            "slug": "99",
+            "csv": "data/United_States_of_America/Senate/term-99.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-99.csv"
+          },
+          {
+            "end_date": "1983-01-03",
+            "id": "term/98",
+            "name": "98th Congress",
+            "start_date": "1983-01-06",
+            "wikidata": "Q4646254",
+            "slug": "98",
+            "csv": "data/United_States_of_America/Senate/term-98.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-98.csv"
+          },
+          {
+            "end_date": "1983-01-03",
+            "id": "term/97",
+            "name": "97th Congress",
+            "start_date": "1981-01-06",
+            "wikidata": "Q4646187",
+            "slug": "97",
+            "csv": "data/United_States_of_America/Senate/term-97.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb4a755/data/United_States_of_America/Senate/term-97.csv"
+          }
+        ],
+        "statement_count": 67815
+      }
+    ]
+  },
+  {
+    "name": "Uruguay",
+    "country": "Uruguay",
+    "code": "UY",
+    "slug": "Uruguay",
+    "legislatures": [
+      {
+        "name": "Chamber of Deputies",
+        "slug": "Deputies",
+        "sources_directory": "data/Uruguay/Deputies/sources",
+        "popolo": "data/Uruguay/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/379e0fb/data/Uruguay/Deputies/ep-popolo-v1.0.json",
+        "names": "data/Uruguay/Deputies/names.csv",
+        "lastmod": "1466619357",
+        "person_count": 106,
+        "sha": "379e0fb",
+        "legislative_periods": [
+          {
+            "id": "term/48",
+            "name": "XLVIII Legislatura",
+            "start_date": "2015-02-15",
+            "slug": "48",
+            "csv": "data/Uruguay/Deputies/term-48.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/379e0fb/data/Uruguay/Deputies/term-48.csv"
+          }
+        ],
+        "statement_count": 3451
+      }
+    ]
+  },
+  {
+    "name": "Uzbekistan",
+    "country": "Uzbekistan",
+    "code": "UZ",
+    "slug": "Uzbekistan",
+    "legislatures": [
+      {
+        "name": "Legislative Chamber",
+        "slug": "Legislative-Chamber",
+        "sources_directory": "data/Uzbekistan/Legislative_Chamber/sources",
+        "popolo": "data/Uzbekistan/Legislative_Chamber/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Uzbekistan/Legislative_Chamber/ep-popolo-v1.0.json",
+        "names": "data/Uzbekistan/Legislative_Chamber/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 147,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "5th Convocation",
+            "start_date": "2015-01-12",
+            "slug": "5",
+            "csv": "data/Uzbekistan/Legislative_Chamber/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Uzbekistan/Legislative_Chamber/term-5.csv"
+          }
+        ],
+        "statement_count": 2499
+      }
+    ]
+  },
+  {
+    "name": "Vanuatu",
+    "country": "Vanuatu",
+    "code": "VU",
+    "slug": "Vanuatu",
+    "legislatures": [
+      {
+        "name": "Parliament",
+        "slug": "Parliament",
+        "sources_directory": "data/Vanuatu/Parliament/sources",
+        "popolo": "data/Vanuatu/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2b091e3/data/Vanuatu/Parliament/ep-popolo-v1.0.json",
+        "names": "data/Vanuatu/Parliament/names.csv",
+        "lastmod": "1467654454",
+        "person_count": 96,
+        "sha": "2b091e3",
+        "legislative_periods": [
+          {
+            "id": "term/11",
+            "name": "11th Parliament",
+            "start_date": "2016-02-11",
+            "slug": "11",
+            "csv": "data/Vanuatu/Parliament/term-11.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2b091e3/data/Vanuatu/Parliament/term-11.csv"
+          },
+          {
+            "end_date": "2015-11-24",
+            "id": "term/10",
+            "name": "10th Parliament",
+            "start_date": "2012-11-19",
+            "slug": "10",
+            "csv": "data/Vanuatu/Parliament/term-10.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2b091e3/data/Vanuatu/Parliament/term-10.csv"
+          }
+        ],
+        "statement_count": 2945
+      }
+    ]
+  },
+  {
+    "name": "Vatican City",
+    "country": "Vatican City",
+    "code": "VA",
+    "slug": "Vatican-City",
+    "legislatures": [
+      {
+        "name": "Pontifical Commission",
+        "slug": "Pontifical-Commission",
+        "sources_directory": "data/Vatican_City/Pontifical_Commission/sources",
+        "popolo": "data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
+        "names": "data/Vatican_City/Pontifical_Commission/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 7,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/2011",
+            "name": "2011–",
+            "start_date": "2011-10-01",
+            "slug": "2011",
+            "csv": "data/Vatican_City/Pontifical_Commission/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Vatican_City/Pontifical_Commission/term-2011.csv"
+          }
+        ],
+        "statement_count": 1283
+      }
+    ]
+  },
+  {
+    "name": "Venezuela",
+    "country": "Venezuela",
+    "code": "VE",
+    "slug": "Venezuela",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Venezuela/Assembly/sources",
+        "popolo": "data/Venezuela/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c4ab87/data/Venezuela/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Venezuela/Assembly/names.csv",
+        "lastmod": "1467956360",
+        "person_count": 279,
+        "sha": "9c4ab87",
+        "legislative_periods": [
+          {
+            "id": "term/2016",
+            "name": "2016–",
+            "start_date": "2016-01-05",
+            "slug": "2016",
+            "csv": "data/Venezuela/Assembly/term-2016.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c4ab87/data/Venezuela/Assembly/term-2016.csv"
+          },
+          {
+            "end_date": "2016-01-04",
+            "id": "term/2011",
+            "name": "2011–2016",
+            "start_date": "2011-01-05",
+            "slug": "2011",
+            "csv": "data/Venezuela/Assembly/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c4ab87/data/Venezuela/Assembly/term-2011.csv"
+          }
+        ],
+        "statement_count": 6888
+      }
+    ]
+  },
+  {
+    "name": "Vietnam",
+    "country": "Vietnam",
+    "code": "VN",
+    "slug": "Vietnam",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "National-Assembly",
+        "sources_directory": "data/Vietnam/National_Assembly/sources",
+        "popolo": "data/Vietnam/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d890681/data/Vietnam/National_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Vietnam/National_Assembly/names.csv",
+        "lastmod": "1467816731",
+        "person_count": 492,
+        "sha": "d890681",
+        "legislative_periods": [
+          {
+            "end_date": "2016-05-22",
+            "id": "term/13",
+            "name": "13th Congress",
+            "start_date": "2011-07-25",
+            "slug": "13",
+            "csv": "data/Vietnam/National_Assembly/term-13.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d890681/data/Vietnam/National_Assembly/term-13.csv"
+          }
+        ],
+        "statement_count": 12160
+      }
+    ]
+  },
+  {
+    "name": "Wales",
+    "country": "Wales",
+    "code": "GB-WLS",
+    "slug": "Wales",
+    "legislatures": [
+      {
+        "name": "National Assembly for Wales",
+        "slug": "Assembly",
+        "sources_directory": "data/Wales/Assembly/sources",
+        "popolo": "data/Wales/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dd9aab5/data/Wales/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Wales/Assembly/names.csv",
+        "lastmod": "1467861984",
+        "person_count": 85,
+        "sha": "dd9aab5",
+        "legislative_periods": [
+          {
+            "id": "term/5",
+            "name": "Fifth Assembly",
+            "start_date": "2016-05-06",
+            "slug": "5",
+            "csv": "data/Wales/Assembly/term-5.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dd9aab5/data/Wales/Assembly/term-5.csv"
+          },
+          {
+            "end_date": "2016-04-06",
+            "id": "term/4",
+            "name": "Fourth Assembly",
+            "start_date": "2011-09-15",
+            "slug": "4",
+            "csv": "data/Wales/Assembly/term-4.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dd9aab5/data/Wales/Assembly/term-4.csv"
+          }
+        ],
+        "statement_count": 5680
+      }
+    ]
+  },
+  {
+    "name": "Wallis and Futuna",
+    "country": "Wallis and Futuna",
+    "code": "WF",
+    "slug": "Wallis-and-Futuna",
+    "legislatures": [
+      {
+        "name": "Territorial Assembly",
+        "slug": "Territorial-Assembly",
+        "sources_directory": "data/Wallis_and_Futuna/Territorial_Assembly/sources",
+        "popolo": "data/Wallis_and_Futuna/Territorial_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Wallis_and_Futuna/Territorial_Assembly/ep-popolo-v1.0.json",
+        "names": "data/Wallis_and_Futuna/Territorial_Assembly/names.csv",
+        "lastmod": "1465812521",
+        "person_count": 20,
+        "sha": "75b7651",
+        "legislative_periods": [
+          {
+            "id": "term/2012",
+            "name": "2012–",
+            "start_date": "2012",
+            "slug": "2012",
+            "csv": "data/Wallis_and_Futuna/Territorial_Assembly/term-2012.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Wallis_and_Futuna/Territorial_Assembly/term-2012.csv"
+          }
+        ],
+        "statement_count": 470
+      }
+    ]
+  },
+  {
+    "name": "Yemen",
+    "country": "Yemen",
+    "code": "YE",
+    "slug": "Yemen",
+    "legislatures": [
+      {
+        "name": "House of Representatives",
+        "slug": "Majlis",
+        "sources_directory": "data/Yemen/Majlis/sources",
+        "popolo": "data/Yemen/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/845c7f6/data/Yemen/Majlis/ep-popolo-v1.0.json",
+        "names": "data/Yemen/Majlis/names.csv",
+        "lastmod": "1466142112",
+        "person_count": 302,
+        "sha": "845c7f6",
+        "legislative_periods": [
+          {
+            "id": "term/2003",
+            "name": "2003–",
+            "start_date": "2003-05-10",
+            "slug": "2003",
+            "csv": "data/Yemen/Majlis/term-2003.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/845c7f6/data/Yemen/Majlis/term-2003.csv"
+          }
+        ],
+        "statement_count": 5185
+      }
+    ]
+  },
+  {
+    "name": "Zambia",
+    "country": "Zambia",
+    "code": "ZM",
+    "slug": "Zambia",
+    "legislatures": [
+      {
+        "name": "National Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Zambia/Assembly/sources",
+        "popolo": "data/Zambia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8966226/data/Zambia/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Zambia/Assembly/names.csv",
+        "lastmod": "1466489747",
+        "person_count": 148,
+        "sha": "8966226",
+        "legislative_periods": [
+          {
+            "id": "term/2011",
+            "name": "11th Assembly",
+            "start_date": "2011-10-06",
+            "slug": "2011",
+            "csv": "data/Zambia/Assembly/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8966226/data/Zambia/Assembly/term-2011.csv"
+          }
+        ],
+        "statement_count": 3832
+      }
+    ]
+  },
+  {
+    "name": "Zimbabwe",
+    "country": "Zimbabwe",
+    "code": "ZW",
+    "slug": "Zimbabwe",
+    "legislatures": [
+      {
+        "name": "House of Assembly",
+        "slug": "Assembly",
+        "sources_directory": "data/Zimbabwe/Assembly/sources",
+        "popolo": "data/Zimbabwe/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3793a71/data/Zimbabwe/Assembly/ep-popolo-v1.0.json",
+        "names": "data/Zimbabwe/Assembly/names.csv",
+        "lastmod": "1466353801",
+        "person_count": 229,
+        "sha": "3793a71",
+        "legislative_periods": [
+          {
+            "id": "term/8",
+            "name": "8th Parliament",
+            "start_date": "2013-09-17",
+            "slug": "8",
+            "csv": "data/Zimbabwe/Assembly/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3793a71/data/Zimbabwe/Assembly/term-8.csv"
+          }
+        ],
+        "statement_count": 5886
+      },
+      {
+        "name": "Senate",
+        "slug": "Senate",
+        "sources_directory": "data/Zimbabwe/Senate/sources",
+        "popolo": "data/Zimbabwe/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ec0d3bf/data/Zimbabwe/Senate/ep-popolo-v1.0.json",
+        "names": "data/Zimbabwe/Senate/names.csv",
+        "lastmod": "1466353802",
+        "person_count": 67,
+        "sha": "ec0d3bf",
+        "legislative_periods": [
+          {
+            "id": "term/8",
+            "name": "8th Parliament",
+            "start_date": "2013-09-17",
+            "slug": "8",
+            "csv": "data/Zimbabwe/Senate/term-8.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ec0d3bf/data/Zimbabwe/Senate/term-8.csv"
+          }
+        ],
+        "statement_count": 1334
+      }
+    ]
+  },
+  {
+    "name": "Åland",
+    "country": "Åland",
+    "code": "AX",
+    "slug": "Aland",
+    "legislatures": [
+      {
+        "name": "Lagting",
+        "slug": "Lagting",
+        "sources_directory": "data/Aland/Lagting/sources",
+        "popolo": "data/Aland/Lagting/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/675cf00/data/Aland/Lagting/ep-popolo-v1.0.json",
+        "names": "data/Aland/Lagting/names.csv",
+        "lastmod": "1467095804",
+        "person_count": 60,
+        "sha": "675cf00",
+        "legislative_periods": [
+          {
+            "end_date": "2019-10-31",
+            "id": "term/2015",
+            "name": "2015–2019",
+            "start_date": "2015-11-02",
+            "slug": "2015",
+            "csv": "data/Aland/Lagting/term-2015.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/675cf00/data/Aland/Lagting/term-2015.csv"
+          },
+          {
+            "end_date": "2015",
+            "id": "term/2011",
+            "name": "2011–2015",
+            "start_date": "2011",
+            "slug": "2011",
+            "csv": "data/Aland/Lagting/term-2011.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/675cf00/data/Aland/Lagting/term-2011.csv"
+          },
+          {
+            "end_date": "2011",
+            "id": "term/2007",
+            "name": "2007–2011",
+            "start_date": "2007",
+            "slug": "2007",
+            "csv": "data/Aland/Lagting/term-2007.csv",
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/675cf00/data/Aland/Lagting/term-2007.csv"
+          }
+        ],
+        "statement_count": 3321
+      }
+    ]
+  }
+]

--- a/tests/page/post.rb
+++ b/tests/page/post.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../lib/page/post'
+
+describe 'Page::Post' do
+  let(:contents) { '---
+title: A Title
+slug: a-slug
+published: true
+---
+# Hello World' }
+  let(:filenames) { [
+    new_tempfile(contents, '2016-01-01-foo'),
+    new_tempfile('irrelevant', '2012-01-01-bar')
+  ] }
+  let(:page) { Page::Post.new(directory: Dir.tmpdir, slug: 'foo') }
+
+  it 'has a title' do
+    Dir.stub :glob, filenames do
+      page.title.must_equal('A Title')
+    end
+  end
+
+  it 'formats the post date' do
+    Dir.stub :glob, filenames do
+      page.date.must_equal('January 1, 2016')
+    end
+  end
+
+  it 'has the post contents' do
+    Dir.stub :glob, filenames do
+      page.body.must_include('<h1>Hello World</h1>')
+    end
+  end
+end

--- a/tests/page/post.rb
+++ b/tests/page/post.rb
@@ -33,11 +33,18 @@ published: true
     end
   end
 
-  describe 'when found fails' do
+  describe 'when it fails to find a post' do
     it 'detects multiple posts with same name and different dates' do
       filenames = ['2016-01-01-foo', '2012-01-01-foo']
       Dir.stub :glob, filenames do
         page.multiple?.must_equal(true)
+      end
+    end
+
+    it 'detects that there are no posts with a slug' do
+      filenames = []
+      Dir.stub :glob, filenames do
+        page.none?.must_equal(true)
       end
     end
   end

--- a/tests/page/post.rb
+++ b/tests/page/post.rb
@@ -32,4 +32,13 @@ published: true
       page.body.must_include('<h1>Hello World</h1>')
     end
   end
+
+  describe 'when found fails' do
+    it 'detects multiple posts with same name and different dates' do
+      filenames = ['2016-01-01-foo', '2012-01-01-foo']
+      Dir.stub :glob, filenames do
+        page.multiple?.must_equal(true)
+      end
+    end
+  end
 end

--- a/tests/page/posts.rb
+++ b/tests/page/posts.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../lib/page/posts'
+
+describe 'Page::Posts' do
+  let(:page) { Page::Posts.new(directory: Dir.tmpdir) }
+  let(:filenames) { ['2016-01-01-foo.md', '2012-01-01-bar.md'] }
+
+  it 'retrieves all posts' do
+    Dir.stub :glob, filenames do
+      page.sorted_posts.count.must_equal(2)
+    end
+  end
+
+  it 'links posts to a url under the blog path' do
+    blog_path = Page::Posts::BASEURL
+    filenames = [
+      new_tempfile('', '2016-01-01-foo'),
+      new_tempfile('', '2012-01-01-bar')
+    ]
+    Dir.stub :glob, filenames do
+      first.url.must_include("#{blog_path}foo")
+      last.url.must_include("#{blog_path}bar")
+    end
+  end
+
+  it 'sorts the posts from newer to older' do
+    Dir.stub :glob, filenames do
+      first_is_newer = first.date > last.date
+      first_is_newer.must_equal(true)
+    end
+  end
+
+  it 'formats the date' do
+    page.format_date(Date.iso8601('1000-10-01')).must_equal('October 1, 1000')
+  end
+
+  def first
+    page.sorted_posts.first
+  end
+
+  def last
+    page.sorted_posts.last
+  end
+end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -17,7 +17,8 @@ module Minitest
     end
 
     before do
-      stub_request(:get, DATASOURCE).to_return(body: countries_json)
+      get_from_disk(DATASOURCE, countries_json)
+      get_from_disk(assembly_json_url, assembly_json)
     end
 
     def new_tempfile(contents, filename = 'sye-tests')
@@ -30,11 +31,25 @@ module Minitest
     private
 
     DATASOURCE = 'https://github.com/everypolitician/everypolitician-data/raw/master/countries.json'
+    REPO_URL = 'https://cdn.rawgit.com/everypolitician/everypolitician-data'
     DISK_PATH = 'tests/fixtures/ep_data'
     COUNTRIES_SHA = 'd8a4682'
+    ASSEMBLY_SHA = '75b7651'
+
+    def get_from_disk(url, json_file)
+      stub_request(:get, url).to_return(body: json_file)
+    end
+
+    def assembly_json_url
+      "#{REPO_URL}/#{ASSEMBLY_SHA}/data/Nigeria/Assembly/ep-popolo-v1.0.json"
+    end
 
     def countries_json
       @countries_json ||= File.read("#{DISK_PATH}/#{COUNTRIES_SHA}/countries.json")
+    end
+
+    def assembly_json
+      @assembly_json ||= File.read("#{DISK_PATH}/#{ASSEMBLY_SHA}/ep-popolo-v1.0.json")
     end
   end
 end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -6,6 +6,7 @@ require 'minitest/autorun'
 require 'nokogiri'
 require 'pry'
 require 'rack/test'
+require 'webmock/minitest'
 
 module Minitest
   class Spec
@@ -15,11 +16,25 @@ module Minitest
       Sinatra::Application
     end
 
+    before do
+      stub_request(:get, DATASOURCE).to_return(body: countries_json)
+    end
+
     def new_tempfile(contents, filename = 'sye-tests')
       Tempfile.open([filename, '.md']) do |f|
         f.write(contents)
         f.path
       end
+    end
+
+    private
+
+    DATASOURCE = 'https://github.com/everypolitician/everypolitician-data/raw/master/countries.json'
+    DISK_PATH = 'tests/fixtures/ep_data'
+    COUNTRIES_SHA = 'd8a4682'
+
+    def countries_json
+      @countries_json ||= File.read("#{DISK_PATH}/#{COUNTRIES_SHA}/countries.json")
     end
   end
 end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -4,8 +4,8 @@ ENV['RACK_ENV'] = 'test'
 require 'everypolitician'
 require 'minitest/autorun'
 require 'nokogiri'
-require 'rack/test'
 require 'pry'
+require 'rack/test'
 
 module Minitest
   class Spec

--- a/tests/web/post.rb
+++ b/tests/web/post.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../app'
+
+describe 'Post Page' do
+  before { get '/blog/citizens-solutions-end-terrorism' }
+  subject { Nokogiri::HTML(last_response.body) }
+
+  it 'shows the post title' do
+    subject.css('.page-title').text.must_equal("Citizens’ Solutions to End Terrorism")
+  end
+
+  it 'shows the date with the right format' do
+    subject.css('.meta').first.text.must_equal('April 18, 2014')
+  end
+
+  it 'displays the contents of the post' do
+    subject.css('.markdown.infopage').text.must_include('Nigerians woke up to news')
+  end
+end

--- a/tests/web/posts.rb
+++ b/tests/web/posts.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../app'
+
+describe 'Posts Page' do
+  before { get '/blog/' }
+  subject { Nokogiri::HTML(last_response.body) }
+
+  it 'shows all posts' do
+    more_than_one = subject.css('.blog-in-a-list').count > 1
+    more_than_one.must_equal(true)
+  end
+
+  describe 'when displaying a post' do
+    let(:single_post) { subject.css('.blog-in-a-list').last }
+
+    it 'links to post url' do
+      single_post.css('h2 a/@href').text.must_equal('/blog/citizens-solutions-end-terrorism')
+    end
+
+    it 'displays post title' do
+      single_post.css('h2').text.must_equal('Citizens’ Solutions to End Terrorism')
+    end
+
+    it 'displays post date' do
+      single_post.css('.meta').text.must_equal('April 18, 2014')
+    end
+
+    it 'displays post excerpt' do
+      single_post.css('div').text.must_include('Nigerians woke up to news')
+    end
+  end
+end

--- a/views/post.erb
+++ b/views/post.erb
@@ -1,5 +1,13 @@
-<h1><%= @post.title %></h1>
+<div class="blog-post">
 
-<p><%= @post.date.strftime("%B %-d, %Y") %></p>
+  <h1 class="page-title"><%= @page.title %></h1>
 
-<%= @post.body %>
+  <p class="meta"><%= @page.date %></p>
+
+  <div class="markdown infopage">
+    <%= @page.body %>
+  </div>
+
+</div>
+
+<%= erb :_comments %>

--- a/views/posts.erb
+++ b/views/posts.erb
@@ -1,7 +1,23 @@
 <h1>Blog</h1>
 
-<ul>
-  <% @posts.each do |post| %>
-  <li><a href="<%= post.url %>"><%= post.title %></a></li>
+<div class="blog-list">
+
+  <% @page.sorted_posts.each do |post| %>
+
+  <div class="blog-in-a-list">
+
+    <h2><a href="<%= post.url %>"><%= post.title %></a></h2>
+
+    <p class="meta"><%= @page.format_date(post.date) %></p>
+
+    <div>
+      <%= post.body %>
+    </div>
+
+    <p><a href="<%= post.url %>">Read more …</a></p>
+
+  </div>
+
   <% end %>
-</ul>
+
+</div>


### PR DESCRIPTION
This PR updates the views in the blog and single blog post so that they use the markup and css classes used in the Jekyll version of the site.

In the way to achieve that, it also adds a convenient class to find markdown files in specific folders, a functionality that will be needed for the rest of content subfolders inside the prose folder.

Finally, it stubs the http requests made to github so that the web tests don't force you to be connected to the internet for them to pass.