### PR TITLE
Summaries

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -147,13 +147,15 @@ end
 
 get '/person/:id/' do |id|
   pass if representatives.none?(id)
-  @page = Page::Person.new(person: representatives.find_single(id), position: 'Representative')
+  summary_finder = Document::Finder.new(pattern: summary_pattern(id), baseurl: '')
+  @page = Page::Person.new(person: representatives.find_single(id), position: 'Representative', summary_doc: summary_finder.find_or_empty)
   erb :person
 end
 
 get '/person/:id/' do |id|
   pass if senators.none?(id)
-  @page = Page::Person.new(person: senators.find_single(id), position: 'Senator')
+  summary_finder = Document::Finder.new(pattern: summary_pattern(id), baseurl: '')
+  @page = Page::Person.new(person: senators.find_single(id), position: 'Senator', summary_doc: summary_finder.find_or_empty)
   erb :person
 end
 

--- a/lib/document/empty_document.rb
+++ b/lib/document/empty_document.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Document
+  class EmptyDocument
+    def featured?
+      false
+    end
+
+    def body
+      ''
+    end
+  end
+end

--- a/lib/document/finder.rb
+++ b/lib/document/finder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative 'exceptions'
 require_relative 'markdown_with_frontmatter'
+require_relative 'empty_document'
 
 module Document
   class Finder
@@ -13,6 +14,10 @@ module Document
       raise_error_if_multiple_files_found
       raise_error_if_no_files_found
       find_all.first
+    end
+
+    def find_or_empty
+      none? ? create_empty_document : find_all.first
     end
 
     def find_all
@@ -46,6 +51,10 @@ module Document
 
     def create_document(filename)
       Document::MarkdownWithFrontmatter.new(filename: filename, baseurl: baseurl)
+    end
+
+    def create_empty_document
+      Document::EmptyDocument.new
     end
   end
 end

--- a/lib/helpers/filepaths_helper.rb
+++ b/lib/helpers/filepaths_helper.rb
@@ -18,6 +18,10 @@ module FilepathsHelper
     "#{content_dir}/posts"
   end
 
+  def summaries_dir
+    "#{content_dir}/summaries"
+  end
+
   def events_pattern
     "#{events_dir}/#{date_glob}-*.md"
   end
@@ -36,6 +40,10 @@ module FilepathsHelper
 
   def post_pattern(slug)
     "#{posts_dir}/#{date_glob}-#{slug}.md"
+  end
+
+  def summary_pattern(id)
+    "#{summaries_dir}/#{id}.md"
   end
 
   private

--- a/lib/page/person.rb
+++ b/lib/page/person.rb
@@ -3,9 +3,10 @@ module Page
   class Person
     attr_reader :person, :position
 
-    def initialize(person:, position:)
+    def initialize(person:, position:, summary_doc:)
       @person = person
       @position = position
+      @summary_doc = summary_doc
     end
 
     def title
@@ -25,11 +26,7 @@ module Page
     end
 
     def summary
-      @summary ||= Document::MarkdownWithFrontmatter.new(
-        filename: summary_markdown_filename, baseurl: nil
-      ).body
-    rescue Errno::ENOENT
-      ''
+      summary_doc.body
     end
 
     def executive_positions
@@ -46,11 +43,6 @@ module Page
 
     private
 
-    def summary_markdown_filename
-      leafname = "#{person.id}.md"
-      File.join(
-        File.dirname(__FILE__), '..', '..', 'prose', 'summaries', leafname
-      )
-    end
+    attr_reader :summary_doc
   end
 end

--- a/tests/document/empty_document.rb
+++ b/tests/document/empty_document.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../lib/document/empty_document'
+
+describe 'Document::EmptyDocument' do
+  let(:document) { Document::EmptyDocument.new }
+
+  it 'is not featured' do
+    document.featured?.must_equal(false)
+  end
+
+  it 'has an empty body' do
+    assert_empty(document.body)
+  end
+end

--- a/tests/document/finder.rb
+++ b/tests/document/finder.rb
@@ -57,5 +57,24 @@ slug: a-slug
         end
       end
     end
+
+    describe 'when searching for a summary' do
+      it 'can find a summary' do
+        contents = '---
+---
+summary'
+        Dir.stub :glob, [new_tempfile(contents)] do
+          finder.find_or_empty.body.strip.must_equal('<p>summary</p>')
+        end
+      end
+    end
+
+    describe 'when no summary is found' do
+      it 'returns a duck type' do
+        Dir.stub :glob, [] do
+          finder.find_or_empty.body.strip.must_equal('')
+        end
+      end
+    end
   end
 end

--- a/tests/page/person.rb
+++ b/tests/page/person.rb
@@ -11,7 +11,8 @@ describe 'Page::Person' do
   ) }
   let(:page) { Page::Person.new(
     person: people.find_single('b2a7f72a-9ecf-4263-83f1-cb0f8783053c'),
-    position: 'Position'
+    position: 'Position',
+    summary_doc: FakeSummary.new('<p>foo</p>')
   ) }
 
   it 'knows the position' do
