### PR TITLE
Let the deploy script use a specific version of content from prose.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 script:
-  - bin/deploy
+  - bin/deploy ffc1fe0
   - bundle exec rake
 sudo: false
 rvm:

--- a/bin/deploy
+++ b/bin/deploy
@@ -4,6 +4,7 @@ set -e
 
 PROSE_REPO_URL='https://github.com/theyworkforyou/shineyoureye-prose.git'
 PROSE_DIR='prose'
+PROSE_COMMITISH=$1
 
 # Make sure we're in the right directory:
 cd "$(dirname ${BASH_SOURCE[0]})"/..
@@ -14,6 +15,12 @@ then
     (cd "$PROSE_DIR" && git fetch origin && git reset --hard origin/gh-pages)
 else
     git clone "$PROSE_REPO_URL" "$PROSE_DIR"
+fi
+
+# Checkout a specific prose sha for tests
+if [ -n "$PROSE_COMMITISH" ]
+then
+    (cd "$PROSE_DIR" && git checkout "$PROSE_SHA")
 fi
 
 # Symlink the media directories into the right place:

--- a/lib/page/info.rb
+++ b/lib/page/info.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# require_relative '../document/markdown_with_frontmatter'
+
+module Page
+  class Info
+  end
+end

--- a/tests/page/info.rb
+++ b/tests/page/info.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../lib/page/info'
+
+describe 'Page::Info' do
+  let(:page) { Page::Info.new }
+
+  it 'has a title' do
+    page.title.must_equal('')
+  end
+end


### PR DESCRIPTION
The deploy script can now be passed an argument so that we can
git checkout a specific SHA in the content repository after cloning it,
and before symlinking the media files.

This is done so that the tests can be run at a specific sha of the
prose repository, in order to get predictable test output.