### PR TITLE
Add basic breadcrumbs functionality

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,6 +2,7 @@ require 'everypolitician'
 require 'sinatra'
 
 require_relative 'lib/document/finder'
+require_relative 'lib/helpers/breadcrumbs_helper'
 require_relative 'lib/helpers/filepaths_helper'
 require_relative 'lib/helpers/layout_helper'
 require_relative 'lib/page/homepage'
@@ -12,6 +13,14 @@ require_relative 'lib/page/post'
 set :datasource, ENV.fetch('DATASOURCE', 'https://github.com/everypolitician/everypolitician-data/raw/master/countries.json')
 set :index, EveryPolitician::Index.new(index_url: settings.datasource)
 set :content_dir, File.join(__dir__, 'prose')
+# The breadcrumb map should not have trailing slashes (except for the
+# root, '/'). If a prefix maps to nil, a breadcrumb won't be generated
+# for that prefix.
+set :breadcrumbs,
+    '/' => 'Home',
+    '/blog' => 'Blog',
+    '/info' => nil,
+    '/info/events' => 'Events'
 
 get '/' do
   posts_finder = Document::Finder.new(pattern: posts_pattern, baseurl: '/blog/')

--- a/lib/functions/breadcrumbs.rb
+++ b/lib/functions/breadcrumbs.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+def normalize_slashes(path)
+  # Squash consecutive slashes:
+  path = path.gsub(%r{\/+/}, '/')
+  # Strip leading and trailing slashes:
+  path.gsub!(%r{^\/*(.*?)\/*$}, '\1')
+end
+
+def all_path_prefixes(path)
+  path_parts = normalize_slashes(path).split('/')
+  path_parts.map.with_index do |path_part, i|
+    ['/' + path_parts.take(i + 1).join('/'), path_part]
+  end.unshift(['/', nil])
+end
+
+def make_breadcrumbs(path, prefix_map)
+  prefix_map = { '/' => 'Home' }.merge(prefix_map)
+  # Attempt to get the human readable name for each path prefix,
+  # or default to the path component itself:
+  breadcrumbs = all_path_prefixes(path).map do |path_prefix, path_part|
+    [path_prefix, prefix_map.fetch(path_prefix, path_part)]
+  end
+  # If the prefix_map stores nil for a particular prefix, that means
+  # the breadcrumb should be omitted entirely:
+  breadcrumbs.reject { |_, link_text| link_text.nil? }
+end

--- a/lib/helpers/breadcrumbs_helper.rb
+++ b/lib/helpers/breadcrumbs_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require_relative '../functions/breadcrumbs'
+
+# This Sinatra helper provides data for rendering "breadcrumbs" on a
+# page, based on the 'breadcrumbs' configuration setting in app.rb.
+module BreadcrumbsHelper
+  def breadcrumbs_data
+    make_breadcrumbs(request.env['PATH_INFO'], settings.breadcrumbs)
+  end
+end
+
+helpers BreadcrumbsHelper

--- a/tests/functions/breadcrumbs.rb
+++ b/tests/functions/breadcrumbs.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../lib/functions/breadcrumbs'
+
+describe 'make_breadcrumbs' do
+  it 'should handle the root path, with a default name' do
+    assert_equal(
+      [
+        ['/', 'Home']
+      ],
+      make_breadcrumbs('/', {})
+    )
+  end
+
+  it 'should handle the root path, with a custom name' do
+    breadcrumbs_prefix_map = { '/' => 'Awesome' }
+    assert_equal(
+      [
+        ['/', 'Awesome']
+      ],
+      make_breadcrumbs('/', breadcrumbs_prefix_map)
+    )
+  end
+
+  it 'should treat the empty path as the root path' do
+    assert_equal(
+      [
+        ['/', 'Home']
+      ],
+      make_breadcrumbs('', {})
+    )
+  end
+
+  it 'should handle handle multiple path parts' do
+    assert_equal(
+      [
+        ['/', 'Home'],
+        ['/foo', 'foo'],
+        ['/foo/bar', 'bar']
+      ],
+      make_breadcrumbs('/foo/bar', {})
+    )
+  end
+
+  it 'should handle handle multiple path parts with custom names' do
+    breadcrumbs_prefix_map = {
+      '/people' => 'Politicians',
+      '/people/mps' => 'MPs',
+      '/places' => 'Places'
+    }
+    assert_equal(
+      [
+        ['/', 'Home'],
+        ['/people', 'Politicians'],
+        ['/people/mps', 'MPs']
+      ],
+      make_breadcrumbs('/people/mps', breadcrumbs_prefix_map)
+    )
+  end
+
+  it 'should ignore an item where the prefix maps to nil' do
+    breadcrumbs_prefix_map = {
+      '/info' => nil,
+    }
+    assert_equal(
+      [
+        ['/', 'Home'],
+        ['/info/places-overview', 'places-overview']
+      ],
+      make_breadcrumbs('/info/places-overview/', breadcrumbs_prefix_map)
+    )
+  end
+end

--- a/tests/web/breadcrumbs.rb
+++ b/tests/web/breadcrumbs.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../app'
+
+describe 'Blog index page' do
+  before { get '/blog/' }
+  subject { Nokogiri::HTML(last_response.body) }
+
+  it 'contains the expected breadcrumbs' do
+    breadcrumbs_ol = subject.css('ol.breadcrumb')
+    lis = breadcrumbs_ol.xpath('.//li')
+    assert_equal(2, lis.count)
+    assert_equal('<li><a href="/">Home</a></li>', lis[0].to_s)
+    assert_equal('<li class="active">Blog</li>', lis[1].to_s)
+  end
+end
+
+describe 'Home page' do
+  before { get '/' }
+  subject { Nokogiri::HTML(last_response.body) }
+
+  it 'contains no breadcrumbs string' do
+    assert_empty(subject.css('ol.breadcrumb'))
+  end
+end

--- a/views/_breadcrumbs.erb
+++ b/views/_breadcrumbs.erb
@@ -1,0 +1,17 @@
+<% breadcrumbs_data.tap do |paths_and_link_text| %>
+  <%# This prevents breadcrumbs from being shown on the homepage: %>
+  <% if paths_and_link_text.count > 1 %>
+    <% item_count = paths_and_link_text.count %>
+    <ol class="breadcrumb">
+      <% breadcrumbs_data.each_with_index do |path_and_link_text, i| %>
+        <% path, link_text = path_and_link_text %>
+        <% if (i + 1) == item_count %>
+          <%# The last breadcrumb is the current page, so don't link it %>
+          <li class="active"><%= link_text %></li>
+        <% else %>
+          <li><a href="<%= path %>"><%= link_text %></a></li>
+        <% end %>
+      <% end %>
+    </ol>
+  <% end %>
+<% end %>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -10,7 +10,6 @@
 
     {% facebook_javascript_sdk %} -->
 
-
     <%= erb :_main_menu %>
 
     <% if is_homepage? %>
@@ -21,7 +20,7 @@
 
       <%= erb :_header %>
 
-      <!-- {% include breadcrumbs.html %} -->
+      <%= erb :_breadcrumbs %>
 
       <div id="page">
         <div class="page-wrapper wrapper">


### PR DESCRIPTION
Add basic breadcrumbs functionality

This provides functionality for breaking down the path part of a URL
an provide a list of links to the information hierarchy represented by
the /-separation, and linking to pages at the higher levels. (These
links at the top of the page are often referred to as "breadcrumbs".)

For example, you might configure the following prefix map:

```ruby
  {
    '/' => 'Homepage',
    '/politicians', => 'People',
    '/politicians/mps', => 'MPs',
  }
```

... and then the following breadcrumbs HTML would be generated for the
path `/politicians/mps/`:

```html
  <ol class="breadcrumb">
    <li><a href="/">Homepage</a></li>
    <li><a href="/politicians">People</a></li>
    <li class="active">MPs</li>
  </ol>
```

Sometimes intermediate breadcrumbs won't have anywhere sensible to link
to - for example, while info pages are all of the form
'/info/hello-world', there is no index of info pages at '/info/', so you
can skip any such prefix from producing a breadcrumb by mapping it to nil.
For example, you could use the prefix map:

```ruby
  { '/info' => nil }
```

... so that the breadcrumb that would otherwise link to '/info' would be
omitted.
