### PR TITLE
Add Info pages

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -3,6 +3,7 @@ require 'sinatra'
 
 require_relative 'lib/document/markdown_with_frontmatter'
 require_relative 'lib/helpers/constants_helper'
+require_relative 'lib/page/info'
 require_relative 'lib/page/posts'
 require_relative 'lib/page/post'
 
@@ -29,4 +30,10 @@ get '/blog/:slug' do |slug|
   raise Sinatra::NotFound if @page.none?
   raise "Multiple posts matched '#{slug}'" if @page.multiple?
   erb :post
+end
+
+get '/info/:slug' do |slug|
+  @page = Page::Info.new(directory: info_dir, slug: slug)
+  raise Sinatra::NotFound if @page.none?
+  erb :info
 end

--- a/lib/helpers/constants_helper.rb
+++ b/lib/helpers/constants_helper.rb
@@ -3,6 +3,10 @@ module ConstantsHelper
     settings.content_dir
   end
 
+  def info_dir
+    "#{content_dir}/info"
+  end
+
   def posts_dir
     "#{content_dir}/posts"
   end

--- a/lib/page/info.rb
+++ b/lib/page/info.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require_relative '../document/markdown_with_frontmatter'
+
+module Page
+  class Info
+    BASEURL = '/info/'
+
+    def initialize(directory:, slug:)
+      @directory = directory
+      @slug = slug
+    end
+
+    def title
+      static_page.title
+    end
+
+    def body
+      static_page.body
+    end
+
+    def none?
+      found.empty?
+    end
+
+    private
+
+    attr_reader :directory, :slug
+
+    def found
+      @found ||= Dir.glob(pattern)
+    end
+
+    def pattern
+      "#{directory}/#{slug}.md"
+    end
+
+    def static_page
+      Document::MarkdownWithFrontmatter.new(filename: found.first, baseurl: BASEURL)
+    end
+  end
+end

--- a/tests/page/info.rb
+++ b/tests/page/info.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../lib/page/info'
+
+describe 'Page::Info' do
+  let(:contents) { '---
+title: A Title
+---
+# Hello World' }
+  let(:filenames) { [new_tempfile(contents, 'info-page-slug')] }
+  let(:page) { Page::Info.new(directory: Dir.tmpdir, slug: 'info-page-slug') }
+
+  it 'has a title' do
+    Dir.stub :glob, filenames do
+      page.title.must_equal('A Title')
+    end
+  end
+
+  it 'has a body' do
+    Dir.stub :glob, filenames do
+      page.body.must_include('<h1>Hello World</h1>')
+    end
+  end
+
+  describe 'when it fails to find a static page' do
+    it 'detects that there are no pages with a slug' do
+      filenames = []
+      Dir.stub :glob, filenames do
+        page.none?.must_equal(true)
+      end
+    end
+  end
+end

--- a/tests/web/info.rb
+++ b/tests/web/info.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../app'
+
+describe 'Info Page' do
+  before { get '/info/about' }
+  subject { Nokogiri::HTML(last_response.body) }
+
+  it 'shows the post title' do
+    subject.css('.page-title').text.must_equal("About")
+  end
+
+  it 'displays the contents of the page' do
+    subject.css('.markdown.infopage').text
+      .must_include('Shine your Eye is an initiative of Enough is Enough Nigeria')
+  end
+end

--- a/views/info.erb
+++ b/views/info.erb
@@ -1,0 +1,5 @@
+<h1 class="page-title"><%= @page.title %></h1>
+
+<div class="markdown infopage">
+  <%= @page.body %>
+</div>


### PR DESCRIPTION
This PR adds a generic presenter page for all info pages (static pages) and the corresponding route and view.

### Short story
For now this is a working solution for the pages that currently exist under `prose/info/`, which don't contain the date in the filename. The presenter is searching for files with a pattern of `"#{directory}/#{slug}.md"`. If new pages are added, prose will include the date in the filename when saving. There doesn't seem to be a way to tell prose to enable/disable the date in the filename, so I have raised an issue with them just in case. - **Update:** They have confirmed it is not possible.

### Long story
- If you don't provide a `title` field in the frontmatter, the `title` text field in the prose editor will show the full file path, for example:
`posts/2017-01-12-your-filename.md`, which you can edit in case you wanted to remove the date. But we don't want the users editing file paths because that's prone to them messing things up.
- Also, if you chose to not provide a `title` field in the frontmatter, you could add a title in the editor, if you go to the metadata form and add it inside the  **Raw metadata** textarea as `title: A title`. Again not ideal!
- If you **do** provide a title field in the frontmatter, the title text field in the prose editor will show either `Untitled` or the default you specified in `value`. But then you can't change the filename, it will be saved as `YYYY-MM-DD-slug.md`.

We strongly want the last option, but with the possibility to enable/disable the inclusion the date in the filename in the prose config file. So I created an issue in the prose repo for that.

This behaviour does not affect existing files that don't include the date in the filename if they are edited.

Also interesting other issue which is related: https://github.com/prose/prose/issues/664