### PR TITLE
Home page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -3,6 +3,7 @@ require 'sinatra'
 
 require_relative 'lib/document/finder'
 require_relative 'lib/helpers/filepaths_helper'
+require_relative 'lib/helpers/layout_helper'
 require_relative 'lib/page/info'
 require_relative 'lib/page/posts'
 require_relative 'lib/page/post'

--- a/app.rb
+++ b/app.rb
@@ -4,6 +4,7 @@ require 'sinatra'
 require_relative 'lib/document/finder'
 require_relative 'lib/helpers/filepaths_helper'
 require_relative 'lib/helpers/layout_helper'
+require_relative 'lib/page/homepage'
 require_relative 'lib/page/info'
 require_relative 'lib/page/posts'
 require_relative 'lib/page/post'
@@ -13,6 +14,9 @@ set :index, EveryPolitician::Index.new(index_url: settings.datasource)
 set :content_dir, File.join(__dir__, 'prose')
 
 get '/' do
+  posts_finder = Document::Finder.new(pattern: posts_pattern, baseurl: '/blog/')
+  events_finder = Document::Finder.new(pattern: events_pattern, baseurl: '/info/events/')
+  @page = Page::Homepage.new(posts: posts_finder.find_all, events: events_finder.find_all)
   erb :homepage
 end
 

--- a/app.rb
+++ b/app.rb
@@ -16,11 +16,6 @@ get '/' do
   erb :homepage
 end
 
-get '/places/' do
-  @country = settings.index.country('Nigeria')
-  erb :places
-end
-
 get '/blog/' do
   finder = Document::Finder.new(pattern: posts_pattern, baseurl: '/blog/')
   @page = Page::Posts.new(posts: finder.find_all, title: 'Blog')

--- a/lib/helpers/layout_helper.rb
+++ b/lib/helpers/layout_helper.rb
@@ -1,0 +1,7 @@
+module LayoutHelper
+  def is_homepage?
+    request.env['PATH_INFO'].match(/^\/?$/)
+  end
+end
+
+helpers LayoutHelper

--- a/lib/helpers/layout_helper.rb
+++ b/lib/helpers/layout_helper.rb
@@ -1,6 +1,20 @@
 module LayoutHelper
+  def meta_title(page)
+    is_homepage? ? site_title : title(page)
+  end
+
+  def site_title
+    'Shine your eye'
+  end
+
   def is_homepage?
     request.env['PATH_INFO'].match(/^\/?$/)
+  end
+
+  private
+
+  def title(page)
+    "#{page.title} :: #{site_title}"
   end
 end
 

--- a/lib/page/homepage.rb
+++ b/lib/page/homepage.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Page
+  class Homepage
+    def initialize(posts:, events:)
+      @posts = posts
+      @events = events
+    end
+
+    def featured_posts
+      posts.sort_by { |d| d.date }.reverse.first(3)
+    end
+
+    def featured_events
+      events.sort_by { |d| d.date }.reverse.first(3)
+    end
+
+    def no_events?
+      featured_events.empty?
+    end
+
+    def format_date(date)
+      date.strftime("%B %-d, %Y")
+    end
+
+    private
+
+    attr_reader :posts, :events
+  end
+end

--- a/tests/page/homepage.rb
+++ b/tests/page/homepage.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../lib/page/homepage'
+
+describe 'Page::Homepage' do
+  let(:documents) { [
+    FakeDocument.new('1000-01-11-foo'),
+    FakeDocument.new('1000-01-12-bar'),
+    FakeDocument.new('1000-01-13-qux'),
+    FakeDocument.new('1000-01-14-qux')
+  ] }
+  let(:page) { Page::Homepage.new(posts: documents, events: documents) }
+
+  describe 'featured posts' do
+    it 'sorts featured posts from newer to older' do
+      first_is_newer = page.featured_posts.first.date > page.featured_posts.last.date
+      first_is_newer.must_equal(true)
+    end
+
+    it 'has a maximum of three featured posts' do
+      page.featured_posts.count(3)
+    end
+  end
+
+  describe 'featured events' do
+    it 'sorts featured events from newer to older' do
+      first_is_newer = page.featured_events.first.date >
+                       page.featured_events.last.date
+      first_is_newer.must_equal(true)
+    end
+
+    it 'has a maximum of three featured events' do
+      page.featured_events.count.must_equal(3)
+    end
+  end
+
+  it 'formats the date' do
+    page.format_date(Date.iso8601('1000-10-01')).must_equal('October 1, 1000')
+  end
+
+  FakeDocument = Struct.new(:filename) do
+    def date
+      Date.iso8601(filename[0..9])
+    end
+  end
+end

