### PR TITLE
Featured people in the homepage

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -68,7 +68,11 @@ senators = EP::PeopleByLegislature.new(
 get '/' do
   posts_finder = Document::Finder.new(pattern: posts_pattern, baseurl: '/blog/')
   events_finder = Document::Finder.new(pattern: events_pattern, baseurl: '/info/events/')
-  @page = Page::Homepage.new(posts: posts_finder.find_all, events: events_finder.find_all)
+  @page = Page::Homepage.new(
+    posts: posts_finder.find_all,
+    events: events_finder.find_all,
+    featured_people: []
+  )
   erb :homepage
 end
 

--- a/app.rb
+++ b/app.rb
@@ -3,6 +3,7 @@ require 'bootstrap-sass'
 require 'everypolitician'
 require 'sinatra'
 
+require_relative 'lib/featured_person'
 require_relative 'lib/document/finder'
 require_relative 'lib/ep/people_by_legislature'
 require_relative 'lib/helpers/filepaths_helper'
@@ -68,11 +69,26 @@ senators = EP::PeopleByLegislature.new(
 get '/' do
   posts_finder = Document::Finder.new(pattern: posts_pattern, baseurl: '/blog/')
   events_finder = Document::Finder.new(pattern: events_pattern, baseurl: '/info/events/')
-  @page = Page::Homepage.new(
-    posts: posts_finder.find_all,
-    events: events_finder.find_all,
-    featured_people: []
-  )
+  summaries_finder = Document::Finder.new(pattern: summaries_pattern, baseurl: '')
+  featured_summaries = summaries_finder.find_featured
+  people = [
+    PageFragment::FeaturedPerson.new(
+      governors.featured_person(featured_summaries),
+      'Governors',
+      '/position/executive-governor/'
+    ),
+    PageFragment::FeaturedPerson.new(
+      senators.featured_person(featured_summaries),
+      'Senators',
+      '/position/senator/'
+    ),
+    PageFragment::FeaturedPerson.new(
+      representatives.featured_person(featured_summaries),
+      'Representatives',
+      '/position/representative/'
+    )
+  ]
+  @page = Page::Homepage.new(posts: posts_finder.find_all, events: events_finder.find_all, featured_people: people)
   erb :homepage
 end
 

--- a/lib/document/finder.rb
+++ b/lib/document/finder.rb
@@ -24,6 +24,10 @@ module Document
       filenames.map { |filename| create_document(filename) }
     end
 
+    def find_featured
+      find_all.select(&:featured?)
+    end
+
     def multiple?
       filenames.size > 1
     end

--- a/lib/ep/people_by_legislature.rb
+++ b/lib/ep/people_by_legislature.rb
@@ -38,6 +38,10 @@ module EP
       legislature.name
     end
 
+    def featured_person(featured_summaries)
+      featured_summaries.map { |summary| find_single(summary.slug) }.compact.first
+    end
+
     private
 
     attr_reader :legislature, :mapit, :baseurl

--- a/lib/featured_person.rb
+++ b/lib/featured_person.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+module PageFragment
+  FeaturedPerson = Struct.new(:featured_person, :people_type_display_text, :people_type_url)
+end

--- a/lib/helpers/filepaths_helper.rb
+++ b/lib/helpers/filepaths_helper.rb
@@ -46,6 +46,10 @@ module FilepathsHelper
     "#{summaries_dir}/#{id}.md"
   end
 
+  def summaries_pattern
+    "#{summaries_dir}/*.md"
+  end
+
   private
 
   def date_glob

--- a/lib/membership_csv/people.rb
+++ b/lib/membership_csv/people.rb
@@ -34,6 +34,10 @@ module MembershipCSV
       nil
     end
 
+    def featured_person(featured_summaries)
+      featured_summaries.map { |summary| find_single(summary.slug) }.compact.first
+    end
+
     private
 
     attr_reader :csv_filename, :mapit, :baseurl

--- a/lib/page/homepage.rb
+++ b/lib/page/homepage.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 module Page
   class Homepage
-    def initialize(posts:, events:)
+    attr_reader :featured_people
+
+    def initialize(posts:, events:, featured_people:)
       @posts = posts
       @events = events
+      @featured_people = featured_people
     end
 
     def featured_posts

--- a/tests/document/finder.rb
+++ b/tests/document/finder.rb
@@ -4,7 +4,7 @@ require_relative '../../lib/document/finder'
 
 describe 'Document::Finder' do
   let(:filename) { 'file-name' }
-  let(:finder) { Document::Finder.new(pattern: 'file-name.md', baseurl: '/path/') }
+  let(:finder) { Document::Finder.new(pattern: "#{filename}.md", baseurl: '/path/') }
 
   it 'finds a single document' do
     Dir.stub :glob, [filename] do
@@ -73,6 +73,28 @@ summary'
       it 'returns a duck type' do
         Dir.stub :glob, [] do
           finder.find_or_empty.body.strip.must_equal('')
+        end
+      end
+    end
+
+    describe 'when searching featured documents' do
+      let(:contents) do
+        '---
+featured: true
+---
+# Foo'
+      end
+      let(:files) { [new_tempfile(contents, 'foo'), new_tempfile(contents, 'bar')] }
+
+      it 'gets all' do
+        Dir.stub :glob, files do
+          finder.find_featured.count.must_equal(2)
+        end
+      end
+
+      it 'gets all as documents' do
+        Dir.stub :glob, files do
+          finder.find_featured.first.body.strip.must_equal('<h1>Foo</h1>')
         end
       end
     end

--- a/tests/ep/people_by_legislature.rb
+++ b/tests/ep/people_by_legislature.rb
@@ -51,6 +51,19 @@ describe 'EP::PeopleByLegislature' do
     it 'knows its legislature name' do
       people.legislature_name.must_equal('House of Representatives')
     end
+
+    it 'finds a featured person' do
+      featured_summaries = [
+        FakeSummary.new('b2a7f72a-9ecf-4263-83f1-cb0f8783053c'),
+        FakeSummary.new('foo')
+      ]
+      people.featured_person(featured_summaries).name.must_equal('ABDUKADIR RAHIS')
+    end
+
+    it 'returns nil if no featured person' do
+      featured_summaries = [FakeSummary.new('foo'), FakeSummary.new('bar')]
+      assert_nil(people.featured_person(featured_summaries))
+    end
   end
 
   describe 'extra mapit functionality' do

--- a/tests/featured_person.rb
+++ b/tests/featured_person.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../lib/featured_person'
+
+describe 'FeaturedPerson' do
+  let(:page_fragment) do
+    PageFragment::FeaturedPerson.new(FakePerson.new('Name'), 'Senators', '/url/to/list/of/senators/')
+  end
+
+  it 'has a featured person' do
+    page_fragment.featured_person.name.must_equal('Name')
+  end
+
+  it 'has a display text for the person type' do
+    page_fragment.people_type_display_text.must_equal('Senators')
+  end
+
+  it 'has a url to the list of people of that type' do
+    page_fragment.people_type_url.must_equal('/url/to/list/of/senators/')
+  end
+
+  FakePerson = Struct.new(:name)
+end

--- a/tests/membership_csv/people.rb
+++ b/tests/membership_csv/people.rb
@@ -54,6 +54,19 @@ id3,name3,name-3,'
     assert_nil(people.legislature_name)
   end
 
+  it 'finds a featured person' do
+    featured_summaries = [
+      FakeSummary.new('id1'),
+      FakeSummary.new('foo')
+    ]
+    people.featured_person(featured_summaries).name.must_equal('name1')
+  end
+
+  it 'returns nil if no featured person' do
+    featured_summaries = [FakeSummary.new('foo'), FakeSummary.new('bar')]
+    assert_nil(people.featured_person(featured_summaries))
+  end
+
   describe 'extra mapit functionality' do
     let(:people) do
       MembershipCSV::People.new(

--- a/tests/page/homepage.rb
+++ b/tests/page/homepage.rb
@@ -12,7 +12,7 @@ describe 'Page::Homepage' do
       document_with_event_date('1000-01-15-qux', in_two_weeks.to_s)
     ]
   end
-  let(:page) { Page::Homepage.new(posts: documents, events: documents) }
+  let(:page) { Page::Homepage.new(posts: documents, events: documents, featured_people: %w(foo bar)) }
 
   describe 'featured posts' do
     it 'sorts featured posts from newer to older' do
@@ -42,7 +42,7 @@ describe 'Page::Homepage' do
     end
 
     it 'detects that there are no featured events' do
-      page = Page::Homepage.new(posts: documents, events: [])
+      page = Page::Homepage.new(posts: documents, events: [], featured_people: [])
       page.no_events?.must_equal(true)
     end
 
@@ -50,10 +50,14 @@ describe 'Page::Homepage' do
       document = basic_document(new_tempfile("---
 title: A Title
 ---", '2000-20-02-file-name'))
-      page = Page::Homepage.new(posts: [], events: [document])
+      page = Page::Homepage.new(posts: [], events: [document], featured_people: [])
       error = assert_raises(RuntimeError) { page.featured_events }
       error.message.must_include('A Title')
     end
+  end
+
+  it 'has the featured people' do
+    page.featured_people.count.must_equal(2)
   end
 
   it 'formats the date' do

--- a/tests/web/homepage.rb
+++ b/tests/web/homepage.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+describe 'Homepage' do
+  before  { get '/' }
+  subject { Nokogiri::HTML(last_response.body) }
+
+  describe 'featured people' do
+    let(:person) { subject.css('.homepage__reps__rep').last }
+
+    it 'links to the person page' do
+      person.css('a/@href').first.text
+            .must_equal('/person/ed60d392-ebe6-49f6-8174-10eb29dbb216/')
+    end
+
+    it 'displays the person medium size image' do
+      person.css('img/@src').text
+            .must_include('/ed60d392-ebe6-49f6-8174-10eb29dbb216/250x250.jpeg')
+    end
+
+    it 'displays the person name' do
+      person.css('p strong').text.must_equal('LAWALI HASSAN')
+    end
+
+    it 'displays the person party name' do
+      person.css('p').text.must_include('All Progressives Congress')
+    end
+
+    it 'displays the person area name' do
+      person.css('p').text.must_include('ANKA//TALATA-MAFARA')
+    end
+
+    it 'displays all types of people' do
+      subject.css('.homepage__reps__rep .btn-default').count.must_equal(3)
+    end
+
+    it 'displays link to Senators' do
+      subject.css('.homepage__reps__rep .btn-default/@href')[1].text
+             .must_equal('/position/senator/')
+    end
+
+    it 'displays the Senators label' do
+      subject.css('.homepage__reps__rep .btn-default')[1].text.strip
+             .must_equal('Senators')
+    end
+
+    it 'displays link to Representatives' do
+      person.css('.btn-default/@href').text.must_equal('/position/representative/')
+    end
+
+    it 'displays the Representatives label' do
+      person.css('.btn-default').text.strip.must_equal('Representatives')
+    end
+  end
+end

--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -29,26 +29,23 @@
         </p>
         <a class="btn btn-default" href="/position/executive-governor/"><b>Governors</b></a>
       </div>
-      <div class="col-sm-4 homepage__reps__rep">
-        <a href="http://sinatra.staging.shineyoureye.org/person/5b2c1b00-d954-44ee-a16b-36f159d12982/">
-          <img src="https://theyworkforyou.github.io/shineyoureye-images/Senate/5b2c1b00-d954-44ee-a16b-36f159d12982/250x250.jpeg">
-        </a>
-        <p>
-            <strong>Binta Garba,</strong>
-            APC, Adamawa North
-        </p>
-        <a class="btn btn-default" href="/position/senator/"><b>Senators</b></a>
-      </div>
-      <div class="col-sm-4 homepage__reps__rep">
-        <a href="/person/ed60d392-ebe6-49f6-8174-10eb29dbb216/">
-          <img src="https://theyworkforyou.github.io/shineyoureye-images/Representatives/ed60d392-ebe6-49f6-8174-10eb29dbb216/250x250.jpeg">
-        </a>
-        <p>
-            <strong>Lawali Hassan,</strong>
-            APC, Zamfara
-        </p>
-        <a class="btn btn-default" href="/position/representative/"><b>Representatives</b></a>
-      </div>
+      <% @page.featured_people.each do |page_fragment| %>
+        <% if page_fragment.featured_person %>
+        <div class="col-sm-4 homepage__reps__rep">
+            <a href="<%= page_fragment.featured_person.url %>">
+                <img src="<%= page_fragment.featured_person.medium_image_url %>">
+            </a>
+            <p>
+                <strong><%= page_fragment.featured_person.name %></strong>,
+                <%= page_fragment.featured_person.party_name %>,
+                <%= page_fragment.featured_person.area.name if page_fragment.featured_person.area %>
+            </p>
+            <a class="btn btn-default" href="<%= page_fragment.people_type_url %>">
+                <strong><%= page_fragment.people_type_display_text %></strong>
+            </a>
+        </div>
+        <% end %>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR removes the hardcoded people in the homepage and replaces it with the featured people calculated as that who has a featured field set to true in their summary.

The governor is hardcoded for now, until we have summaries for the governors.

## Screenshots

![featured](https://cloud.githubusercontent.com/assets/2157089/23723136/f00327ea-043f-11e7-8db5-f1c574e219b4.png)

## Related issues

Closes https://github.com/theyworkforyou/shineyoureye-sinatra/issues/46

## Notes to merger

Merge after #99 