### PR TITLE
Extract a finder class to hold the logic for finding a file

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,6 +1,7 @@
 require 'everypolitician'
 require 'sinatra'
 
+require_relative 'lib/document/finder'
 require_relative 'lib/document/markdown_with_frontmatter'
 require_relative 'lib/helpers/constants_helper'
 require_relative 'lib/page/info'
@@ -21,19 +22,19 @@ get '/places/' do
 end
 
 get '/blog/' do
-  @page = Page::Posts.new(baseurl: '/blog/', directory: posts_dir)
+  finder = Document::Finder.new(pattern: posts_pattern, baseurl: '/blog/')
+  @page = Page::Posts.new(posts: finder.find_all)
   erb :posts
 end
 
 get '/blog/:slug' do |slug|
-  @page = Page::Post.new(baseurl: '/blog/', directory: posts_dir, slug: slug)
-  raise Sinatra::NotFound if @page.none?
-  raise "Multiple posts matched '#{slug}'" if @page.multiple?
+  finder = Document::Finder.new(pattern: post_pattern(slug), baseurl: '/blog/')
+  @page = Page::Post.new(post: finder.find_single)
   erb :post
 end
 
 get '/info/:slug' do |slug|
-  @page = Page::Info.new(baseurl: '/info/', directory: info_dir, slug: slug)
-  raise Sinatra::NotFound if @page.none?
+  finder = Document::Finder.new(pattern: info_pattern(slug), baseurl: '/info/')
+  @page = Page::Info.new(static_page: finder.find_single)
   erb :info
 end

--- a/lib/document/finder.rb
+++ b/lib/document/finder.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require_relative 'markdown_with_frontmatter'
+
+module Document
+  class Finder
+    def initialize(pattern:, baseurl:)
+      @pattern = pattern
+      @baseurl = baseurl
+    end
+
+    def find_single
+      raise "Multiple posts matched '#{pattern}'" if multiple?
+      raise Sinatra::NotFound if none?
+      find_all.first
+    end
+
+    def find_all
+      filenames.map { |filename| create_document(filename) }
+    end
+
+    private
+
+    attr_reader :pattern, :baseurl
+
+    def multiple?
+      filenames.size > 1
+    end
+
+    def none?
+      filenames.empty?
+    end
+
+    def filenames
+      @filenames ||= Dir.glob(pattern)
+    end
+
+    def create_document(filename)
+      Document::MarkdownWithFrontmatter.new(filename: filename, baseurl: baseurl)
+    end
+  end
+end

--- a/lib/helpers/constants_helper.rb
+++ b/lib/helpers/constants_helper.rb
@@ -10,6 +10,24 @@ module ConstantsHelper
   def posts_dir
     "#{content_dir}/posts"
   end
+
+  def posts_pattern
+    "#{posts_dir}/#{date_glob}-*.md"
+  end
+
+  def post_pattern(slug)
+    "#{posts_dir}/#{date_glob}-#{slug}.md"
+  end
+
+  def info_pattern(slug)
+    "#{info_dir}/#{slug}.md"
+  end
+
+  private
+
+  def date_glob
+    '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+  end
 end
 
 helpers ConstantsHelper

--- a/lib/page/info.rb
+++ b/lib/page/info.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
-require_relative '../document/markdown_with_frontmatter'
-
 module Page
   class Info
-    def initialize(baseurl:, directory:, slug:)
-      @baseurl = baseurl
-      @directory = directory
-      @slug = slug
+    def initialize(static_page:)
+      @static_page = static_page
     end
 
     def title
@@ -17,24 +13,8 @@ module Page
       static_page.body
     end
 
-    def none?
-      found.empty?
-    end
-
     private
 
-    attr_reader :baseurl, :directory, :slug
-
-    def found
-      @found ||= Dir.glob(pattern)
-    end
-
-    def pattern
-      "#{directory}/#{slug}.md"
-    end
-
-    def static_page
-      Document::MarkdownWithFrontmatter.new(filename: found.first, baseurl: baseurl)
-    end
+    attr_reader :static_page
   end
 end

--- a/lib/page/post.rb
+++ b/lib/page/post.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
-require_relative '../document/markdown_with_frontmatter'
-
 module Page
   class Post
-    def initialize(baseurl:, directory:, slug:)
-      @baseurl = baseurl
-      @directory = directory
-      @slug = slug
+    def initialize(post:)
+      @post = post
     end
 
     def title
@@ -21,29 +17,8 @@ module Page
       post.body
     end
 
