### PR TITLE
List of governors

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ rbenv rehash
 * `lib/ep`: code to parse EveryPolitician data
 * `lib/helpers`: mostly site-specific stuff
 * `lib/mapit`: code to parse Mapit data
-* `lib/morph`: code to parse Morph data
+* `lib/membership_csv`: code to parse membership data coming from a CSV file, for example a scraper running in Morph
 * `lib/page`: presenters to extract all logic out of the views
 * `mapit`: CSV files that map MapIt Area IDs to other IDs
 * `morph`: CSV files produced by a scraper on morph.io

--- a/app.rb
+++ b/app.rb
@@ -169,6 +169,13 @@ get '/person/:id/' do |id|
   erb :person
 end
 
+get '/person/:id/' do |id|
+  pass if governors.none?(id)
+  summary_finder = Document::Finder.new(pattern: summary_pattern(id), baseurl: '')
+  @page = Page::Person.new(person: governors.find_single(id), position: 'Governor', summary_doc: summary_finder.find_or_empty)
+  erb :person
+end
+
 Search = Struct.new(:title)
 get '/search/' do
   @page = Search.new('Search')

--- a/app.rb
+++ b/app.rb
@@ -9,6 +9,7 @@ require_relative 'lib/helpers/filepaths_helper'
 require_relative 'lib/helpers/layout_helper'
 require_relative 'lib/helpers/settings_helper'
 require_relative 'lib/mapit/wrapper'
+require_relative 'lib/membership_csv/people'
 require_relative 'lib/page/homepage'
 require_relative 'lib/page/info'
 require_relative 'lib/page/jinja2'
@@ -48,7 +49,11 @@ mapit = Mapit::Wrapper.new(
 )
 
 # Assemble data on the members of the various legislatures we support:
