### PR TITLE
Remove the reference to a Sinatra exception in the finder class

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -29,6 +29,7 @@ end
 
 get '/blog/:slug' do |slug|
   finder = Document::Finder.new(pattern: post_pattern(slug), baseurl: '/blog/')
+  pass if finder.none?
   @page = Page::Post.new(post: finder.find_single)
   erb :post
 end
@@ -41,12 +42,14 @@ end
 
 get '/info/events/:slug' do |slug|
   finder = Document::Finder.new(pattern: event_pattern(slug), baseurl: '/info/events/')
+  pass if finder.none?
   @page = Page::Post.new(post: finder.find_single)
   erb :post
 end
 
 get '/info/:slug' do |slug|
   finder = Document::Finder.new(pattern: info_pattern(slug), baseurl: '/info/')
+  pass if finder.none?
   @page = Page::Info.new(static_page: finder.find_single)
   erb :info
 end

--- a/lib/document/exceptions.rb
+++ b/lib/document/exceptions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module Document
+  class NoFilesFoundError < StandardError
+    def initialize(msg='No files found')
+      super
+    end
+  end
+end

--- a/lib/document/finder.rb
+++ b/lib/document/finder.rb
@@ -19,6 +19,14 @@ module Document
       filenames.map { |filename| create_document(filename) }
     end
 
+    def multiple?
+      filenames.size > 1
+    end
+
+    def none?
+      filenames.empty?
+    end
+
     private
 
     attr_reader :pattern, :baseurl
@@ -30,14 +38,6 @@ module Document
     def raise_error_if_no_files_found
       message = "No documents matched '#{pattern}'"
       raise Document::NoFilesFoundError, message if none?
-    end
-
-    def multiple?
-      filenames.size > 1
-    end
-
-    def none?
-      filenames.empty?
     end
 
     def filenames

--- a/lib/document/finder.rb
+++ b/lib/document/finder.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_relative 'exceptions'
 require_relative 'markdown_with_frontmatter'
 
 module Document
@@ -10,7 +11,7 @@ module Document
 
     def find_single
       raise "Multiple posts matched '#{pattern}'" if multiple?
-      raise Sinatra::NotFound if none?
+      raise_error_if_no_files_found
       find_all.first
     end
 
@@ -21,6 +22,11 @@ module Document
     private
 
     attr_reader :pattern, :baseurl
+
+    def raise_error_if_no_files_found
+      message = "No documents matched '#{pattern}'"
+      raise Document::NoFilesFoundError, message if none?
+    end
 
     def multiple?
       filenames.size > 1

--- a/lib/document/finder.rb
+++ b/lib/document/finder.rb
@@ -10,7 +10,7 @@ module Document
     end
 
     def find_single
-      raise "Multiple posts matched '#{pattern}'" if multiple?
+      raise_error_if_multiple_files_found
       raise_error_if_no_files_found
       find_all.first
     end
@@ -22,6 +22,10 @@ module Document
     private
 
     attr_reader :pattern, :baseurl
+
+    def raise_error_if_multiple_files_found
+      raise "Multiple posts matched '#{pattern}'" if multiple?
+    end
 
     def raise_error_if_no_files_found
       message = "No documents matched '#{pattern}'"

--- a/tests/document/finder.rb
+++ b/tests/document/finder.rb
@@ -28,17 +28,33 @@ slug: a-slug
   end
 
   describe 'when it fails to find a document' do
-    it 'detects multiple documents with same name and different dates' do
-      Dir.stub :glob, ['2016-01-01-file-name', '2012-01-01-file-name'] do
-        error = assert_raises(RuntimeError) { finder.find_single }
-        error.message.must_include('file-name.md')
+    describe 'when multiple documents with same name and different dates' do
+      it 'raises an exception if method is called directly' do
+        Dir.stub :glob, ['2016-01-01-file-name', '2012-01-01-file-name'] do
+          error = assert_raises(RuntimeError) { finder.find_single }
+          error.message.must_include('file-name.md')
+        end
+      end
+
+      it 'can check before calling the method' do
+        Dir.stub :glob, ['2016-01-01-file-name', '2012-01-01-file-name'] do
+          finder.multiple?.must_equal(true)
+        end
       end
     end
 
-    it 'detects that there are no documents with a slug' do
-      Dir.stub :glob, [] do
-        error = assert_raises(Document::NoFilesFoundError) { finder.find_single }
-        error.message.must_include('file-name.md')
+    describe 'when there are no documents with a slug' do
+      it 'raises an exception if method is called directly' do
+        Dir.stub :glob, [] do
+          error = assert_raises(Document::NoFilesFoundError) { finder.find_single }
+          error.message.must_include('file-name.md')
+        end
+      end
+
+      it 'can check before calling the method' do
+        Dir.stub :glob, [] do
+          finder.none?.must_equal(true)
+        end
       end
     end
   end

--- a/tests/document/finder.rb
+++ b/tests/document/finder.rb
@@ -37,8 +37,8 @@ slug: a-slug
 
     it 'detects that there are no documents with a slug' do
       Dir.stub :glob, [] do
-        require 'sinatra'
-        assert_raises(Sinatra::NotFound) { finder.find_single }
+        error = assert_raises(Document::NoFilesFoundError) { finder.find_single }
+        error.message.must_include('file-name.md')
       end
     end
   end

--- a/tests/web/info.rb
+++ b/tests/web/info.rb
@@ -14,4 +14,10 @@ describe 'Info Page' do
     subject.css('.markdown.infopage').text
       .must_include('Shine your Eye is an initiative of Enough is Enough Nigeria')
   end
+
+  it 'throws a 404 error if no file is found' do
+    get '/info/i-dont-exist'
+    subject = Nokogiri::HTML(last_response.body)
+    subject.css('h1').first.text.must_equal('Not Found')
+  end
 end

--- a/tests/web/post.rb
+++ b/tests/web/post.rb
@@ -17,4 +17,10 @@ describe 'Post Page' do
   it 'displays the contents of the post' do
     subject.css('.markdown.infopage').text.must_include('Nigerians woke up to news')
   end
+
+  it 'throws a 404 error if no file is found' do
+    get '/blog/i-dont-exist'
+    subject = Nokogiri::HTML(last_response.body)
+    subject.css('h1').first.text.must_equal('Not Found')
+  end
 end


### PR DESCRIPTION
The lib folder should be plug and play, so no files inside that folder
should be referencing anything from Sinatra. A normal exception is
raised for the case in which no files are found.