### PR TITLE
Improve person

### DIFF
--- a/lib/ep/person.rb
+++ b/lib/ep/person.rb
@@ -9,7 +9,7 @@ module EP
     end
 
     extend Forwardable
-    def_delegators :@person, :id, :name, :image, :birth_date, :phone,
+    def_delegators :@person, :id, :name, :birth_date, :image, :phone,
                              :email, :twitter, :facebook, :memberships
 
     def thumbnail_image_url
@@ -92,6 +92,7 @@ module EP
     end
 
     def proxy_image_variant(size)
+      return if image.nil?
       raise_unless_image_size_available(size)
       'https://theyworkforyou.github.io/shineyoureye-images' \
       "/#{legislature.slug}/#{id}/#{ALLOWED_IMAGE_SIZES[size]}.jpeg"

--- a/lib/ep/person.rb
+++ b/lib/ep/person.rb
@@ -25,15 +25,15 @@ module EP
     end
 
     def twitter_display
-      "@#{twitter}"
+      "@#{twitter}" if twitter
     end
 
     def twitter_url
-      "https://twitter.com/#{twitter}"
+      "https://twitter.com/#{twitter}" if twitter
     end
 
     def facebook_display
-      facebook.to_s.split('/').last
+      facebook.split('/').last if facebook
     end
 
     def facebook_url
@@ -42,11 +42,11 @@ module EP
 
     def wikipedia_url
       link = person.links.find { |l| l[:note] == 'Wikipedia (en)' }
-      link ? link[:url] : nil
+      link[:url] if link
     end
 
     def email_url
-      "mailto:#{email}"
+      "mailto:#{email}" if email
     end
 
     def current_memberships

--- a/lib/page/person.rb
+++ b/lib/page/person.rb
@@ -17,10 +17,6 @@ module Page
       person.name
     end
 
-    def email
-      person.email
-    end
-
     def wikipedia_url
       person.wikipedia_url
     end

--- a/lib/page/person.rb
+++ b/lib/page/person.rb
@@ -29,18 +29,6 @@ module Page
       summary_doc.body
     end
 
-    def executive_positions
-      [] # sort by start date reverse
-    end
-
-    def job_history
-      [] # sort by start date reverse
-    end
-
-    def education
-      [] # sort by start date reverse
-    end
-
     private
 
     attr_reader :summary_doc

--- a/lib/page/person.rb
+++ b/lib/page/person.rb
@@ -17,10 +17,6 @@ module Page
       person.name
     end
 
-    def wikipedia_url
-      person.wikipedia_url
-    end
-
     def summary
       summary_doc.body
     end

--- a/tests/ep/person.rb
+++ b/tests/ep/person.rb
@@ -14,10 +14,6 @@ describe 'EP::Person' do
     person.name.must_equal('ABDULLAHI ADAMU')
   end
 
-  it 'has an image' do
-    person.image.must_equal('http://www.nass.gov.ng/images/mps/852.jpg')
-  end
-
   it 'has a thumbnail image' do
     person.thumbnail_image_url.must_include('100x100.jpeg')
   end
@@ -41,6 +37,11 @@ describe 'EP::Person' do
   it 'throws an exception if the image size does not exist' do
     error = assert_raises(RuntimeError) { person.send(:proxy_image_variant, :tiny) }
     error.message.must_include('tiny')
+  end
+
+  it 'returns nil if there is no image' do
+    person = ep_person('78a5c98d-8bbb-45ec-8faa-937d77a93191')
+    assert_nil(person.send(:proxy_image_variant, 'irrelevant'))
   end
 
   it 'has a date of birth' do
@@ -195,11 +196,15 @@ describe 'EP::Person' do
 
   def ep_person(id)
     EP::Person.new(
-      person: latest_term.people.find { |person| person.id == id },
+      person: person_by_id(id),
       term: latest_term,
       mapit: FakeMapit.new(1),
       baseurl: '/baseurl/'
     )
