### PR TITLE
Return parent as place

### DIFF
--- a/lib/helpers/filepaths_helper.rb
+++ b/lib/helpers/filepaths_helper.rb
@@ -5,6 +5,7 @@ module FilepathsHelper
   def mappings
     Mapit::Mappings.new(
       fed_to_sta_ids_mapping_filename: './mapit/fed_to_sta_area_ids_mapping.csv',
+      sen_to_sta_ids_mapping_filename: './mapit/sen_to_sta_area_ids_mapping.csv',
       pombola_slugs_to_mapit_ids_filename: './mapit/pombola_place_slugs_to_mapit.csv',
       mapit_to_ep_areas_fed_filename: './mapit/mapit_to_ep_area_ids_mapping_FED.csv',
       mapit_to_ep_areas_sen_filename: './mapit/mapit_to_ep_area_ids_mapping_SEN.csv'

--- a/lib/mapit/mappings.rb
+++ b/lib/mapit/mappings.rb
@@ -5,11 +5,13 @@ module Mapit
   class Mappings
     def initialize(
       fed_to_sta_ids_mapping_filename:,
+      sen_to_sta_ids_mapping_filename:,
       pombola_slugs_to_mapit_ids_filename:,
       mapit_to_ep_areas_fed_filename:,
       mapit_to_ep_areas_sen_filename:
     )
       @fed_to_sta_ids_mapping_filename = fed_to_sta_ids_mapping_filename
+      @sen_to_sta_ids_mapping_filename = sen_to_sta_ids_mapping_filename
       @pombola_slugs_to_mapit_ids_filename = pombola_slugs_to_mapit_ids_filename
       @mapit_to_ep_areas_fed_filename = mapit_to_ep_areas_fed_filename
       @mapit_to_ep_areas_sen_filename = mapit_to_ep_areas_sen_filename
@@ -17,6 +19,10 @@ module Mapit
 
     def fed_to_sta_mapping
       @fed_to_sta_mapping ||= CSV.read(fed_to_sta_ids_mapping_filename).to_h
+    end
+
+    def sen_to_sta_mapping
+      @sen_to_sta_mapping ||= CSV.read(sen_to_sta_ids_mapping_filename).to_h
     end
 
     def mapit_ids_to_pombola_slugs
@@ -29,8 +35,9 @@ module Mapit
 
     private
 
-    attr_reader :fed_to_sta_ids_mapping_filename, :pombola_slugs_to_mapit_ids_filename,
-                :mapit_to_ep_areas_fed_filename, :mapit_to_ep_areas_sen_filename
+    attr_reader :fed_to_sta_ids_mapping_filename, :sen_to_sta_ids_mapping_filename,
+                :pombola_slugs_to_mapit_ids_filename, :mapit_to_ep_areas_fed_filename,
+                :mapit_to_ep_areas_sen_filename
 
     def reverse_pombola_slugs_to_mapit_ids
       CSV.read(pombola_slugs_to_mapit_ids_filename).map { |row| [row[1], row.first] }

--- a/lib/mapit/place.rb
+++ b/lib/mapit/place.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 module Mapit
   class Place
-    def initialize(place:, mapit_ids_to_pombola_slugs:, baseurl:)
+    attr_reader :parent
+
+    def initialize(place:, parent:, pombola_slug:, baseurl:)
       @place = place
-      @mapit_ids_to_pombola_slugs = mapit_ids_to_pombola_slugs
+      @parent = parent
+      @pombola_slug = pombola_slug
       @baseurl = baseurl
     end
 
@@ -15,28 +18,12 @@ module Mapit
       place['name']
     end
 
-    def parent_name
-      place['parent_name']
-    end
-
     def url
-      build_url(place['id']) if place['id']
-    end
-
-    def parent_url
-      build_url(place['parent_id']) if place['parent_id']
+      baseurl + pombola_slug + '/'
     end
 
     private
 
-    attr_reader :place, :mapit_ids_to_pombola_slugs, :baseurl
-
-    def build_url(id)
-      "#{baseurl}#{pombola_slug(id)}/"
-    end
-
-    def pombola_slug(id)
-      mapit_ids_to_pombola_slugs[id.to_s]
-    end
+    attr_reader :place, :pombola_slug, :baseurl
   end
 end

--- a/tests/mapit/mappings.rb
+++ b/tests/mapit/mappings.rb
@@ -9,6 +9,7 @@ describe 'Mapit::Mappings' do
     ) }
     let(:mappings) { Mapit::Mappings.new(
       fed_to_sta_ids_mapping_filename: fed_to_sta,
+      sen_to_sta_ids_mapping_filename: 'irrelevant',
       pombola_slugs_to_mapit_ids_filename: 'irrelevant',
       mapit_to_ep_areas_fed_filename: 'irrelevant',
       mapit_to_ep_areas_sen_filename: 'irrelevant'
@@ -27,6 +28,31 @@ describe 'Mapit::Mappings' do
     end
   end
 
+  describe 'SEN to STA mappings' do
+    let(:sen_to_sta) { new_tempfile('809,2
+812,3'
+    ) }
+    let(:mappings) { Mapit::Mappings.new(
+      fed_to_sta_ids_mapping_filename: 'irrelevant',
+      sen_to_sta_ids_mapping_filename: sen_to_sta,
+      pombola_slugs_to_mapit_ids_filename: 'irrelevant',
+      mapit_to_ep_areas_fed_filename: 'irrelevant',
+      mapit_to_ep_areas_sen_filename: 'irrelevant'
+    ) }
+
+    it 'can map all districts to their state' do
+      mappings.sen_to_sta_mapping.count.must_equal(2)
+    end
+
+    it 'returns SEN to STA mappings as a hash' do
+      mappings.sen_to_sta_mapping['809'].must_equal('2')
+    end
+
+    it 'returns nil if SEN id does not exist' do
+      assert_nil(mappings.sen_to_sta_mapping['0'])
+    end
+  end
+
   describe 'Mapit ids to Pombola slugs' do
     let(:pombola_to_mapit) { new_tempfile('gwagwaladakuje,949,FED
 federal-capital-territory,16,STA
@@ -35,6 +61,7 @@ ebonyi,12,STA'
     ) }
     let(:mappings) { Mapit::Mappings.new(
       fed_to_sta_ids_mapping_filename: 'irrelevant',
+      sen_to_sta_ids_mapping_filename: 'irrelevant',
       pombola_slugs_to_mapit_ids_filename: pombola_to_mapit,
       mapit_to_ep_areas_fed_filename: 'irrelevant',
       mapit_to_ep_areas_sen_filename: 'irrelevant'
@@ -62,6 +89,7 @@ ebonyi,12,STA'
     ) }
     let(:mappings) { Mapit::Mappings.new(
       fed_to_sta_ids_mapping_filename: 'irrelevant',
+      sen_to_sta_ids_mapping_filename: 'irrelevant',
       pombola_slugs_to_mapit_ids_filename: 'irrelevant',
       mapit_to_ep_areas_fed_filename: mapit_to_ep_fed,
       mapit_to_ep_areas_sen_filename: mapit_to_ep_sen

--- a/tests/mapit/place.rb
+++ b/tests/mapit/place.rb
@@ -6,7 +6,8 @@ describe 'Place' do
   describe 'if area has a parent' do
     let(:place) { Mapit::Place.new(
       place: area_with_parent,
-      mapit_ids_to_pombola_slugs: mapit_ids_to_pombola_slugs,
+      parent: parent,
+      pombola_slug: 'gwagwaladakuje',
       baseurl: '/baseurl/'
     ) }
 
@@ -19,7 +20,7 @@ describe 'Place' do
     end
 
     it 'knows its parent name' do
-      place.parent_name.must_equal('Federal Capital Territory')
+      place.parent.name.must_equal('Federal Capital Territory')
     end
 
     it 'builds the place url with the baseurl' do
@@ -27,36 +28,32 @@ describe 'Place' do
     end
 
     it 'builds the parent url with the baseurl' do
-      place.parent_url.must_equal('/baseurl/federal-capital-territory/')
+      place.parent.url.must_equal('/baseurl/federal-capital-territory/')
     end
   end
 
   describe 'if area has no parent' do
-    let(:place) { Mapit::Place.new(
-      place: area_with_no_parent,
-      mapit_ids_to_pombola_slugs: mapit_ids_to_pombola_slugs,
-      baseurl: '/baseurl/'
-    ) }
+    let(:place) { parent }
 
-    it 'returns nil for the parent name' do
-      assert_nil(place.parent_name)
+    it 'returns nil for the parent' do
+      assert_nil(place.parent)
     end
-
-    it 'returns nil for the parent url' do
-      assert_nil(place.parent_url)
-    end
-  end
-
-  def mapit_ids_to_pombola_slugs
-    { '949' => 'gwagwaladakuje', '16' => 'federal-capital-territory' }
   end
 
   def area_with_parent
-    parent = {'parent_id' => 16, 'parent_name' => 'Federal Capital Territory'}
-    JSON.parse(FED_JSON).values.first.merge(parent)
+    JSON.parse(FED_JSON).values.first
   end
 
   def area_with_no_parent
     JSON.parse(STA_JSON).values.first
+  end
+
+  def parent
+    Mapit::Place.new(
+      place: area_with_no_parent,
+      parent: nil,
+      pombola_slug: 'federal-capital-territory',
+      baseurl: '/baseurl/'
+    )
   end
 end

--- a/tests/mapit/wrapper.rb
+++ b/tests/mapit/wrapper.rb
@@ -27,8 +27,7 @@ describe 'Mappit::Wrapper' do
     end
 
     it 'does not have parent data for the states' do
-      assert_nil(mapit.states.first.parent_name)
-      assert_nil(mapit.states.first.parent_url)
+      assert_nil(mapit.states.first.parent)
     end
   end
 
@@ -46,11 +45,11 @@ describe 'Mappit::Wrapper' do
     end
 
     it 'has federal constituencies with a parent name' do
-      mapit.federal_constituencies.first.parent_name.must_equal('Federal Capital Territory')
+      mapit.federal_constituencies.first.parent.name.must_equal('Federal Capital Territory')
     end
 
     it 'has federal constituencies with a parent url' do
-      mapit.federal_constituencies.first.parent_url.must_equal('/baseurl/federal-capital-territory/')
+      mapit.federal_constituencies.first.parent.url.must_equal('/baseurl/federal-capital-territory/')
     end
   end
 
@@ -68,7 +67,11 @@ describe 'Mappit::Wrapper' do
     end
 
     it 'has senatorial districts with a parent name' do
-      mapit.senatorial_districts.first.parent_name.must_equal('Abia')
+      mapit.senatorial_districts.first.parent.name.must_equal('Abia')
+    end
+
+    it 'has senatorial districts with a parent url' do
+      mapit.senatorial_districts.first.parent.url.must_equal('/baseurl/abia/')
     end
   end
 
@@ -86,7 +89,11 @@ describe 'Mappit::Wrapper' do
 
   class FakeMappings
     def fed_to_sta_mapping
-      { '949' => '16', '1091' => '12', '963' => '9', '809' => '2' }
+      { '949' => '16', '1091' => '12', '963' => '9' }
+    end
+
+    def sen_to_sta_mapping
+      { '809' => '2' }
     end
 
     def mapit_ids_to_pombola_slugs

--- a/views/federal.erb
+++ b/views/federal.erb
@@ -37,7 +37,7 @@
       </div>
       <div class="media-body">
         <a href="<%= place.url %>"><h3 class="media-heading"><%= place.name %></h3></a>
-        <p class="parent-place">Parent place: <a href="<%= place.parent_url %>"><%= place.parent_name %></a></p>
+        <p class="parent-place">Parent place: <a href="<%= place.parent.url %>"><%= place.parent.name %></a></p>
         <div class="kind">Federal Constituency<br>House of Representatives 2011-current</div>
       </div>
     </li>


### PR DESCRIPTION
As suggested by @mhl, it is a better idea to make a `Place` object return its parent as another `Place` object. 

This turned out to be a great idea that simplified the code, in particular the `Place` class code :tada: :boom: 