### PR TITLE
Add featured field to the frontmatter for summaries

### DIFF
--- a/lib/document/frontmatter_parser.rb
+++ b/lib/document/frontmatter_parser.rb
@@ -19,6 +19,10 @@ module Document
       fetch('published', true)
     end
 
+    def featured?
+      fetch('featured', false)
+    end
+
     private
 
     attr_reader :filecontents

--- a/lib/document/markdown_with_frontmatter.rb
+++ b/lib/document/markdown_with_frontmatter.rb
@@ -25,6 +25,10 @@ module Document
       frontmatter.published?
     end
 
+    def featured?
+      frontmatter.featured?
+    end
+
     def body
       markdown.as_html
     end

--- a/tests/document/frontmatter_parser.rb
+++ b/tests/document/frontmatter_parser.rb
@@ -38,6 +38,20 @@ foo: bar
 ---'
       parser(contents).published?.must_equal(true)
     end
+
+    it 'knows if it is featured' do
+      contents = '---
+featured: true
+---'
+      parser(contents).featured?.must_equal(true)
+    end
+
+    it 'is not featured by default' do
+      contents = '---
+foo: bar
+---'
+      parser(contents).featured?.must_equal(false)
+    end
   end
 
   describe 'when file has frontmatter and markdown' do

--- a/tests/document/markdown_with_frontmatter.rb
+++ b/tests/document/markdown_with_frontmatter.rb
@@ -36,6 +36,10 @@ published: true
     document.date.day.must_equal(1)
   end
 
+  it 'is not featured' do
+    document.featured?.must_equal(false)
+  end
+
   describe 'when there is no slug field' do
     it 'builds the url from the filename' do
       document = Document::MarkdownWithFrontmatter.new(


### PR DESCRIPTION
The featured field is added so that three persons can appear as featured in the front page. We do this by adding a feature field in the frontmatter of summaries, which are mapped 1-1 to persons.