### PR TITLE
Small bugfix for the BASEURL constant being quoted needlessly

### DIFF
--- a/lib/page/post.rb
+++ b/lib/page/post.rb
@@ -44,7 +44,7 @@ module Page
     end
 
     def post
-      Document::MarkdownWithFrontmatter.new(filename: found.first, baseurl: 'BASEURL')
+      Document::MarkdownWithFrontmatter.new(filename: found.first, baseurl: BASEURL)
     end
   end
 end


### PR DESCRIPTION
`BASEURL` was quoted in the post page.