--- a/tests/web/layout.rb
+++ b/tests/web/layout.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 require_relative '../../app'
 
 describe 'Layout' do
-  before  { get '/' }
+  before  { get '/info/about' }
   subject { Nokogiri::HTML(last_response.body) }
 
   it 'includes the head' do

--- a/views/_footer.erb
+++ b/views/_footer.erb
@@ -1,5 +1,10 @@
+<% if is_homepage? %>
+<div style=" padding: 5rem 0 4rem;  background: #253130; color: white;">
+  <div class="container">
+<% else %>
 <footer id="site-footer">
   <div class="wrapper">
+<% end %>
 
     <div class="row">
       <div class="seven columns">

--- a/views/_head.erb
+++ b/views/_head.erb
@@ -7,13 +7,24 @@
   <title><%= meta_title(@page) %></title>
 
   <link href="https://fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
-  <link rel="stylesheet" type="text/css" href="/javascripts/jquery-ui-1.11.4.custom/jquery-ui.css">
 
+  <% if is_homepage? %>
+  <link rel="stylesheet" href="http://www.eie.ng/syedemo/css/normalize.css">
+  <link rel="stylesheet" href="http://www.eie.ng/syedemo/css/skeleton.css">
+  <link rel="stylesheet" href="/css/menu.css">
+
+  <link rel="icon" type="image/png" href="http://eie.ng/nl/images/sye.png">
+
+  <% else %>
+  <link rel="stylesheet" type="text/css" href="/javascripts/jquery-ui-1.11.4.custom/jquery-ui.css">
   <link href="/css/screen.css" rel="stylesheet">
+
   <link rel="icon" href="/images/favicon.png">
 
   <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
   <script src="/javascripts/jquery-ui-1.11.4.custom/jquery-ui.min.js"></script>
+  <% end %>
+
 
   <!-- {% jekyll_search_assets %} -->
 

--- a/views/_head.erb
+++ b/views/_head.erb
@@ -4,14 +4,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
 
-  <title>
-    <!-- {% if page.title %}
-    {{ page.title }} :: {{ site.title }}
-    {% else %}
-    {{ site.title }}
-    {% endif %} -->
-    Shine your eye
-  </title>
+  <title><%= meta_title(@page) %></title>
 
   <link href="https://fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
   <link rel="stylesheet" type="text/css" href="/javascripts/jquery-ui-1.11.4.custom/jquery-ui.css">