-    def multiple?
-      found.size > 1
-    end
-
-    def none?
-      found.empty?
-    end
-
     private
 
-    attr_reader :baseurl, :directory, :slug
-
-    def found
-      @found ||= Dir.glob(pattern)
-    end
-
-    def pattern
-      date_glob = '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
-      "#{directory}/#{date_glob}-#{slug}.md"
-    end
-
-    def post
-      Document::MarkdownWithFrontmatter.new(filename: found.first, baseurl: baseurl)
-    end
+    attr_reader :post
   end
 end

--- a/lib/page/posts.rb
+++ b/lib/page/posts.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
-require_relative '../document/markdown_with_frontmatter'
-
 module Page
   class Posts
-    def initialize(baseurl:, directory:)
-      @baseurl = baseurl
-      @directory = directory
+    def initialize(posts:)
+      @posts = posts
     end
 
     def sorted_posts
@@ -18,23 +15,6 @@ module Page
 
     private
 
-    attr_reader :baseurl, :directory
-
-    def posts
-      filenames.map { |filename| create_post(filename) }
-    end
-
-    def filenames
-      @filenames ||= Dir.glob(pattern)
-    end
-
-    def pattern
-      date_glob = '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
-      "#{directory}/#{date_glob}-*.md"
-    end
-
-    def create_post(filename)
-      Document::MarkdownWithFrontmatter.new(filename: filename, baseurl: baseurl)
-    end
+    attr_reader :posts
   end
 end

--- a/tests/document/finder.rb
+++ b/tests/document/finder.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../lib/document/finder'
+
+describe 'Document::Finder' do
+  let(:filename) { 'file-name' }
+  let(:finder) { Document::Finder.new(pattern: './file-name.md', baseurl: '/path/') }
+
+  it 'finds a single document' do
+    Dir.stub :glob, [filename] do
+      finder.find_single.class.must_equal(Document::MarkdownWithFrontmatter)
+    end
+  end
+
+  it 'creates a document with the right url' do
+    contents = '---
+slug: a-slug
+---'
+    Dir.stub :glob, [new_tempfile(contents, filename)] do
+      finder.find_single.url.must_equal('/path/a-slug')
+    end
+  end
+
+  it 'finds several documents' do
+    Dir.stub :glob, [filename, 'another-file'] do
+      finder.find_all.count.must_equal(2)
+    end
+  end
+
+  describe 'when it fails to find a document' do
+    it 'detects multiple documents with same name and different dates' do
+      Dir.stub :glob, ['2016-01-01-file-name', '2012-01-01-file-name'] do
+        error = assert_raises(RuntimeError) { finder.find_single }
+        assert_match /file-name.md/, error.message
+      end
+    end
+
+    it 'detects that there are no documents with a slug' do
+      Dir.stub :glob, [] do
+        require 'sinatra'
+        assert_raises(Sinatra::NotFound) { finder.find_single }
+      end
+    end
+  end
+end

--- a/tests/page/info.rb
+++ b/tests/page/info.rb
@@ -3,32 +3,24 @@ require 'test_helper'
 require_relative '../../lib/page/info'
 
 describe 'Page::Info' do
