### PR TITLE
Add event dates and sort events by event date in the homepage

### DIFF
--- a/lib/document/frontmatter_parser.rb
+++ b/lib/document/frontmatter_parser.rb
@@ -23,6 +23,10 @@ module Document
       fetch('featured', false)
     end
 
+    def event_date
+      fetch('eventdate')
+    end
+
     private
 
     attr_reader :filecontents

--- a/lib/document/markdown_with_frontmatter.rb
+++ b/lib/document/markdown_with_frontmatter.rb
@@ -29,6 +29,11 @@ module Document
       frontmatter.featured?
     end
 
+    def event_date
+      return nil if frontmatter.event_date.empty?
+      Date.parse(frontmatter.event_date)
+    end
+
     def body
       markdown.as_html
     end

--- a/lib/page/homepage.rb
+++ b/lib/page/homepage.rb
@@ -11,7 +11,7 @@ module Page
     end
 
     def featured_events
-      events.sort_by { |d| d.date }.reverse.first(3)
+      future_events.sort_by { |d| d.event_date }.first(3)
     end
 
     def no_events?
@@ -25,5 +25,16 @@ module Page
     private
 
     attr_reader :posts, :events
+
+    def future_events
+      events.select do |d|
+        raise_no_event_date_error(d)
+        d.event_date >= Date.today
+      end
+    end
+
+    def raise_no_event_date_error(d)
+      raise "No event date for #{d.title}" unless d.event_date
+    end
   end
 end

--- a/tests/document/frontmatter_parser.rb
+++ b/tests/document/frontmatter_parser.rb
@@ -52,6 +52,20 @@ foo: bar
 ---'
       parser(contents).featured?.must_equal(false)
     end
+
+    it 'has an event date' do
+      contents = "---
+eventdate: '2010-01-01 10:00 +0000'
+---"
+      parser(contents).event_date.must_equal('2010-01-01 10:00 +0000')
+    end
+
+    it 'if there is no event date, returns an empty string' do
+      contents = '---
+foo: bar
+---'
+      parser(contents).event_date.must_equal('')
+    end
   end
 
   describe 'when file has frontmatter and markdown' do
@@ -65,7 +79,7 @@ title: A Title
   end
 
   describe 'when frontmatter is empty' do
-    it 'sends an empty field' do
+    it 'returns an empty string' do
       contents = '---
 ---'
       parser(contents).title.must_equal('')

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -28,6 +28,10 @@ module Minitest
       end
     end
 
+    def basic_document(filename)
+      Document::MarkdownWithFrontmatter.new(filename: filename, baseurl: 'irrelevant')
+    end
+
     private
 
     DATASOURCE = 'https://github.com/everypolitician/everypolitician-data/raw/master/countries.json'


### PR DESCRIPTION
This PR adds an `event_date` convenience method to documents.

The events are selected by event day. Only the events happening
in the future are shown in the homepage. This includes events
happening "today".

The events are sorted from those happening sooner to those
happening later. From those, the three soonest ones are taken.