+  end
+
+  def person_by_id(id)
+    latest_term.people.find { |person| person.id == id }
   end
 
   def latest_term

--- a/tests/ep/person.rb
+++ b/tests/ep/person.rb
@@ -4,23 +4,18 @@ require_relative '../../lib/ep/everypolitician_extensions'
 require_relative '../../lib/ep/person'
 
 describe 'EP::Person' do
-  let(:person) { EP::Person.new(
-    person: person_plus_missing_data,
-    term: latest_term,
-    mapit: FakeMapit.new(1),
-    baseurl: '/baseurl/'
-  ) }
+  let(:person) { ep_person('9de46243-685e-4902-81d4-b3e01faa93d5') }
 
   it 'has an EveryPolitician id' do
-    person.id.must_equal('003e0736-add0-4997-9444-94fac606bb95')
+    person.id.must_equal('9de46243-685e-4902-81d4-b3e01faa93d5')
   end
 
   it 'has a name' do
-    person.name.must_equal('MALLAM GANA')
+    person.name.must_equal('ABDULLAHI ADAMU')
   end
 
   it 'has an image' do
-    person.image.must_equal('http://www.nass.gov.ng/images/mps/616.jpg')
+    person.image.must_equal('http://www.nass.gov.ng/images/mps/852.jpg')
   end
 
   it 'has a thumbnail image' do
@@ -36,11 +31,11 @@ describe 'EP::Person' do
   end
 
   it 'uses the legislature slug in the proxy image url' do
-    person.thumbnail_image_url.must_include('Representatives')
+    person.thumbnail_image_url.must_include('Senate')
   end
 
   it 'uses the person id in the proxy image url' do
-    person.thumbnail_image_url.must_include('003e0736-add0-4997-9444-94fac606bb95')
+    person.thumbnail_image_url.must_include('9de46243-685e-4902-81d4-b3e01faa93d5')
   end
 
   it 'throws an exception if the image size does not exist' do
@@ -49,47 +44,125 @@ describe 'EP::Person' do
   end
 
   it 'has a date of birth' do
-    person.birth_date.must_equal('1000-01-10')
+    person.birth_date.must_equal('1946-07-23')
+  end
+
+  describe 'when it does not have a date of birth' do
+    let(:person) { ep_person('0b536a2c-2bc9-46a0-8d40-0deb9241cb31') }
+
+    it 'returns nil' do
+      assert_nil(person.birth_date)
+    end
   end
 
   it 'has a phone' do
-    person.phone.must_equal('1234 5678')
+    person.phone.must_equal('08065186557')
   end
 
-  it 'has a Twitter' do
-    person.twitter.must_equal('atwitterhandle')
+  describe 'when it does not have a phone' do
+    let(:person) { ep_person('0de9e40b-52bc-459f-978b-2aea514eec79') }
+
+    it 'returns nil' do
+      assert_nil(person.phone)
+    end
   end
 
-  it 'has a Twitter display' do
-    person.twitter_display.must_equal('@atwitterhandle')
+  describe 'when it has Twitter' do
+    let(:person) { ep_person('13721811-4357-419c-8ca7-8f1170b36f1a') }
+
+    it 'has Twitter' do
+      person.twitter.must_equal('benmurraybruce')
+    end
+
+    it 'has a Twitter display' do
+      person.twitter_display.must_equal('@benmurraybruce')
+    end
+
+    it 'has a Twitter url' do
+      person.twitter_url.must_equal('https://twitter.com/benmurraybruce')
+    end
   end
 
-  it 'has a Twitter url' do
-    person.twitter_url.must_equal('https://twitter.com/atwitterhandle')
+  describe 'when it has no Twitter' do
+    it 'returns nil for Twitter' do
+      assert_nil(person.twitter)
+    end
+
+    it 'returns nil for the Twitter display' do
+      assert_nil(person.twitter_display)
+    end
+
+    it 'returns nil for the Twitter url' do
+      assert_nil(person.twitter_url)
+    end
   end
 
