### PR TITLE
Add tests for the content of the 'unlinked' pages

### DIFF
--- a/tests/web/unlinked_pages.rb
+++ b/tests/web/unlinked_pages.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+describe 'The Scraper Start Page' do
+  before  { get '/scraper-start-page.html' }
+  subject { Nokogiri::HTML(last_response.body) }
+
+  it 'must have a link to the Jinja2 template' do
+    refute_empty(subject.xpath('//a[@href="/jinja2-template.html"]'))
+  end
+
+  it 'must have a link to the home page' do
+    refute_empty(subject.xpath('//a[@href="/"]'))
+  end
+end
+
+describe 'The Jinja2 Template' do
+  before  { get '/jinja2-template.html' }
+  subject { Nokogiri::HTML(last_response.body) }
+
+  it 'must have the right <div>s around a Jinja2 include of \'content\'' do
+    refute_empty(subject.xpath('//div[@id="page"]/div[@class="page-section"]/div[@class="container" and contains(text(), "{% include content %}")]'))
+  end
+end


### PR DESCRIPTION
There are two pages that aren't linked from the homepage - a special
page for the crawler to start from, and a page that just serves up a
Jinja2 template for the Polling Unit search lookup app to use.

This commit adds tests that check that these pages exist and have the
content that's important on them.