### PR TITLE
Remove area types from Mapit::Mappings

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -28,14 +28,15 @@ set :twitter_user, 'NGShineyoureye'
 # Create a wrapper for the mappings between the various IDs we have
 # to use for areas / places.
 mapit_mappings = Mapit::Mappings.new(
-  fed_to_sta_ids_mapping_filename:
-    './mapit/fed_to_sta_area_ids_mapping.csv',
+  parent_mapping_filenames: [
+    'mapit/fed_to_sta_area_ids_mapping.csv'
+  ],
   pombola_slugs_to_mapit_ids_filename:
-    './mapit/pombola_place_slugs_to_mapit.csv',
-  mapit_to_ep_areas_fed_filename:
-    './mapit/mapit_to_ep_area_ids_mapping_FED.csv',
-  mapit_to_ep_areas_sen_filename:
-    './mapit/mapit_to_ep_area_ids_mapping_SEN.csv'
+    'mapit/pombola_place_slugs_to_mapit.csv',
+  mapit_to_ep_areas_filenames: [
+    'mapit/mapit_to_ep_area_ids_mapping_FED.csv',
+    'mapit/mapit_to_ep_area_ids_mapping_SEN.csv',
+  ]
 )
 
 # Create a wrapper that caches MapIt and EveryPolitician area data:

--- a/lib/mapit/mappings.rb
+++ b/lib/mapit/mappings.rb
@@ -20,11 +20,11 @@ module Mapit
     end
 
     def pombola_slugs_to_mapit_ids
-      @pombola_slugs_to_mapit_ids ||= pombola_slugs_to_mapit_ids_ignore_last.to_h
+      @pombola_slugs_to_mapit_ids ||= pombola_slugs_to_mapit_ids_ignore_type.to_h
     end
 
     def mapit_ids_to_pombola_slugs
-      @mapit_ids_to_pombola_slugs ||= reverse(pombola_slugs_to_mapit_ids_ignore_last).to_h
+      @mapit_ids_to_pombola_slugs ||= reverse(pombola_slugs_to_mapit_ids_ignore_type).to_h
     end
 
     def ep_to_mapit_ids
@@ -39,7 +39,7 @@ module Mapit
     # The Pombola to Mapit CSV file contains three columns:
     # Pombola slug, Mapit id, area type (FED, SEN or STA)
     # We don't need the last column for this mapping
-    def pombola_slugs_to_mapit_ids_ignore_last
+    def pombola_slugs_to_mapit_ids_ignore_type
       @pombola_to_mapit ||= read(pombola_slugs_to_mapit_ids_filename).map { |row| row[0..-2] }
     end
 

--- a/lib/mapit/mappings.rb
+++ b/lib/mapit/mappings.rb
@@ -4,9 +4,9 @@ require 'csv'
 module Mapit
   class Mappings
     def initialize(
-      parent_mapping_filenames:,
-      pombola_slugs_to_mapit_ids_filename:,
-      mapit_to_ep_areas_filenames:
+      parent_mapping_filenames: [],
+      pombola_slugs_to_mapit_ids_filename: nil,
+      mapit_to_ep_areas_filenames: []
     )
       @parent_mapping_filenames = parent_mapping_filenames
       @pombola_slugs_to_mapit_ids_filename = pombola_slugs_to_mapit_ids_filename
@@ -46,6 +46,7 @@ module Mapit
     end
 
     def pombola_slugs_to_mapit_ids_data
+      return [] unless pombola_slugs_to_mapit_ids_filename
       read(pombola_slugs_to_mapit_ids_filename)
     end
 

--- a/lib/mapit/wrapper.rb
+++ b/lib/mapit/wrapper.rb
@@ -53,7 +53,7 @@ module Mapit
     end
 
     def parent_id(area)
-      area['parent_area'] || fed_to_sta_mapping[area['id'].to_s].to_i
+      area['parent_area'] || child_to_parent[area['id'].to_s].to_i
     end
 
     def parent_name(area)
@@ -72,8 +72,8 @@ module Mapit
       mapit_mappings.mapit_ids_to_pombola_slugs
     end
 
-    def fed_to_sta_mapping
-      mapit_mappings.fed_to_sta_mapping
+    def child_to_parent
+      mapit_mappings.child_to_parent
     end
 
     def ep_to_mapit_ids

--- a/tests/document/finder.rb
+++ b/tests/document/finder.rb
@@ -4,7 +4,7 @@ require_relative '../../lib/document/finder'
 
 describe 'Document::Finder' do
   let(:filename) { 'file-name' }
-  let(:finder) { Document::Finder.new(pattern: './file-name.md', baseurl: '/path/') }
+  let(:finder) { Document::Finder.new(pattern: 'file-name.md', baseurl: '/path/') }
 
   it 'finds a single document' do
     Dir.stub :glob, [filename] do

--- a/tests/mapit/mappings.rb
+++ b/tests/mapit/mappings.rb
@@ -9,8 +9,6 @@ describe 'Mapit::Mappings' do
     ) }
     let(:mappings) { Mapit::Mappings.new(
       parent_mapping_filenames: [fed_to_sta],
-      pombola_slugs_to_mapit_ids_filename: 'irrelevant',
-      mapit_to_ep_areas_filenames: ['irrelevant', 'irrelevant']
     ) }
 
     it 'can map all constituencies to their state' do