-  it 'has a Facebook' do
-    person.facebook.must_equal('https://facebook.com/afacebookuser')
+  describe 'when it has Facebook' do
+    let(:person_with_facebook) { person.extend(Facebook) }
+
+    it 'has Facebook' do
+      person_with_facebook.facebook.must_equal('https://facebook.com/afacebookuser')
+    end
+
+    it 'has a Facebook display' do
+      person_with_facebook.facebook_display.must_equal('afacebookuser')
+    end
+
+    it 'has a Facebook url' do
+      person_with_facebook.facebook_url.must_equal('https://facebook.com/afacebookuser')
+    end
   end
 
-  it 'has a Facebook display' do
-    person.facebook_display.must_equal('afacebookuser')
+  describe 'when it has no Facebook' do
+    it 'returns nil for Facebook' do
+      assert_nil(person.facebook)
+    end
+
+    it 'returns nil for the Facebook display' do
+      assert_nil(person.facebook_display)
+    end
+
+    it 'returns nil for the Facebook url' do
+      assert_nil(person.facebook_url)
+    end
   end
 
-  it 'has a Facebook url' do
-    person.facebook_url.must_equal('https://facebook.com/afacebookuser')
+  it 'has a Wikipedia url' do
+    person.wikipedia_url.must_equal('https://en.wikipedia.org/wiki/Abdulahi_Bala_Adamu')
   end
 
-  it 'has an email' do
-    person.email.must_equal('person@example.com')
+  describe 'when it does not have a wikipedia url' do
+    let(:person) { ep_person('0b536a2c-2bc9-46a0-8d40-0deb9241cb31') }
+
+    it 'returns nil' do
+      assert_nil(person.wikipedia_url)
+    end
   end
 
-  it 'has an email url' do
-    person.email_url.must_equal('mailto:person@example.com')
+  describe 'when it has an email' do
+    it 'has an email' do
+      person.email.must_equal('adamu.abdullahi@gmail.com')
+    end
+
+    it 'has an email url' do
+      person.email_url.must_equal('mailto:adamu.abdullahi@gmail.com')
+    end
+  end
+
+  describe 'when it has no email' do
+    let(:person) { ep_person('0b536a2c-2bc9-46a0-8d40-0deb9241cb31') }
+
+    it 'returns nil for an email' do
+      assert_nil(person.email)
+    end
+
+    it 'returns nil for an email url' do
+      assert_nil(person.email_url)
+    end
   end
 
   it 'has the membership for that person' do
-    person.current_memberships.first[:person_id].must_equal('003e0736-add0-4997-9444-94fac606bb95')
+    person.current_memberships.first[:person_id].must_equal('9de46243-685e-4902-81d4-b3e01faa93d5')
   end
 
   it 'has the person membership for the last term' do
@@ -117,38 +190,26 @@ describe 'EP::Person' do
   end
 
   it 'has a url' do
-    person.url.must_equal('/baseurl/003e0736-add0-4997-9444-94fac606bb95/')
+    person.url.must_equal('/baseurl/9de46243-685e-4902-81d4-b3e01faa93d5/')
+  end
+
+  def ep_person(id)
+    EP::Person.new(
+      person: latest_term.people.find { |person| person.id == id },
+      term: latest_term,
+      mapit: FakeMapit.new(1),
+      baseurl: '/baseurl/'
+    )
   end
 
   def latest_term
-    legislature = nigeria_at_known_revision.legislature('Representatives')
+    legislature = nigeria_at_known_revision.legislature('Senate')
     legislature.legislative_periods.sort_by { |term| term.start_date }.last
   end
 