--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -1,1 +1,110 @@
-<h1>ShineYourEye</h1>
+<div style="padding: 5rem 0 4rem;">
+  <div class="container">
+    <div class="row">
+      <div class="five columns">
+        <img src="/static/images/mz-nigeria-logo-symbol.png" class="u-max-full-width"/>
+      </div>
+      <div class="seven columns" style="padding-top: 4rem;">
+        <h5><b>Shine Your Eye</b> is an SMS and web platform that facilitates engagement with National Assembly members and other elected officials.</h5>
+        <a class="button button-primary" href="/search/">
+          Find your Representative
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<div style="padding: 4rem 0 0; background: #bbf6d7; text-align: center;">
+  <div class="container">
+    <h4><b>Find more information about your government representatives</b></h4>
+    <div class="row" >
+      <div class="four columns" >
+        <a href="/governors/person/nasir-el-rufai/">
+          <img src="http://www.shineyoureye.org/media_root/cache/fa/18/fa18778ccb20510ac887c07750e47fa3.jpg" class="u-max-full-width"/>
+        </a><br>
+        <span style="font-size: 0.9em;">Nasir El-Rufai,</span> <span style="font-size: 0.8em;">  APC, Kaduna</span><br>
+        <a class="button" href="/position/executive-governor/"><b>Governors</b></a>
+        <p>&nbsp;</p>
+      </div>
+      <div class="four columns" >
+        <a href="/senate/person/76d38ffb-0b7e-4b3e-b5a6-92eed438c4c8/">
+          <img src="http://www.shineyoureye.org/media_root/images/1014158160editor_Chris_Anyanwu.jpg" class="u-max-full-width"/>
+        </a><br>
+        <span style="font-size: 0.9em;">Anyanwu Chris N. D,</span> <span style="font-size: 0.8em;">  APC, Abuja</span><br>
+        <a class="button" href="/position/senator/"><b>Senators</b></a>
+        <p>&nbsp;</p>
+      </div>
+      <div class="four columns" >
+        <a  href="/assembly/person/ed60d392-ebe6-49f6-8174-10eb29dbb216/">
+          <img src="http://www.shineyoureye.org/media_root/cache/7a/bb/7abb1cb47babe064deba452e976dc6cc.jpg" class="u-max-full-width"/>
+        </a><br>
+        <span style="font-size: 0.9em;">Lawali Hassan,</span> <span style="font-size: 0.8em;">  APC, Zamfara</span><br>
+        <a class="button" href="/position/representative/"><b>Representatives</b></a>
+        <p>&nbsp;</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<div style=" padding: 4rem 0 4rem; ">
+  <div class="container">
+    <div class="row">
+      <div class="six columns">
+        <h4><b><a href="/blog/">News</a></b></h4>
+        <% @page.featured_posts.each do |post| %>
+        <h5 style="font-weight: inherit;">
+          <a style="display: block;" href="<%= post.url %>"><%= post.title %></a>
+          <small style="display: block; font-size: 0.7em;"><%= @page.format_date(post.date) %></small>
+        </h5>
+        <% end %>
+      </div>
+      <div class="six columns">
+        <h4><b><a href="/info/events">Events</a></b></h4>
+        <% @page.featured_events.each do |event| %>
+        <h5 style="font-weight: inherit;">
+          <a style="display: block;" href="<%= event.url %>"><%= event.title %></a>
+          <small style="display: block; font-size: 0.7em;"><%= @page.format_date(event.date) %></small>
+        </h5>
+        <% end %>
+        <% if @page.no_events? %>
+        <p>There are no upcoming events.</p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<div style=" padding: 5rem 0 4rem; background: #bbf6d7 ; ">
+  <div class="container">
+    <div class="row">
+      <div class="six columns"><h1>Quote of the Week</h1> </div>
+      <div class="six columns">
+        <em>"Followers who tell the truth and leaders who listen to it, are an unbeatable combination."</em>
+        <p style="color:#000; margin-top:0px; font-weight:bold">- Warren Bennis </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+
+
+<div style=" padding: 5rem 0 4rem;">
+  <div class="container">
+    <div class="row" >
+      <div class="six columns">
+        <iframe width="100%" height="315px" src="https://www.youtube.com/embed/NDSIJfYWgko" frameborder="0" allowfullscreen></iframe>
+        <p>&nbsp;</p>
+      </div>
+      <div class="six columns">
+        <div align="center"><span style="font-size: 1em; "><a class="button" href="https://twitter.com/NGShineYourEye">Shine Your Eye on Twitter</a></span></div>
+        <a style="color: white !important;" class="twitter-timeline"  href="https://twitter.com/NGShineYourEye" data-widget-id="661503293731000320" width="600px" data-chrome="nofooter noborders noheader noscrollbar transparent"  data-tweet-limit="3">Tweets by @NGShineYourEye</a>
+        <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+      </div>
+    </div>
+  </div>
+</div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -13,16 +13,24 @@
 
     <%= erb :_main_menu %>
 
-    <%= erb :_header %>
+    <% if is_homepage? %>
 
-    <!-- {% include breadcrumbs.html %} -->
+      <%= yield %>
 
-    <div id="page">
-      <div class="page-wrapper wrapper">
-        <%= yield %>
-        <br clear="both">
+    <% else %>
+
+      <%= erb :_header %>
+
+      <!-- {% include breadcrumbs.html %} -->
+
+      <div id="page">
+        <div class="page-wrapper wrapper">
+          <%= yield %>
+          <br clear="both">
+        </div>
       </div>
-    </div>
+
+    <% end %>
 
     <%= erb :_footer %>
 


### PR DESCRIPTION
This PR adds the home page, including featured persons (hardcoded for now) featured posts (the three more recent ones) and featured events (the three more recent ones, but only if they are from the last month)

The conditional title in the head tag was also fixed.

There are no tests for the home page view because the homepage as it is in the Jekyll version of the site is the whole HTML document, i.e. it is not generated using the layout. So some parts in the home page layout are different to the rest of the pages' layout (probably, changes were made in the generic layout that all pages use, and the home page got out of sync). 

This results in some parts of the home page layout being slightly different, which I have identified. For now, I have marked those different parts with a conditional that checks if the page is the home page or another page:

* the part where the styles are imported in the head tag (`_head` partial)
* the styles in the footer (`_footer` partial)
* a section in the body (`layout` view)

In my opinion the section in the body can stay, but the sections in the head and footer could easily be simplified by the designers to unify the markup and the css. That would allow the conditional to go away.