@@ -24,6 +22,10 @@ describe 'Mapit::Mappings' do
     it 'returns nil if FED id does not exist' do
       assert_nil(mappings.child_to_parent['0'])
     end
+
+    it 'returns an empty map if no Pombola <-> MapIt mapping is supplied' do
+      assert_empty(mappings.pombola_slugs_to_mapit_ids)
+    end
   end
 
   describe 'Mapit ids to Pombola slugs' do
@@ -33,9 +35,7 @@ abakalikiizzi,1091,FED
 ebonyi,12,STA'
     ) }
     let(:mappings) { Mapit::Mappings.new(
-      parent_mapping_filenames: ['irrelevant'],
       pombola_slugs_to_mapit_ids_filename: pombola_to_mapit,
-      mapit_to_ep_areas_filenames: ['irrelevant', 'irrelevant']
     ) }
 
     it 'can map all mapit ids to their Pombola slug' do
@@ -71,8 +71,6 @@ ebonyi,12,STA'
 836,"area/delta_central,_delta_state"'
     ) }
     let(:mappings) { Mapit::Mappings.new(
-      parent_mapping_filenames: ['irrelevant'],
-      pombola_slugs_to_mapit_ids_filename: 'irrelevant',
       mapit_to_ep_areas_filenames: [mapit_to_ep_fed, mapit_to_ep_sen]
     ) }
 

--- a/tests/mapit/mappings.rb
+++ b/tests/mapit/mappings.rb
@@ -8,22 +8,21 @@ describe 'Mapit::Mappings' do
 1091,12'
     ) }
     let(:mappings) { Mapit::Mappings.new(
-      fed_to_sta_ids_mapping_filename: fed_to_sta,
+      parent_mapping_filenames: [fed_to_sta],
       pombola_slugs_to_mapit_ids_filename: 'irrelevant',
-      mapit_to_ep_areas_fed_filename: 'irrelevant',
-      mapit_to_ep_areas_sen_filename: 'irrelevant'
+      mapit_to_ep_areas_filenames: ['irrelevant', 'irrelevant']
     ) }
 
     it 'can map all constituencies to their state' do
-      mappings.fed_to_sta_mapping.count.must_equal(2)
+      mappings.child_to_parent.count.must_equal(2)
     end
 
     it 'returns FED to STA mappings as a hash' do
-      mappings.fed_to_sta_mapping['949'].must_equal('16')
+      mappings.child_to_parent['949'].must_equal('16')
     end
 
     it 'returns nil if FED id does not exist' do
-      assert_nil(mappings.fed_to_sta_mapping['0'])
+      assert_nil(mappings.child_to_parent['0'])
     end
   end
 
@@ -34,10 +33,9 @@ abakalikiizzi,1091,FED
 ebonyi,12,STA'
     ) }
     let(:mappings) { Mapit::Mappings.new(
-      fed_to_sta_ids_mapping_filename: 'irrelevant',
+      parent_mapping_filenames: ['irrelevant'],
       pombola_slugs_to_mapit_ids_filename: pombola_to_mapit,
-      mapit_to_ep_areas_fed_filename: 'irrelevant',
-      mapit_to_ep_areas_sen_filename: 'irrelevant'
+      mapit_to_ep_areas_filenames: ['irrelevant', 'irrelevant']
     ) }
 
     it 'can map all mapit ids to their Pombola slug' do
@@ -73,10 +71,9 @@ ebonyi,12,STA'
 836,"area/delta_central,_delta_state"'
     ) }
     let(:mappings) { Mapit::Mappings.new(
-      fed_to_sta_ids_mapping_filename: 'irrelevant',
+      parent_mapping_filenames: ['irrelevant'],
       pombola_slugs_to_mapit_ids_filename: 'irrelevant',
-      mapit_to_ep_areas_fed_filename: mapit_to_ep_fed,
-      mapit_to_ep_areas_sen_filename: mapit_to_ep_sen
+      mapit_to_ep_areas_filenames: [mapit_to_ep_fed, mapit_to_ep_sen]
     ) }
 
     it 'can map all ep areas to their mapit area' do

--- a/tests/mapit/wrapper.rb
+++ b/tests/mapit/wrapper.rb
@@ -112,7 +112,7 @@ describe 'Mappit::Wrapper' do
   end
 
   class FakeMappings
-    def fed_to_sta_mapping
+    def child_to_parent
       { '949' => '16', '1091' => '12', '963' => '9', '809' => '2' }
     end
 


### PR DESCRIPTION
The parameters to the initializer and one of the method names of
Mapit::Mappings include the area type, and limited the number of mapping
filenames used for parent-child relationships and MapIt <-> EP area IDs
mappings. There's no need for this - the class can be more generic in
its handling of these CSV files, which will make it more easily
extendable in this app and reusable for others.

This also makes the initializer argument optional, since users won't
necessarily have to supply all of them.