-  let(:contents) { '---
-title: A Title
----
-# Hello World' }
-  let(:filenames) { [new_tempfile(contents, 'info-page-slug')] }
-  let(:page) { Page::Info.new(
-    baseurl: '', directory: Dir.tmpdir, slug: 'info-page-slug') }
+  let(:page) { Page::Info.new(static_page: FakeInfo.new) }
+
 
   it 'has a title' do
-    Dir.stub :glob, filenames do
-      page.title.must_equal('A Title')
-    end
+    page.title.must_equal('A Title')
   end
 
   it 'has a body' do
-    Dir.stub :glob, filenames do
-      page.body.must_include('<h1>Hello World</h1>')
-    end
+    page.body.must_include('Hello World')
   end
 
-  describe 'when it fails to find a static page' do
-    it 'detects that there are no pages with a slug' do
-      filenames = []
-      Dir.stub :glob, filenames do
-        page.none?.must_equal(true)
-      end
+  class FakeInfo
+    def title
+      'A Title'
+    end
+
+    def body
+      'Hello World'
     end
   end
 end

--- a/tests/page/post.rb
+++ b/tests/page/post.rb
@@ -3,49 +3,31 @@ require 'test_helper'
 require_relative '../../lib/page/post'
 
 describe 'Page::Post' do
-  let(:contents) { '---
-title: A Title
-slug: a-slug
-published: true
----
-# Hello World' }
-  let(:filenames) { [
-    new_tempfile(contents, '2016-01-01-foo'),
-    new_tempfile('irrelevant', '2012-01-01-bar')
-  ] }
-  let(:page) { Page::Post.new(baseurl: '', directory: Dir.tmpdir, slug: 'foo') }
+  let(:page) { Page::Post.new(post: FakePost.new('2016-01-01-foo')) }
 
   it 'has a title' do
-    Dir.stub :glob, filenames do
-      page.title.must_equal('A Title')
-    end
+    page.title.must_equal('A Title')
   end
 
   it 'formats the post date' do
-    Dir.stub :glob, filenames do
-      page.date.must_equal('January 1, 2016')
-    end
+    page.date.must_equal('January 1, 2016')
   end
 
   it 'has the post contents' do
-    Dir.stub :glob, filenames do
-      page.body.must_include('<h1>Hello World</h1>')
-    end
+    page.body.must_include('Hello World')
   end
 
-  describe 'when it fails to find a post' do
-    it 'detects multiple posts with same name and different dates' do
-      filenames = ['2016-01-01-foo', '2012-01-01-foo']
-      Dir.stub :glob, filenames do
-        page.multiple?.must_equal(true)
-      end
+  FakePost = Struct.new(:filename) do
+    def title
+      'A Title'
     end
 
-    it 'detects that there are no posts with a slug' do
-      filenames = []
-      Dir.stub :glob, filenames do
-        page.none?.must_equal(true)
-      end
+    def date
+      Date.iso8601(filename[0..9])
+    end
+
+    def body
+      'Hello World'
     end
   end
 end

--- a/tests/page/posts.rb
+++ b/tests/page/posts.rb
@@ -3,31 +3,24 @@ require 'test_helper'
 require_relative '../../lib/page/posts'
 
 describe 'Page::Posts' do
-  let(:page) { Page::Posts.new(baseurl: '/blog/', directory: Dir.tmpdir) }
-  let(:filenames) { ['2016-01-01-foo.md', '2012-01-01-bar.md'] }
+  let(:posts) { [
+    FakeDoc.new('2016-01-01-foo', '/blog/'),
+    FakeDoc.new('2012-01-01-bar', '/blog/')
+  ] }
+  let(:page) { Page::Posts.new(posts: posts) }
 
   it 'retrieves all posts' do
-    Dir.stub :glob, filenames do
-      page.sorted_posts.count.must_equal(2)
-    end
+    page.sorted_posts.count.must_equal(2)
   end
 
   it 'links posts to a url under the blog path' do
-    filenames = [
-      new_tempfile('', '2016-01-01-foo'),
-      new_tempfile('', '2012-01-01-bar')
-    ]
-    Dir.stub :glob, filenames do
-      first.url.must_include("/blog/foo")
-      last.url.must_include("/blog/bar")
-    end
+    first.url.must_equal("/blog/foo")
+    last.url.must_equal("/blog/bar")
   end
 
   it 'sorts the posts from newer to older' do
-    Dir.stub :glob, filenames do
-      first_is_newer = first.date > last.date
-      first_is_newer.must_equal(true)
-    end
+    first_is_newer = first.date > last.date
+    first_is_newer.must_equal(true)
   end
 
   it 'formats the date' do
@@ -40,5 +33,15 @@ describe 'Page::Posts' do
 
   def last
     page.sorted_posts.last
+  end
+
+  FakeDoc = Struct.new(:filename, :baseurl) do
+    def url
+      baseurl + filename[-3..-1]
+    end
+
+    def date
+      Date.iso8601(filename[0..9])
+    end
   end
 end


### PR DESCRIPTION
The changes in this PR will hopefully make the code less resilient to change and adaptable to different country needs.

- There was some repetition in the posts, post and info pages that suggested that there was another class hiding inside of them. The repetition was extracted into a class that contains all the logic for searching documents with a certain name in a certain directory.

- By doing this the dependency on `MarkdownWithFrontmatter` is now in one single class (the `Finder` class) instead of spread across all page classes. Changes to `MarkdownWithFrontmatter` affect only the `Finder` class.

- As a consequence, now the presenters contain only the logic for the views and no extra dependencies. They depend on an abstraction that responds to the relevant messages and have a single responsibility.

- The site-specific definitions, in particular those related to filepaths and filenames, are now in one place (the constants helper), and easy to edit per country.

- As an extra consequence, the repetition in the page tests was eliminated as well, and the tests are now much simpler.





