### PR TITLE
Simplify rakefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 script:
   - bin/deploy ffc1fe0
-  - bundle exec rake
+  - bundle exec rake test
 sudo: false
 rvm:
   - 2.3.1

--- a/README.md
+++ b/README.md
@@ -12,20 +12,15 @@ and then go to <http://localhost:4567/>
 
 ## Run the tests
 
-### Run the document tests
-
-```
-bundle exec rake test:doc
-```
-
-### Run the web tests
-
-```
-bundle exec rake test:web
-```
 
 ### Run all tests
 
 ```
-bundle exec rake
+bundle exec rake test
+```
+
+### Run one test file
+
+```
+bundle exec rake test TEST='path/to/test/file'
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -2,19 +2,11 @@
 require 'rake/testtask'
 
 Rake::TestTask.new do |t|
-  t.name = 'test:doc'
+  t.name = 'test'
   t.warning = true
-  t.description = 'Run "Document" tests'
-  t.test_files = FileList['tests/document/*.rb']
+  t.description = 'Run all tests'
+  t.test_files = FileList['tests/**/*.rb']
   t.libs << 'tests'
 end
 
-Rake::TestTask.new do |t|
-  t.name = 'test:web'
-  t.warning = true
-  t.description = 'Run "Web" tests'
-  t.test_files = FileList['tests/web/*.rb']
-  t.libs << 'tests'
-end
-
-task default: ['test:doc', 'test:web']
+task default: ['test']


### PR DESCRIPTION
The Rakefile was simplified leaving only a task that runs all the tests as specified in the `default` task definition. This allows to run all the tests as `bundle exec rake test`