### PR TITLE
Only load MapIt data once per server instance

### DIFF
--- a/lib/helpers/filepaths_helper.rb
+++ b/lib/helpers/filepaths_helper.rb
@@ -2,15 +2,6 @@
 require_relative '../mapit/mappings'
 
 module FilepathsHelper
-  def mappings
-    Mapit::Mappings.new(
-      fed_to_sta_ids_mapping_filename: './mapit/fed_to_sta_area_ids_mapping.csv',
-      pombola_slugs_to_mapit_ids_filename: './mapit/pombola_place_slugs_to_mapit.csv',
-      mapit_to_ep_areas_fed_filename: './mapit/mapit_to_ep_area_ids_mapping_FED.csv',
-      mapit_to_ep_areas_sen_filename: './mapit/mapit_to_ep_area_ids_mapping_SEN.csv'
-    )
-  end
-
   def content_dir
     settings.content_dir
   end

--- a/lib/helpers/settings_helper.rb
+++ b/lib/helpers/settings_helper.rb
@@ -1,17 +1,5 @@
 # frozen_string_literal: true
 module SettingsHelper
-  def house
-    settings.index.country('Nigeria').legislature('Representatives')
-  end
-
-  def senate
-    settings.index.country('Nigeria').legislature('Senate')
-  end
-
-  def mapit_url
-    settings.mapit_url
-  end
-
   def twitter_user
     settings.twitter_user
   end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -17,6 +17,11 @@ module Minitest
     include Rack::Test::Methods
 
     def app
+      # Some resources are requested from MapIt's API at the start of
+      # app.rb, so we only require app.rb here, after the stubbing of
+      # requests has been set up - otherwise it will try to make real
+      # requests to the API when running tests.
+      require_relative '../app'
       Sinatra::Application
     end
 

--- a/tests/web/constituencies.rb
+++ b/tests/web/constituencies.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../app'
 
 describe 'Federal Constituencies Page' do
   before { get '/place/is/federal-constituency/' }

--- a/tests/web/constituency.rb
+++ b/tests/web/constituency.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../app'
 
 describe 'Federal Constituency Place Page' do
   before { get '/place/abakalikiizzi/' }

--- a/tests/web/district.rb
+++ b/tests/web/district.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../app'
 
 describe 'Senatorial District Place Page' do
   before { get '/place/abia-central/' }

--- a/tests/web/districts.rb
+++ b/tests/web/districts.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../app'
 
 describe 'Senatorial Districts Page' do
   before { get '/place/is/senatorial-district/' }

--- a/tests/web/info.rb
+++ b/tests/web/info.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../app'
 
 describe 'Info Page' do
   before { get '/info/about' }

--- a/tests/web/layout.rb
+++ b/tests/web/layout.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../app'
 
 describe 'Layout' do
   before  { get '/info/about' }

--- a/tests/web/person.rb
+++ b/tests/web/person.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../app'
 
 describe 'Person Page' do
   before { get '/person/b2a7f72a-9ecf-4263-83f1-cb0f8783053c/' }

--- a/tests/web/post.rb
+++ b/tests/web/post.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../app'
 
 describe 'Post Page' do
   before { get '/blog/citizens-solutions-end-terrorism' }

--- a/tests/web/posts.rb
+++ b/tests/web/posts.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../app'
 
 describe 'Posts Page' do
   before { get '/blog/' }

--- a/tests/web/representatives.rb
+++ b/tests/web/representatives.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../app'
 
 describe 'List of Representatives' do
   before { get '/position/representative/' }

--- a/tests/web/search.rb
+++ b/tests/web/search.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../app'
 
 describe 'Search Page' do
   before { get '/search/' }

--- a/tests/web/senators.rb
+++ b/tests/web/senators.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../app'
 
 describe 'Senate' do
   before { get '/position/senator/' }

--- a/tests/web/states.rb
+++ b/tests/web/states.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../app'
 
 describe 'States Page' do
   before { get '/place/is/state/' }


### PR DESCRIPTION
Mapit::Wrapper was being instantiated on every request that needed MapIt
data, and so new requests to the MapIt API were being made on every request
that required them. This is a waste of resources, and massively slows
down crawling the site - the fix in this commit speeds up the crawling
of the site from about 10 minutes to about 2 minutes on my laptop.

There's no advantage in 'governors', 'representatives' and 'senators'
being functions, or from 'mapit_url' and 'mappings' being helpers
(they're only used in app.rb) so these are just variables in app.rb now.
This also makes it more explicit where that data comes from.