-  def person_plus_missing_data
-    person = latest_term.people.first
-    person.extend MissingData
-  end
-
-  module MissingData
-    def birth_date
-      '1000-01-10'
-    end
-
-    def twitter
-      'atwitterhandle'
-    end
-
+  module Facebook
     def facebook
       'https://facebook.com/afacebookuser'
-    end
-
-    def email
-      'person@example.com'
-    end
-
-    def phone
-      '1234 5678'
     end
   end
 end

--- a/tests/page/person.rb
+++ b/tests/page/person.rb
@@ -6,8 +6,8 @@ require_relative '../../lib/page/person'
 describe 'Page::Person' do
   let(:people) { EP::PeopleByLegislature.new(
     legislature: nigeria_at_known_revision.legislature('Representatives'),
-    mapit: FakeMapit.new(1),
-    baseurl: '/baseurl/'
+    mapit: 'irrelevant',
+    baseurl: 'irrelevant'
   ) }
   let(:page) { Page::Person.new(
     person: people.find_single('b2a7f72a-9ecf-4263-83f1-cb0f8783053c'),
@@ -23,10 +23,6 @@ describe 'Page::Person' do
     page.title.must_equal('ABDUKADIR RAHIS')
   end
 
-  it 'has a name' do
-    page.person.name.must_equal('ABDUKADIR RAHIS')
-  end
-
   it 'has a social media share name' do
     page.share_name.must_equal('ABDUKADIR RAHIS')
   end
@@ -35,28 +31,42 @@ describe 'Page::Person' do
     page.person.image.must_include('/images/mps/546.jpg')
   end
 
-  it 'has a thumbnail image' do
-    page.person.thumbnail_image_url.must_include('/b2a7f72a-9ecf-4263-83f1-cb0f8783053c/100x100.jpeg')
-  end
-
-  it 'knows the area url' do
-    page.person.area.url.must_equal('/place/pombola-slug/')
-  end
-
-  it 'knows the area name' do
-    page.person.area.name.must_equal('Mapit Area Name')
-  end
-
-  it 'knows the party url' do
-    page.person.party_url.must_equal('/organisation/apc/')
-  end
-
-  it 'knows the party name' do
-    page.person.party_name.must_equal('All Progressives Congress')
-  end
-
   it 'has a summary' do
     page.summary.must_equal('<p>foo</p>')
+  end
+
+  describe 'person' do
+    it 'has a url to a medium-sized image' do
+      page.person.respond_to?(:medium_image_url).must_equal(true)
+    end
+
+    it 'has a name' do
+      page.person.respond_to?(:name).must_equal(true)
+    end
+
+    it 'has an area' do
+      page.person.respond_to?(:area).must_equal(true)
+    end
+
+    it 'has a party name' do
+      page.person.respond_to?(:party_name).must_equal(true)
+    end
+
+    it 'has an email' do
+      page.person.respond_to?(:email).must_equal(true)
+    end
+
+    it 'has an email url' do
+      page.person.respond_to?(:email_url).must_equal(true)
+    end
+
+    it 'has a wikipedia url' do
+      page.person.respond_to?(:wikipedia_url).must_equal(true)
+    end
+
+    it 'has an id' do
+      page.person.respond_to?(:id).must_equal(true)
+    end
   end
 
   FakeSummary = Struct.new(:body)

--- a/tests/page/person.rb
+++ b/tests/page/person.rb
@@ -59,17 +59,5 @@ describe 'Page::Person' do
     page.summary.must_equal('<p>foo</p>')
   end
 
-  it 'knows the executive positions' do
-    page.executive_positions.must_equal([])
-  end
-
-  it 'knows the job history' do
-    page.job_history.must_equal([])
-  end
-
-  it 'knows the education' do
-    page.education.must_equal([])
-  end
-
   FakeSummary = Struct.new(:body)
 end

--- a/tests/page/person.rb
+++ b/tests/page/person.rb
@@ -27,10 +27,6 @@ describe 'Page::Person' do
     page.share_name.must_equal('ABDUKADIR RAHIS')
   end
 
-  it 'has an image' do
-    page.person.image.must_include('/images/mps/546.jpg')
-  end
-
   it 'has a summary' do
     page.summary.must_equal('<p>foo</p>')
   end

--- a/tests/page/person.rb
+++ b/tests/page/person.rb
@@ -48,6 +48,38 @@ describe 'Page::Person' do
       page.person.respond_to?(:party_name).must_equal(true)
     end
 
+    it 'has a birth date' do
+      page.person.respond_to?(:birth_date).must_equal(true)
+    end
+
+    it 'has a phone' do
+      page.person.respond_to?(:phone).must_equal(true)
+    end
+
+    it 'has a Twitter' do
+      page.person.respond_to?(:twitter).must_equal(true)
+    end
+
+    it 'has a Twitter url' do
+      page.person.respond_to?(:twitter_url).must_equal(true)
+    end
+
+    it 'has a Twitter display' do
+      page.person.respond_to?(:twitter_display).must_equal(true)
+    end
+
+    it 'has a Facebook' do
+      page.person.respond_to?(:facebook).must_equal(true)
+    end
+
+    it 'has a Facebook url' do
+      page.person.respond_to?(:facebook_url).must_equal(true)
+    end
+
+    it 'has a Facebook display' do
+      page.person.respond_to?(:facebook_display).must_equal(true)
+    end
+
     it 'has an email' do
       page.person.respond_to?(:email).must_equal(true)
     end

--- a/tests/web/person.rb
+++ b/tests/web/person.rb
@@ -28,16 +28,12 @@ describe 'Person Page' do
     end
   end
 
-  describe 'when subject does not have an image' do
-    before { get '/person/764fce72-c12a-42ad-ba84-d899f81f7a77/' }
+  describe 'when person does not have an image' do
+    before { get '/person/78a5c98d-8bbb-45ec-8faa-937d77a93191/' }
 
     it 'shows a picture anyway (empty avatar)' do
-      # n.b. at the moment we just have a copy of the avatar image;
-      # once
-      # https://github.com/everypolitician-scrapers/nigeria-national-assembly/issues/10
-      # is dealt with we can make this test more helpful.
       subject.css('img.person__image/@src').first.text
-        .must_equal('https://theyworkforyou.github.io/shineyoureye-images/Representatives/764fce72-c12a-42ad-ba84-d899f81f7a77/250x250.jpeg')
+        .must_equal('/images/person-250x250.png')
     end
   end
 

--- a/tests/web/person.rb
+++ b/tests/web/person.rb
@@ -59,6 +59,18 @@ describe 'Person Page' do
     subject.css('.person__party a').first.text.must_equal('All Progressives Congress')
   end
 
+  describe 'when person has an email' do
+    before { get '/person/9de46243-685e-4902-81d4-b3e01faa93d5/' }
+
+    it 'links to the email' do
+      subject.css('.person__email a/@href').first.text.must_equal('mailto:adamu.abdullahi@gmail.com')
+    end
+
+    it 'displays the email' do
+      subject.css('.person__email a').first.text.must_equal('adamu.abdullahi@gmail.com')
+    end
+  end
+
   describe 'summary section' do
     before { get '/person/0baa5a03-b1e0-4e66-b3f9-daee8bacb87d/' }
 

--- a/tests/web/person.rb
+++ b/tests/web/person.rb
@@ -13,7 +13,7 @@ describe 'Person Page' do
     subject.css('.person__key-info h2').first.text.must_equal('Representative')
   end
 
-  it 'shows the person name' do
+  it 'displays the person name' do
     subject.css('h1.person__name').text.must_equal('ABDUKADIR RAHIS')
   end
 
@@ -55,15 +55,69 @@ describe 'Person Page' do
     subject.css('.person__party a').first.text.must_equal('All Progressives Congress')
   end
 
+  describe 'when person has a birth date' do
+    before { get '/person/007d807d-2f2d-4a2e-829f-1fd5109bb7de/' }
+
+    it 'displays it' do
+      subject.css('.person__birthdate').first.text.must_equal('1970-01-02')
+    end
+  end
+
+  describe 'when person has a phone' do
+    it 'displays it' do
+      subject.css('.person__phone').first.text.must_equal('08083999997')
+    end
+  end
+
+  describe 'when person has a Twitter' do
+    before { get '/person/13721811-4357-419c-8ca7-8f1170b36f1a/'}
+
+    it 'links to it' do
+      subject.css('.person__twitter a/@href').first.text
+        .must_equal('https://twitter.com/benmurraybruce')
+    end
+
+    it 'displays it' do
+      subject.css('.person__twitter a').first.text.must_equal('@benmurraybruce')
+    end
+  end
+
+  # describe 'when person has a Facebook' do
+  #   it 'links to it' do
+  #     subject.css('.person__facebook a/@href').first.text
+  #       .must_equal('https://facebook.com/benmurraybruce')
+  #   end
+  #
+  #   it 'displays it' do
+  #     subject.css('.person__facebook a').first.text.must_equal('@benmurraybruce')
+  #   end
+  # end
+
   describe 'when person has an email' do
     before { get '/person/9de46243-685e-4902-81d4-b3e01faa93d5/' }
 
     it 'links to the email' do
-      subject.css('.person__email a/@href').first.text.must_equal('mailto:adamu.abdullahi@gmail.com')
+      subject.css('.person__email a/@href').first.text
+        .must_equal('mailto:adamu.abdullahi@gmail.com')
     end
 
     it 'displays the email' do
-      subject.css('.person__email a').first.text.must_equal('adamu.abdullahi@gmail.com')
+      subject.css('.person__email a').first.text
+        .must_equal('adamu.abdullahi@gmail.com')
+    end
+  end
+
+  describe 'when person has wikipedia url' do
+    before { get '/person/0577f346-e883-4e1d-94eb-e3050d5c15f1/'}
+
+    it 'links to it' do
+      subject.css('.person__wikipedia a/@href').first.text
+        .must_equal('https://en.wikipedia.org/wiki/Fatimat_Olufunke_Raji-Rasaki')
+    end
+
+    it 'displays it' do
+      subject.css('.person__wikipedia a').first.text
+        .must_equal('https://en.wikipedia.org/wiki/Fatimat_Olufunke_Raji-Rasaki')
     end
   end
 

--- a/views/person.erb
+++ b/views/person.erb
@@ -18,9 +18,9 @@
           <% end %>
             <h2>Party</h2>
             <p class="person__party"><a href="<%= @page.person.party_url %>"><%= @page.person.party_name %></a></p>
-          <% if @page.email %>
+          <% if @page.person.email %>
             <h2>Email</h2>
-            <p><a href="mailto:<%= @page.email %>"><%= @page.email %></a></p>
+            <p class="person__email"><a href="<%= @page.person.email_url %>"><%= @page.person.email %></a></p>
           <% end %>
 
           <% if @page.wikipedia_url %>

--- a/views/person.erb
+++ b/views/person.erb
@@ -10,22 +10,46 @@
 
     <div class="col-sm-8 col-md-9">
         <header class="person__key-info">
+
             <h2><%= @page.position %></h2>
             <h1 class="person__name"><%= @page.person.name %></h1>
+
           <% if @page.person.area %>
             <h2>Constituency</h2>
             <p class="person__area"><a href="<%= @page.person.area.url %>"><%= @page.person.area.name %></a></p>
           <% end %>
+
             <h2>Party</h2>
             <p class="person__party"><a href="<%= @page.person.party_url %>"><%= @page.person.party_name %></a></p>
+
+          <% if @page.person.birth_date %>
+            <h2>Birth date</h2>
+            <p class="person__birthdate"><%= @page.person.birth_date %></p>
+          <% end %>
+
+          <% if @page.person.phone %>
+            <h2>Phone</h2>
+            <p class="person__phone"><%= @page.person.phone %></p>
+          <% end %>
+
+          <% if @page.person.twitter %>
+            <h2>Twitter</h2>
+            <p class="person__twitter"><a href="<%= @page.person.twitter_url %>"><%= @page.person.twitter_display %></a></p>
+          <% end %>
+
+          <% if @page.person.facebook %>
+            <h2>Facebook</h2>
+            <p class="person__facebook"><a href="<%= @page.person.facebook_url %>"><%= @page.person.facebook_display %></a></p>
+          <% end %>
+
           <% if @page.person.email %>
             <h2>Email</h2>
             <p class="person__email"><a href="<%= @page.person.email_url %>"><%= @page.person.email %></a></p>
           <% end %>
 
-          <% if @page.wikipedia_url %>
+          <% if @page.person.wikipedia_url %>
             <h2>Wikipedia</h2>
-            <p><a href="<%= @page.wikipedia_url %>"><%= @page.wikipedia_url %></a></p>
+            <p class="person__wikipedia"><a href="<%= @page.person.wikipedia_url %>"><%= @page.person.wikipedia_url %></a></p>
           <% end %>
 
         </header>

--- a/views/person.erb
+++ b/views/person.erb
@@ -1,6 +1,6 @@
 <div class="row">
     <div class="col-sm-4 col-md-3">
-      <% if @page.person.image %>
+      <% if @page.person.medium_image_url %>
         <img class="person__image" src="<%= @page.person.medium_image_url %>" alt="<%= @page.person.name %>">
       <% else %>
         <img class="person__image" src="/images/person-250x250.png" alt="<%= @page.person.name %>">

--- a/views/person.erb
+++ b/views/person.erb
@@ -39,50 +39,8 @@
             </div>
         </section>
 
-      <% if @page.executive_positions.size > 0 %>
-        <section class="person__section">
-            <h2>Experience</h2>
-            <ul class="unstyled-list">
-              <% @page.executive_positions.each do |position| %>
-              <li>
-                <a href="<%= position.executive_positions_by_role.url %>" class="experience__item">
-                  <%= 'include person_experience_item.html item=position' %>
-                </a>
-              </li>
-              <% end %>
-            </ul>
-        </section>
-      <% end %>
-
-      <% if @page.job_history.size > 0 %>
-        <section class="person__section">
-            <h2>Job history</h2>
-            <ul class="unstyled-list">
-              <% @page.job_history.each do |job| %>
-              <li class="experience__item">
-                <%= 'include person_experience_item.html item=job' %>
-              </li>
-              <% end %>
-            </ul>
-        </section>
-      <% end %>
-
-      <% if @page.education.size > 0 %>
-        <section class="person__section">
-            <h2>Education</h2>
-            <ul class="unstyled-list">
-              <% @page.education.each do |education| %>
-              <li>
-                <%= 'include person_experience_item.html item=education' %>
-              </li>
-              <% end %>
-            </ul>
-        </section>
-      <% end %>
-
         <section class="person__section">
           <%= erb :_comments %>
         </section>
-
     </div>
 </div>


### PR DESCRIPTION
This PR improves the person page as a previous step to having the governors in.

We have some methods in person but we are not using them in the views:

* image <-- this is not exposed anymore, as it is not used
* birth_date
* phone
* twitter
* facebook
* memberships <-- this is still exposed but not used out of EP::Person

Also, there is some unused code that can be deleted

The Facebook tests for the integration tests are commented because no senator or representative has a facebook account, but governors do, so then we will be able to fetch a governor and uncomment them.

![senator](https://cloud.githubusercontent.com/assets/2157089/23416275/1fcae966-fdda-11e6-9c73-f277a5047339.png)

## Notes to merger

Merge this before #83 