@@ -55,25 +56,7 @@ describe 'Page::Person' do
   end
 
   it 'has a summary' do
-    # Patch the summary_markdown_filename to point to a file with
-    # known Markdown content.
-    def page.summary_markdown_filename
-      File.join(
-        File.dirname(__FILE__), '..', 'fixtures', 'example-summary.md'
-      )
-    end
-    page.summary.must_equal(
-      "<p>Some example summary text</p>
-
-<h3>Positions</h3>
-
-<ul>
-<li>First item in the list</li>
-<li>Second item in the list</li>
-</ul>
-
-"
-    )
+    page.summary.must_equal('<p>foo</p>')
   end
 
   it 'knows the executive positions' do
@@ -88,15 +71,5 @@ describe 'Page::Person' do
     page.education.must_equal([])
   end
 
-  it 'can find the filename for the Markdown summary text' do
-    expected_relative = File.join(
-      File.dirname(__FILE__), '..', '..', 'prose', 'summaries',
-      'b2a7f72a-9ecf-4263-83f1-cb0f8783053c.md'
-    )
-    expected_absolute = Pathname.new(expected_relative).cleanpath
-    actual_relative = page.send(:summary_markdown_filename)
-    actual_absolute = Pathname.new(actual_relative).cleanpath
-    actual_absolute.must_equal(expected_absolute)
-  end
-
+  FakeSummary = Struct.new(:body)
 end

--- a/tests/web/person.rb
+++ b/tests/web/person.rb
@@ -59,6 +59,31 @@ describe 'Person Page' do
     subject.css('.person__party a').first.text.must_equal('All Progressives Congress')
   end
 
+  describe 'summary section' do
+    before { get '/person/0baa5a03-b1e0-4e66-b3f9-daee8bacb87d/' }
+
+    it 'edit link points to the right person id' do
+      subject.css('.person-edit-link a/@href').text
+        .must_include('/summaries/0baa5a03-b1e0-4e66-b3f9-daee8bacb87d.md')
+    end
+
+    it 'shows summary contents if person has summary' do
+      subject.css('.person-summary li').last.text
+        .must_include('Student at LEA PRI.SCH. from 1969 to 1974')
+    end
+  end
+
+  describe 'when person has no summary' do
+    it 'edit link points to the right person id' do
+      subject.css('.person-edit-link a/@href').text
+        .must_include('/summaries/b2a7f72a-9ecf-4263-83f1-cb0f8783053c.md')
+    end
+
+    it 'shows nothing in the summary' do
+      subject.css('.person-summary').text.strip.must_equal('')
+    end
+  end
+
   describe 'when requesting a senator page' do
     before { get '/person/6b0cdd74-7960-478f-ac93-d230f486a5b9/' }
 

--- a/views/person.erb
+++ b/views/person.erb
@@ -30,15 +30,15 @@
 
         </header>
 
-      <% if @page.summary %>
         <section class="person__section">
             <h2>Summary</h2>
-            <div class="person-edit-link"><a href="http://prose.io/#theyworkforyou/shineyoureye-prose/edit/gh-pages/summaries/<%= @page.person.id %>.md">Edit</a></div>
+            <div class="person-edit-link">
+              <a href="http://prose.io/#theyworkforyou/shineyoureye-prose/edit/gh-pages/summaries/<%= @page.person.id %>.md">Edit</a>
+            </div>
             <div class="person-summary">
-                <p><%= @page.summary %></p>
+                <%= @page.summary %>
             </div>
         </section>
-      <% end %>
 
       <% if @page.executive_positions.size > 0 %>
         <section class="person__section">


### PR DESCRIPTION
At the moment, the person page is in charge of finding a summary document and creating a documetn object. This responsibility is misplaced, as it is the responsibility of the finder to do that.

The definition of where the summaries should be found was also moved to the filepaths helper.

On the other hand, summaries are optional documents. This PR refactors the code, providing a method in the finder to find optional documents, and if no document is found, a duck type is sent.

The unit tests for the body and featured fields exist already in the tests for a `MarkdownWithFrontmatter`, object, so they were not repeated. However, the integration tests that are the web tests assure that the wiring of the search for a summary document works correctly and the contents of such document are displayed properly, whether a summary document exists or not.

A test for the edit link was added, to check that the id is the correct one.

## Person with summary

![summaries](https://cloud.githubusercontent.com/assets/2157089/23218323/e5070fb4-f913-11e6-82c9-867b54de1cc5.png)

## Person with no summary

![no-summaries](https://cloud.githubusercontent.com/assets/2157089/23218345/efe560e8-f913-11e6-9663-1b200e2ed135.png)

