### PR TITLE
Make it more clear that the Edit button only applies to summaries

### DIFF
--- a/public/stylesheets/sass/_person.scss
+++ b/public/stylesheets/sass/_person.scss
@@ -35,3 +35,7 @@
         margin-bottom: 2em;
     }
 }
+
+.person-edit-link {
+  font-size: 0.5em;
+}

--- a/tests/web/person.rb
+++ b/tests/web/person.rb
@@ -63,7 +63,7 @@ describe 'Person Page' do
     before { get '/person/0baa5a03-b1e0-4e66-b3f9-daee8bacb87d/' }
 
     it 'edit link points to the right person id' do
-      subject.css('.person-edit-link a/@href').text
+      subject.css('.person-edit-link/@href').text
         .must_include('/summaries/0baa5a03-b1e0-4e66-b3f9-daee8bacb87d.md')
     end
 
@@ -75,7 +75,7 @@ describe 'Person Page' do
 
   describe 'when person has no summary' do
     it 'edit link points to the right person id' do
-      subject.css('.person-edit-link a/@href').text
+      subject.css('.person-edit-link/@href').text
         .must_include('/summaries/b2a7f72a-9ecf-4263-83f1-cb0f8783053c.md')
     end
 

--- a/views/person.erb
+++ b/views/person.erb
@@ -31,12 +31,11 @@
         </header>
 
         <section class="person__section">
-            <h2>Summary</h2>
-            <div class="person-edit-link">
-              <a href="http://prose.io/#theyworkforyou/shineyoureye-prose/edit/gh-pages/summaries/<%= @page.person.id %>.md">Edit</a>
-            </div>
+            <h2>Summary
+                <a class="person-edit-link" href="http://prose.io/#theyworkforyou/shineyoureye-prose/edit/gh-pages/summaries/<%= @page.person.id %>.md">Edit</a>
+            </h2>
             <div class="person-summary">
-                <%= @page.summary %>
+              <%= @page.summary %>
             </div>
         </section>
 
@@ -81,7 +80,9 @@
         </section>
       <% end %>
 
-        <%= erb :_comments %>
+        <section class="person__section">
+          <%= erb :_comments %>
+        </section>
 
     </div>
 </div>


### PR DESCRIPTION
This tiny PR makes it more clear that the Edit button only applies to summaries and not the rest of the information in the page.

![edit-button](https://cloud.githubusercontent.com/assets/2157089/23513572/65b0f668-ff5c-11e6-8f23-3aa6d1f92654.png)