-governors = nil
+governors = MembershipCSV::People.new(
+  csv_filename: 'morph/nigeria-state-governors.csv',
+  mapit: mapit,
+  baseurl: '/person/'
+)
 representatives = EP::PeopleByLegislature.new(
   legislature: settings.index.country('Nigeria').legislature('Representatives'),
   mapit: mapit,
@@ -59,8 +64,6 @@ senators = EP::PeopleByLegislature.new(
   mapit: mapit,
   baseurl: '/person/'
 )
-
-# Now we define the routes:
 
 get '/' do
   posts_finder = Document::Finder.new(pattern: posts_pattern, baseurl: '/blog/')
@@ -144,6 +147,11 @@ end
 
 get '/position/senator/' do
   @page = Page::People.new(title: 'Senator', people_by_legislature: senators)
+  erb :people
+end
+
+get '/position/executive-governor/' do
+  @page = Page::People.new(title: 'Executive Governor', people_by_legislature: governors)
   erb :people
 end
 

--- a/lib/mapit/wrapper.rb
+++ b/lib/mapit/wrapper.rb
@@ -22,6 +22,10 @@ module Mapit
       id_to_place[mapit_mappings.ep_to_mapit_ids[id]]
     end
 
+    def area_from_mapit_name(name)
+      name_to_place[name]
+    end
+
     def places_of_type(area_type)
       type_to_places[area_type]
     end
@@ -54,6 +58,10 @@ module Mapit
     def cache_mapit_data
       @type_to_places = area_types.map { |t| [t, places(t)] }.to_h
       @id_to_place = type_to_places.values.flatten.map { |a| [a.id.to_s, a] }.to_h
+    end
+
+    def name_to_place
+      @name_to_place ||= id_to_place.values.map { |place| [place.name, place] }.to_h
     end
 
     def set_up_parent_child_relationships

--- a/lib/membership_csv/people.rb
+++ b/lib/membership_csv/people.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require 'csv'
+require_relative 'person'
+
+module MembershipCSV
+  class People
+    def initialize(csv_filename:, mapit:, baseurl:)
+      @csv_filename = csv_filename
+      @mapit = mapit
+      @baseurl = baseurl
+    end
+
+    def find_all
+      all_people.sort_by(&:name)
+    end
+
+    def find_single(id)
+      id_to_person[id]
+    end
+
+    def none?(id)
+      find_single(id).nil?
+    end
+
+    private
+
+    attr_reader :csv_filename, :mapit, :baseurl
+
+    def all_people
+      @all_people ||= read_with_headers.map { |row| create_person(remove_empty_cells(row)) }
+    end
+
+    def remove_empty_cells(row)
+      row.reject { |header, value| value.nil? || value.empty? }.to_h
+    end
+
+    def read_with_headers
+      CSV.read(csv_filename, headers: :first_row)
+    end
+
+    def id_to_person
+      @id_to_person ||= all_people.map { |person| [person.id, person] }.to_h
+    end
+
+    def create_person(row)
+      Person.new(person: row, mapit: mapit, baseurl: baseurl)
+    end
+  end
+end

--- a/lib/membership_csv/person.rb
+++ b/lib/membership_csv/person.rb
@@ -70,7 +70,7 @@ module MembershipCSV
     end
 
     def url
-      baseurl + slug + '/' if slug
+      baseurl + id + '/' if id
     end
 
     private

--- a/tests/mapit/wrapper.rb
+++ b/tests/mapit/wrapper.rb
@@ -102,6 +102,24 @@ describe 'Mappit::Wrapper' do
     end
   end
 
+  describe 'when getting an area from a Mapit state name' do
+    it 'finds a state' do
+      mapit.area_from_mapit_name('Abia').id.must_equal(2)
+    end
+
+    it 'finds a federal constituency' do
+      mapit.area_from_mapit_name('Federal Capital Territory').id.must_equal(16)
+    end
+
+    it 'finds a senatorial district' do
+      mapit.area_from_mapit_name('ABIA CENTRAL').id.must_equal(809)
+    end
+
+    it 'returns nil if no area was found' do
+      assert_nil(mapit.area_from_mapit_name('I-dont-exist'))
+    end
+  end
+
   class FakeMappings
     def child_to_parent
       { '949' => '16', '1091' => '12', '963' => '9', '809' => '2' }

--- a/tests/membership_csv/people.rb
+++ b/tests/membership_csv/people.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../lib/membership_csv/people'
+
+describe 'MembershipCSV::People' do
+  let(:contents) { 'id,name,identifier__shineyoureye,phone
+id1,name1,name-1,1234
+id2,name2,name-2,5678
+id3,name3,name-3,'
+  }
+  let(:people) { MembershipCSV::People.new(
+    csv_filename: new_tempfile(contents),
+    mapit: 'irrelevant',
+    baseurl: '/baseurl/'
+  ) }
+
+  it 'finds all people' do
+    people.find_all.count.must_equal(3)
+  end
+
+  it 'finds all people as morph persons' do
+    people.find_all.first.id.must_equal('id1')
+  end
+
+  it 'uses the baseurl in the person url' do
+    people.find_all.first.url.must_equal('/baseurl/id1/')
+  end
+
+  it 'returns nil for empty fields' do
+    assert_nil(people.find_all.last.phone)
+  end
+
+  it 'finds all people sorted by name' do
+    sorted_alphabetically = people.find_all.first.name < people.find_all.last.name
+    sorted_alphabetically.must_equal(true)
+  end
+
+  it 'finds by id' do
+    people.find_single('id2').name.must_equal('name2')
+  end
+
+  it 'can check if id does not exist' do
+    people.none?('i-do-not-exist').must_equal(true)
+  end
+
+  describe 'extra mapit functionality' do
+    let(:people) { MembershipCSV::People.new(
+      csv_filename: new_tempfile(contents),
+      mapit: FakeMapit.new(1),
+      baseurl: '/baseurl/'
+    ) }
+
+    it 'assigns a mapit area to the person' do
+      people.find_single('id3').area.id.must_equal(1)
+    end
+  end
+end

--- a/tests/membership_csv/person.rb
+++ b/tests/membership_csv/person.rb
@@ -186,10 +186,10 @@ describe 'MembershipCSV::Person' do
 
   describe 'url' do
     it 'has a url' do
-      person.url.must_equal('/baseurl/okezie-ikpeazu/')
+      person.url.must_equal('/baseurl/gov:victor-okezie-ikpeazu/')
     end
 
-    it 'returns nil if no site identifier' do
+    it 'returns nil if no id' do
       person = morph_person(person_empty)
       assert_nil(person.url)
     end

--- a/tests/page/person.rb
+++ b/tests/page/person.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 require 'test_helper'
 require_relative '../../lib/ep/people_by_legislature'
+require_relative '../../lib/membership_csv/people'
 require_relative '../../lib/page/person'
+require_relative 'person_interface_test'
 
 describe 'Page::Person' do
   let(:people) { EP::PeopleByLegislature.new(
@@ -31,70 +33,27 @@ describe 'Page::Person' do
     page.summary.must_equal('<p>foo</p>')
   end
 
-  describe 'person' do
-    it 'has a url to a medium-sized image' do
-      page.person.respond_to?(:medium_image_url).must_equal(true)
-    end
+  describe 'when page is an EP person' do
+    include PersonInterfaceTest
+    let(:person) { page.person }
+  end
 
-    it 'has a name' do
-      page.person.respond_to?(:name).must_equal(true)
-    end
-
-    it 'has an area' do
-      page.person.respond_to?(:area).must_equal(true)
-    end
-
-    it 'has a party name' do
-      page.person.respond_to?(:party_name).must_equal(true)
-    end
-
-    it 'has a birth date' do
-      page.person.respond_to?(:birth_date).must_equal(true)
-    end
-
-    it 'has a phone' do
-      page.person.respond_to?(:phone).must_equal(true)
-    end
-
-    it 'has a Twitter' do
-      page.person.respond_to?(:twitter).must_equal(true)
-    end
-
-    it 'has a Twitter url' do
-      page.person.respond_to?(:twitter_url).must_equal(true)
-    end
-
-    it 'has a Twitter display' do
-      page.person.respond_to?(:twitter_display).must_equal(true)
-    end
-
-    it 'has a Facebook' do
-      page.person.respond_to?(:facebook).must_equal(true)
-    end
-
-    it 'has a Facebook url' do
-      page.person.respond_to?(:facebook_url).must_equal(true)
-    end
-
-    it 'has a Facebook display' do
-      page.person.respond_to?(:facebook_display).must_equal(true)
-    end
-
-    it 'has an email' do
-      page.person.respond_to?(:email).must_equal(true)
-    end
-
-    it 'has an email url' do
-      page.person.respond_to?(:email_url).must_equal(true)
-    end
-
-    it 'has a wikipedia url' do
-      page.person.respond_to?(:wikipedia_url).must_equal(true)
-    end
-
-    it 'has an id' do
-      page.person.respond_to?(:id).must_equal(true)
-    end
+  describe 'when page is a Morph person' do
+    include PersonInterfaceTest
+    let(:contents) { 'id
+1'
+    }
+    let(:people) { MembershipCSV::People.new(
+      csv_filename: new_tempfile(contents),
+      mapit: 'irrelevant',
+      baseurl: 'irrelevant'
+    ) }
+    let(:page) { Page::Person.new(
+      person: people.find_single('1'),
+      position: 'irrelevant',
+      summary_doc: 'irrelevant'
+    ) }
+    let(:person) { page.person }
   end
 
   FakeSummary = Struct.new(:body)

--- a/tests/page/person_interface_test.rb
+++ b/tests/page/person_interface_test.rb
@@ -1,0 +1,69 @@
+class Module
+  include Minitest::Spec::DSL
+end
+
+module PersonInterfaceTest
+  it 'has a url to a medium-sized image' do
+    assert_respond_to(person, :medium_image_url)
+  end
+
+  it 'has a name' do
+    assert_respond_to(person, :name)
+  end
+
+  it 'has an area' do
+    assert_respond_to(person, :area)
+  end
+
+  it 'has a party name' do
+    assert_respond_to(person, :party_name)
+  end
+
+  it 'has a birth date' do
+    assert_respond_to(person, :birth_date)
+  end
+
+  it 'has a phone' do
+    assert_respond_to(person, :phone)
+  end
+
+  it 'has a Twitter' do
+    assert_respond_to(person, :twitter)
+  end
+
+  it 'has a Twitter url' do
+    assert_respond_to(person, :twitter_url)
+  end
+
+  it 'has a Twitter display' do
+    assert_respond_to(person, :twitter_display)
+  end
+
+  it 'has a Facebook' do
+    assert_respond_to(person, :facebook)
+  end
+
+  it 'has a Facebook url' do
+    assert_respond_to(person, :facebook_url)
+  end
+
+  it 'has a Facebook display' do
+    assert_respond_to(person, :facebook_display)
+  end
+
+  it 'has an email' do
+    assert_respond_to(person, :email)
+  end
+
+  it 'has an email url' do
+    assert_respond_to(person, :email_url)
+  end
+
+  it 'has a wikipedia url' do
+    assert_respond_to(person, :wikipedia_url)
+  end
+
+  it 'has an id' do
+    assert_respond_to(person, :id)
+  end
+end

--- a/tests/web/governors.rb
+++ b/tests/web/governors.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+describe 'List of Governors' do
+  before { get '/position/executive-governor/' }
+  subject { Nokogiri::HTML(last_response.body) }
+
+  it 'shows the title' do
+    subject.css('.page-title').text.must_include('Executive Governor')
+  end
+
+  describe 'person list' do
+    it 'lists all governors' do
+      subject.css('.media').count.must_equal(36)
+    end
+  end
+
+  describe 'person item' do
+    let(:person) { subject.css('.media').first }
+
+    it 'links to the person page' do
+      person.css('.media-left a/@href').first.text
+        .must_equal('/person/gov:abdulaziz-abubakar-yari/')
+      person.css('.media-body a/@href').first.text
+        .must_equal('/person/gov:abdulaziz-abubakar-yari/')
+    end
+
+    describe 'when person has an image' do
+      it 'points to the right path' do
+        person.css('a img/@src').first.text
+          .must_include('/gov:abdulaziz-abubakar-yari/100x100.jpeg')
+      end
+
+      it 'has an srcset' do
+        person.css('a img/@srcset').first.text
+          .must_include('/gov:abdulaziz-abubakar-yari/100x100.jpeg')
+      end
+
+      it 'has the name as alternative text' do
+        person.css('a img/@alt').first.text.must_equal('Abdulaziz Abubakar Yari')
+      end
+    end
+
+    describe 'when person does not have an image' do
+      let(:person) { subject.xpath('//li[@class="media"][.//h3[text()="Godwin Obaseki"]]') }
+
+      it 'shows a picture anyway (empty avatar)' do
+        person.css('.media-object/@src').first.text
+          .must_include('/images/person-250x250.png')
+      end
+    end
+
+    it 'displays the representative name' do
+      person.css('.media-heading').text.must_equal('Abdulaziz Abubakar Yari')
+    end
+
+    it 'shows right area type name' do
+      person.css('.media-body p').first.text.must_include('Zamfara')
+    end
+
+    it 'links to area page' do
+      person.css('.listing__area/@href').text.must_equal('/place/zamfara/')
+    end
+
+    it 'displays area name' do
+      person.css('.listing__area').text.must_equal('Zamfara')
+    end
+
+    it 'links to party page' do
+      person.css('.listing__party/@href').text.must_equal('/organisation/apc/')
+    end
+
+    it 'displays party name' do
+      person.css('.listing__party').text.must_equal('APC')
+    end
+  end
+end

--- a/tests/web/person.rb
+++ b/tests/web/person.rb
@@ -38,12 +38,19 @@ describe 'Person Page' do
   end
 
   describe 'when person has an area' do
+    it 'shows the area type name' do
+      subject.css('.person__key-info h2').text
+        .must_include('Federal Constituency')
+    end
+
     it 'links to the area page' do
-      subject.css('.person__area a/@href').first.text.must_equal('/place/maiduguri/')
+      subject.css('.person__area a/@href').first.text
+        .must_equal('/place/maiduguri/')
     end
 
     it 'displays the area name' do
-      subject.css('.person__area a').first.text.must_equal('Maiduguri (Metropolitan)')
+      subject.css('.person__area a').first.text
+        .must_equal('Maiduguri (Metropolitan)')
     end
   end
 
@@ -82,16 +89,18 @@ describe 'Person Page' do
     end
   end
 
-  # describe 'when person has a Facebook' do
-  #   it 'links to it' do
-  #     subject.css('.person__facebook a/@href').first.text
-  #       .must_equal('https://facebook.com/benmurraybruce')
-  #   end
-  #
-  #   it 'displays it' do
-  #     subject.css('.person__facebook a').first.text.must_equal('@benmurraybruce')
-  #   end
-  # end
+  describe 'when person has a Facebook' do
+    before { get '/person/gov:willie-obiano/' }
+
+    it 'links to it' do
+      subject.css('.person__facebook a/@href').first.text
+        .must_equal('https://www.facebook.com/WillieObiano')
+    end
+
+    it 'displays it' do
+      subject.css('.person__facebook a').first.text.must_equal('WillieObiano')
+    end
+  end
 
   describe 'when person has an email' do
     before { get '/person/9de46243-685e-4902-81d4-b3e01faa93d5/' }
@@ -155,6 +164,18 @@ describe 'Person Page' do
 
     it 'displays the right position' do
       subject.css('.person__key-info h2').first.text.must_equal('Senator')
+    end
+  end
+
+  describe 'when requesting a governor page' do
+    before { get '/person/gov:victor-okezie-ikpeazu/' }
+
+    it 'finds the governor by slug' do
+      subject.css('title').text.must_include('Victor Okezie Ikpeazu')
+    end
+
+    it 'displays the right position' do
+      subject.css('.person__key-info h2').first.text.must_equal('Governor')
     end
   end
 

--- a/tests/web/representatives.rb
+++ b/tests/web/representatives.rb
@@ -40,11 +40,11 @@ describe 'List of Representatives' do
     end
 
     describe 'when person does not have an image' do
-      let(:person) { subject.css('.media')[2] }
+      let(:person) { subject.xpath('//li[@class="media"][.//h3[text()="ADAMU KAMALE"]]') }
 
       it 'shows a picture anyway (empty avatar)' do
-        person.css('a img/@src').first.text
-          .must_include('/764fce72-c12a-42ad-ba84-d899f81f7a77/100x100.jpeg')
+        person.css('.media-object/@src').first.text
+          .must_include('/images/person-250x250.png')
       end
     end
 

--- a/tests/web/senators.rb
+++ b/tests/web/senators.rb
@@ -38,10 +38,11 @@ describe 'Senate' do
     end
 
     describe 'when person does not have an image' do
-      let(:person) { subject.css('.media')[2] }
+      let(:person) { subject.xpath('//li[@class="media"][.//h3[text()="ATAI USMAN"]]') }
 
-      it 'shows a generic picture' do
-        person.css('a img/@src').first.text.must_include('/f63fc610-ec4b-4ba0-bf02-b543c5fd8c8f/100x100.jpeg')
+      it 'shows a picture anyway (empty avatar)' do
+        person.css('.media-object/@src').first.text
+          .must_include('/images/person-250x250.png')
       end
     end
 

--- a/views/_list_of_people.erb
+++ b/views/_list_of_people.erb
@@ -5,6 +5,8 @@
             <a href="<%= person.url %>">
               <% if person.thumbnail_image_url %>
                 <img class="media-object" src="<%= person.thumbnail_image_url %>" srcset="<%= person.thumbnail_image_url %>" alt="<%= person.name %>">
+              <% else %>
+                <img class="media-object" src="/images/person-250x250.png" srcset="/images/person-250x250.png" alt="<%= person.name %>">
               <% end %>
             </a>
         </div>

--- a/views/person.erb
+++ b/views/person.erb
@@ -15,7 +15,7 @@
             <h1 class="person__name"><%= @page.person.name %></h1>
 
           <% if @page.person.area %>
-            <h2>Constituency</h2>
+            <h2><%= @page.person.area.type_name %></h2>
             <p class="person__area"><a href="<%= @page.person.area.url %>"><%= @page.person.area.name %></a></p>
           <% end %>
 


### PR DESCRIPTION
This PR adds a route for the list of governors and another for a governor's dedicated page.

Morph data lacks a member for the Federal Capital Territory, and so we get only 36 states as opposed to 37 from Mapit.

Also, the same region is called Nassarawa in Mapit and Nasarawa in the data coming from Morph.

## Screenshots

List of governors, now with images! :+1: 

![governors](https://cloud.githubusercontent.com/assets/2157089/23656972/d380b46e-0333-11e7-8c9e-27b85a376294.png)

Governor page, with url using ids:

![person](https://cloud.githubusercontent.com/assets/2157089/23656981/e3d3a2ea-0333-11e7-8535-58b3efada622.png)

## Related issues

Fixes https://github.com/theyworkforyou/shineyoureye-sinatra/issues/35

## Notes to reviewer
GitHub is showing the commits in the wrong order

## Notes to merger 
Merge after #83 and before #88 