### PR TITLE
Add RuboCop to Travis and fix the errors it finds

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,9 @@
+AllCops:
+  DisplayCopNames: true
+  TargetRubyVersion: 2.3
+
+Metrics/LineLength:
+  Max: 120
+
+Documentation:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 script:
   - bin/prepare-data ffc1fe0
-  - bundle exec rake test
+  - bundle exec rake
 sudo: false
 rvm:
   - 2.3.1

--- a/Gemfile
+++ b/Gemfile
@@ -20,5 +20,6 @@ group :test do
   gem 'minitest'
   gem 'pry'
   gem 'rack-test'
+  gem 'rubocop'
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby '2.3.1'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
+gem 'bootstrap-sass'
 gem 'compass'
 gem 'coveralls', require: false
 gem 'everypolitician', '~> 0.20.0', github: 'everypolitician/everypolitician-ruby'
@@ -14,7 +15,6 @@ gem 'rake'
 gem 'rdiscount'
 gem 'sass'
 gem 'sinatra'
-gem 'bootstrap-sass'
 
 group :test do
   gem 'minitest'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-# Update README if this version is updated
+# Warning: update the README and TargetRubyVersion in .rubocop.yml if
+# this version is changed:
 ruby '2.3.1'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
+    ast (2.3.0)
     autoprefixer-rails (6.7.0)
       execjs
     bootstrap-sass (3.3.7)
@@ -51,6 +52,9 @@ GEM
     multi_json (1.12.1)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
+    parser (2.4.0.0)
+      ast (~> 2.2)
+    powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -61,12 +65,20 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    rainbow (2.2.1)
     rake (12.0.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     rdiscount (2.2.0.1)
     require_all (1.3.3)
+    rubocop (0.47.1)
+      parser (>= 2.3.3.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
     simplecov (0.12.0)
@@ -84,6 +96,7 @@ GEM
     thor (0.19.4)
     tilt (2.0.5)
     tins (1.13.2)
+    unicode-display_width (1.1.3)
     webmock (2.1.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -103,6 +116,7 @@ DEPENDENCIES
   rack-test
   rake
   rdiscount
+  rubocop
   sass
   sinatra
   webmock
@@ -111,4 +125,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.2
+   1.14.5

--- a/README.md
+++ b/README.md
@@ -158,17 +158,29 @@ bundle exec rackup
 And go to <http://localhost:9292/>
 
 
-## Tests
+## Tests and RubCop
 
-(Assuming you have installed the fixtures with `bin/prepare-data`, as above.)
+(This assumes you have installed the fixtures with `bin/prepare-data`, as above.)
 
-### Run the tests
+### Run both the tests and RuboCop checks
 
 ```bash
-bundle exec rake test
+bundle exec rake
 ```
 
-### Run one test file
+### Running just the RuboCop checks
+
+```bash
+bundle exec rake rubocop
+```
+
+### Running just the tests
+
+```base
+bundle  exec rake test
+```
+
+### Run the tests from just one file
 
 ```bash
 bundle exec rake test TEST='path/to/test/file'

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'rake/testtask'
+require 'rubocop/rake_task'
 
 Rake::TestTask.new do |t|
   t.name = 'test'
@@ -9,4 +10,6 @@ Rake::TestTask.new do |t|
   t.libs << 'tests'
 end
 
-task default: ['test']
+RuboCop::RakeTask.new
+
+task default: ['test', 'rubocop']

--- a/Rakefile
+++ b/Rakefile
@@ -12,4 +12,4 @@ end
 
 RuboCop::RakeTask.new
 
-task default: ['test', 'rubocop']
+task default: %w(test rubocop)

--- a/app.rb
+++ b/app.rb
@@ -30,13 +30,13 @@ set :twitter_user, 'NGShineyoureye'
 mapit_mappings = Mapit::Mappings.new(
   parent_mapping_filenames: [
     'mapit/fed_to_sta_area_ids_mapping.csv',
-    'mapit/sen_to_sta_area_ids_mapping.csv',
+    'mapit/sen_to_sta_area_ids_mapping.csv'
   ],
   pombola_slugs_to_mapit_ids_filename:
     'mapit/pombola_place_slugs_to_mapit.csv',
   mapit_to_ep_areas_filenames: [
     'mapit/mapit_to_ep_area_ids_mapping_FED.csv',
-    'mapit/mapit_to_ep_area_ids_mapping_SEN.csv',
+    'mapit/mapit_to_ep_area_ids_mapping_SEN.csv'
   ]
 )
 
@@ -111,19 +111,31 @@ get '/place/is/state/' do
 end
 
 get '/place/is/federal-constituency/' do
-  @page = Page::Places.new(title: 'Federal Constituencies (Current)', places: mapit.places_of_type('FED'), people_by_legislature: representatives)
+  @page = Page::Places.new(
+    title: 'Federal Constituencies (Current)',
+    places: mapit.places_of_type('FED'),
+    people_by_legislature: representatives
+  )
   erb :places
 end
 
 get '/place/is/senatorial-district/' do
-  @page = Page::Places.new(title: 'Senatorial Districts (Current)', places: mapit.places_of_type('SEN'), people_by_legislature: senators)
+  @page = Page::Places.new(
+    title: 'Senatorial Districts (Current)',
+    places: mapit.places_of_type('SEN'),
+    people_by_legislature: senators
+  )
   erb :places
 end
 
 get '/place/:slug/' do |slug|
   constituency = mapit.area_from_pombola_slug(slug)
   pass if representatives.none_by_mapit_area?(constituency.id)
-  @page = Page::Place.new(place: constituency, people_by_legislature: representatives, people_path: '/people/')
+  @page = Page::Place.new(
+    place: constituency,
+    people_by_legislature: representatives,
+    people_path: '/people/'
+  )
   erb :place
 end
 
@@ -158,21 +170,33 @@ end
 get '/person/:id/' do |id|
   pass if representatives.none?(id)
   summary_finder = Document::Finder.new(pattern: summary_pattern(id), baseurl: '')
-  @page = Page::Person.new(person: representatives.find_single(id), position: 'Representative', summary_doc: summary_finder.find_or_empty)
+  @page = Page::Person.new(
+    person: representatives.find_single(id),
+    position: 'Representative',
+    summary_doc: summary_finder.find_or_empty
+  )
   erb :person
 end
 
 get '/person/:id/' do |id|
   pass if senators.none?(id)
   summary_finder = Document::Finder.new(pattern: summary_pattern(id), baseurl: '')
-  @page = Page::Person.new(person: senators.find_single(id), position: 'Senator', summary_doc: summary_finder.find_or_empty)
+  @page = Page::Person.new(
+    person: senators.find_single(id),
+    position: 'Senator',
+    summary_doc: summary_finder.find_or_empty
+  )
   erb :person
 end
 
 get '/person/:id/' do |id|
   pass if governors.none?(id)
   summary_finder = Document::Finder.new(pattern: summary_pattern(id), baseurl: '')
-  @page = Page::Person.new(person: governors.find_single(id), position: 'Governor', summary_doc: summary_finder.find_or_empty)
+  @page = Page::Person.new(
+    person: governors.find_single(id),
+    position: 'Governor',
+    summary_doc: summary_finder.find_or_empty
+  )
   erb :person
 end
 
@@ -202,5 +226,5 @@ get '/jinja2-template.html' do
 end
 
 get '/scraper-start-page.html' do
-  erb :scraper_start_page, :layout => false
+  erb :scraper_start_page, layout: false
 end

--- a/bin/build_summaries.rb
+++ b/bin/build_summaries.rb
@@ -22,7 +22,7 @@ end
 def build_slug_to_uuid
   map = {}
   ep_index = EveryPolitician::Index.new()
-  ['Representatives', 'Senate'].each do |house_name|
+  %w(Representatives Senate).each do |house_name|
     house = ep_index.country('Nigeria').legislature(house_name)
     house.latest_term.memberships.map(&:person).uniq(&:id).each do |person|
       identifier_sye = person.identifiers.find { |i| i[:scheme] == 'shineyoureye' }

--- a/bin/build_summaries.rb
+++ b/bin/build_summaries.rb
@@ -12,7 +12,10 @@ unless ENV['MORPH_API_KEY']
   exit(1)
 end
 
-CSV_URL = "https://morph.io/everypolitician-scrapers/nigeria-shineyoureye-positions/data.csv?key=#{URI.escape(ENV['MORPH_API_KEY'])}&query=select+%2A+from+%27data%27"
+CSV_URL = 'https://morph.io/everypolitician-scrapers/' \
+          'nigeria-shineyoureye-positions/data.csv' \
+          "?key=#{URI.escape(ENV['MORPH_API_KEY'])}" \
+          "&query=select+%2A+from+%27data%27"
 
 people = CSV.new(open(CSV_URL), :headers => :first_row).group_by do |row|
   raise "A person_slug was missing in the data" unless row['person_slug']

--- a/bin/build_summaries.rb
+++ b/bin/build_summaries.rb
@@ -15,10 +15,10 @@ end
 CSV_URL = 'https://morph.io/everypolitician-scrapers/' \
           'nigeria-shineyoureye-positions/data.csv' \
           "?key=#{URI.escape(ENV['MORPH_API_KEY'])}" \
-          "&query=select+%2A+from+%27data%27"
+          '&query=select+%2A+from+%27data%27'
 
 people = CSV.new(open(CSV_URL), :headers => :first_row).group_by do |row|
-  raise "A person_slug was missing in the data" unless row['person_slug']
+  raise 'A person_slug was missing in the data' unless row['person_slug']
   row['person_slug']
 end
 

--- a/bin/build_summaries.rb
+++ b/bin/build_summaries.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'csv'
 require 'date'

--- a/bin/build_summaries.rb
+++ b/bin/build_summaries.rb
@@ -22,17 +22,21 @@ people = CSV.new(open(CSV_URL), headers: :first_row).group_by do |row|
   row['person_slug']
 end
 
+def slug_to_uuid_for_house(house)
+  map = {}
+  house.latest_term.memberships.map(&:person).uniq(&:id).each do |person|
+    identifier_sye = person.identifiers.find { |i| i[:scheme] == 'shineyoureye' }
+    map[identifier_sye[:identifier]] = person.id if identifier_sye
+  end
+  map
+end
+
 def build_slug_to_uuid
   map = {}
-  ep_index = EveryPolitician::Index.new()
+  ep_index = EveryPolitician::Index.new
   %w(Representatives Senate).each do |house_name|
     house = ep_index.country('Nigeria').legislature(house_name)
-    house.latest_term.memberships.map(&:person).uniq(&:id).each do |person|
-      identifier_sye = person.identifiers.find { |i| i[:scheme] == 'shineyoureye' }
-      if identifier_sye
-        map[identifier_sye[:identifier]] = person.id
-      end
-    end
+    map.merge(slug_to_uuid_for_house(house))
   end
   map
 end
@@ -44,32 +48,53 @@ def format_date(partial_iso8601)
     return d.strftime('%B %Y')
   end
   d = Date.parse(partial_iso8601)
-  return d.strftime('%-d %B %Y')
+  d.strftime('%-d %B %Y')
+end
+
+def only_end(start_date, end_date)
+  start_date.empty? && !end_date.empty?
+end
+
+def only_start(start_date, end_date)
+  end_date.empty? && !start_date.empty?
+end
+
+def both_start_and_end(start_date, end_date)
+  !start_date.empty? && !end_date.empty?
+end
+
+def formatted_date_range(start_date, end_date)
+  if only_end(start_date, end_date)
+    " until #{format_date(end_date)}"
+  elsif only_start(start_date, end_date)
+    " starting at #{format_date(start_date)}"
+  elsif both_start_and_end(start_date, end_date)
+    " from #{format_date(start_date)} to #{format_date(end_date)}"
+  else
+    ''
+  end
+end
+
+def get_markdown_for_position(position)
+  start_date = position['start_date']
+  end_date = position['end_date']
+  role = position['role']
+  organization = position['organization_name']
+  return if position['organization_classification'].include? 'Party'
+  return if organization.empty?
+  return if role.empty?
+  bullet_item = "* #{role} at #{organization}"
+  bullet_item += formatted_date_range(start_date, end_date)
+  bullet_item + "\n"
 end
 
 def get_markdown_from_rows(positions)
   return nil if positions.empty?
   result = positions[0]['person_summary'].strip
   result += "\n\n" unless result.empty?
-  for position in positions
-    start_date = position['start_date']
-    end_date = position['end_date']
-    role = position['role']
-    classification = position['organization_classification']
-    organization = position['organization_name']
-    category = position['organization_category']
-    next if classification.include? 'Party'
-    next if organization.empty?
-    next if role.empty?
-    result += "* #{role} at #{organization}"
-    if start_date.empty? and not end_date.empty?
-      result += " until #{format_date(end_date)}"
-    elsif end_date.empty? and not start_date.empty?
-      result += " starting at #{format_date(start_date)}"
-    elsif (not start_date.empty?) and (not end_date.empty?)
-      result += " from #{format_date(start_date)} to #{format_date(end_date)}"
-    end
-    result += "\n"
+  positions.each do |position|
+    position_markdown = get_markdown_for_position(position)
+    result += position_markdown if position_markdown
   end
   result += "\n"
 end
@@ -82,7 +107,6 @@ people.each do |slug, positions|
   filename = File.join(
     File.dirname(__FILE__), '..', 'prose', 'summaries', "#{uuid}.md"
   )
-  markdown = get_markdown_from_rows(positions)
   open(filename, 'w') do |f|
     f.write("---\n")
     f.write("featured: false\n")

--- a/bin/build_summaries.rb
+++ b/bin/build_summaries.rb
@@ -17,7 +17,7 @@ CSV_URL = 'https://morph.io/everypolitician-scrapers/' \
           "?key=#{URI.escape(ENV['MORPH_API_KEY'])}" \
           '&query=select+%2A+from+%27data%27'
 
-people = CSV.new(open(CSV_URL), :headers => :first_row).group_by do |row|
+people = CSV.new(open(CSV_URL), headers: :first_row).group_by do |row|
   raise 'A person_slug was missing in the data' unless row['person_slug']
   row['person_slug']
 end

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sinatra'
 require 'bootstrap-sass'
 require 'sass/plugin/rack'

--- a/lib/document/exceptions.rb
+++ b/lib/document/exceptions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Document
   class NoFilesFoundError < StandardError
-    def initialize(msg='No files found')
+    def initialize(msg = 'No files found')
       super
     end
   end

--- a/lib/document/frontmatter_parser.rb
+++ b/lib/document/frontmatter_parser.rb
@@ -32,7 +32,7 @@ module Document
     attr_reader :filecontents
 
     def parse
-      YAML::load(filecontents) || {}
+      YAML.safe_load(filecontents) || {}
     end
 
     def fetch(key, default_value = '')

--- a/lib/document/markdown_parser.rb
+++ b/lib/document/markdown_parser.rb
@@ -6,7 +6,7 @@ module Document
     # Regex from Jekyll
     # https://github.com/jekyll/jekyll/blob/fac041933c3e328ff73dc91faeaeb08182ae3c74/
     #     lib/jekyll/document.rb#L10
-    YAML_FRONT_MATTER_REGEXP = %r!\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)!m
+    YAML_FRONT_MATTER_REGEXP = /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
 
     def initialize(filecontents:)
       @filecontents = filecontents

--- a/lib/document/markdown_with_frontmatter.rb
+++ b/lib/document/markdown_with_frontmatter.rb
@@ -10,7 +10,8 @@ module Document
     end
 
     def date
-      Date.iso8601($1) if DATE_PATTERN =~ basename
+      match_data = DATE_PATTERN.match(basename)
+      Date.iso8601(match_data[:date]) if match_data
     end
 
     def title
@@ -40,7 +41,7 @@ module Document
 
     private
 
-    DATE_PATTERN = /^(\d{4}-\d{2}-\d{2})/
+    DATE_PATTERN = /^(?<date>\d{4}-\d{2}-\d{2})/
     attr_reader :filename, :baseurl
 
     def basename

--- a/lib/document/markdown_with_frontmatter.rb
+++ b/lib/document/markdown_with_frontmatter.rb
@@ -61,7 +61,7 @@ module Document
     end
 
     def filecontents
-      @contents ||= File.open(filename, 'r') { |f| f.read }
+      @contents ||= File.open(filename, 'r', &:read)
     end
 
     def frontmatter

--- a/lib/ep/people_by_legislature.rb
+++ b/lib/ep/people_by_legislature.rb
@@ -47,7 +47,7 @@ module EP
     end
 
     def latest_term
-      legislature.legislative_periods.sort_by { |term| term.start_date }.last
+      legislature.legislative_periods.sort_by(&:start_date).last
     end
 
     def create_person(person)

--- a/lib/ep/person.rb
+++ b/lib/ep/person.rb
@@ -12,8 +12,9 @@ module EP
     end
 
     extend Forwardable
-    def_delegators :@person, :id, :name, :birth_date, :image, :phone,
-                             :email, :twitter, :facebook, :memberships
+    def_delegators :@person,
+                   :id, :name, :birth_date, :image, :phone,
+                   :email, :twitter, :facebook, :memberships
 
     include PersonProxyImages
     include PersonSocial

--- a/lib/helpers/layout_helper.rb
+++ b/lib/helpers/layout_helper.rb
@@ -10,7 +10,7 @@ module LayoutHelper
   end
 
   def homepage?
-    request.env['PATH_INFO'].match(/^\/?$/)
+    request.env['PATH_INFO'].match(%r{^\/?$})
   end
 
   def add_active_class(path)

--- a/lib/helpers/layout_helper.rb
+++ b/lib/helpers/layout_helper.rb
@@ -1,18 +1,20 @@
+# frozen_string_literal: true
+
 module LayoutHelper
   def meta_title(page)
-    is_homepage? ? site_title : title(page)
+    homepage? ? site_title : title(page)
   end
 
   def site_title
     'Shine your eye'
   end
 
-  def is_homepage?
+  def homepage?
     request.env['PATH_INFO'].match(/^\/?$/)
   end
 
   def add_active_class(path)
-    is_current_page?(path) ? active_class : ''
+    current_page?(path) ? active_class : ''
   end
 
   private
@@ -21,7 +23,7 @@ module LayoutHelper
     "#{page.title} :: #{site_title}"
   end
 
-  def is_current_page?(path)
+  def current_page?(path)
     request.env['PATH_INFO'] == path
   end
 

--- a/lib/mapit/place.rb
+++ b/lib/mapit/place.rb
@@ -22,7 +22,7 @@ module Mapit
       mapit_area_data['type_name']
     end
 
-    alias_method :child_area?, :parent
+    alias child_area? parent
 
     def url
       "#{baseurl}#{pombola_slug}/"

--- a/lib/mapit/place.rb
+++ b/lib/mapit/place.rb
@@ -22,7 +22,7 @@ module Mapit
       mapit_area_data['type_name']
     end
 
-    alias_method :is_child_area?, :parent
+    alias_method :child_area?, :parent
 
     def url
       "#{baseurl}#{pombola_slug}/"

--- a/lib/mapit/wrapper.rb
+++ b/lib/mapit/wrapper.rb
@@ -3,7 +3,6 @@ require_relative 'place'
 
 module Mapit
   class Wrapper
-
     def initialize(mapit_mappings:, baseurl:, area_types:, data_directory:)
       @baseurl = baseurl
       @area_types = area_types

--- a/lib/membership_csv/people.rb
+++ b/lib/membership_csv/people.rb
@@ -31,7 +31,7 @@ module MembershipCSV
     end
 
     def remove_empty_cells(row)
-      row.reject { |header, value| value.nil? || value.empty? }.to_h
+      row.reject { |_header, value| value.nil? || value.empty? }.to_h
     end
 
     def read_with_headers

--- a/lib/page/homepage.rb
+++ b/lib/page/homepage.rb
@@ -19,7 +19,7 @@ module Page
     end
 
     def format_date(date)
-      date.strftime("%B %-d, %Y")
+      date.strftime('%B %-d, %Y')
     end
 
     private

--- a/lib/page/homepage.rb
+++ b/lib/page/homepage.rb
@@ -7,11 +7,11 @@ module Page
     end
 
     def featured_posts
-      posts.sort_by { |d| d.date }.reverse.first(3)
+      posts.sort_by(&:date).reverse.first(3)
     end
 
     def featured_events
-      future_events.sort_by { |d| d.event_date }.first(3)
+      future_events.sort_by(&:event_date).first(3)
     end
 
     def no_events?

--- a/lib/page/post.rb
+++ b/lib/page/post.rb
@@ -10,7 +10,7 @@ module Page
     end
 
     def date
-      post.date.strftime("%B %-d, %Y")
+      post.date.strftime('%B %-d, %Y')
     end
 
     def body

--- a/lib/page/posts.rb
+++ b/lib/page/posts.rb
@@ -13,7 +13,7 @@ module Page
     end
 
     def format_date(date)
-      date.strftime("%B %-d, %Y")
+      date.strftime('%B %-d, %Y')
     end
 
     private

--- a/lib/page/posts.rb
+++ b/lib/page/posts.rb
@@ -9,7 +9,7 @@ module Page
     end
 
     def sorted_posts
-      posts.sort_by { |d| d.date }.reverse
+      posts.sort_by(&:date).reverse
     end
 
     def format_date(date)

--- a/lib/person_proxy_images.rb
+++ b/lib/person_proxy_images.rb
@@ -18,7 +18,7 @@ module PersonProxyImages
     thumbnail: '100x100',
     medium: '250x250',
     original: 'original'
-  }
+  }.freeze
 
   def proxy_image_variant(size)
     return if image.nil?

--- a/lib/person_proxy_images.rb
+++ b/lib/person_proxy_images.rb
@@ -27,8 +27,7 @@ module PersonProxyImages
   end
 
   def raise_unless_image_size_available(size)
-    unless ALLOWED_IMAGE_SIZES.has_key?(size)
-      raise "Size #{size} is not known to be available"
-    end
+    error_message = "Size #{size} is not known to be available"
+    raise error_message unless ALLOWED_IMAGE_SIZES.key?(size)
   end
 end

--- a/tests/.rubocop.yml
+++ b/tests/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from: ../.rubocop.yml
+
+Metrics/BlockLength:
+  Enabled: false

--- a/tests/document/markdown_with_frontmatter.rb
+++ b/tests/document/markdown_with_frontmatter.rb
@@ -3,17 +3,21 @@ require 'test_helper'
 require_relative '../../lib/document/markdown_with_frontmatter'
 
 describe 'Document::MarkdownWithFrontmatter' do
-  let(:contents) { "---
+  let(:contents) do
+    "---
 title: A Title
 slug: a-slug
 published: true
 eventdate: '2000-01-01 15:00 +0000'
 ---
-# Hello World" }
-  let(:document) { Document::MarkdownWithFrontmatter.new(
-    filename: new_tempfile(contents, '1000-10-01-file-name'),
-    baseurl: '/events/')
-  }
+# Hello World"
+  end
+  let(:document) do
+    Document::MarkdownWithFrontmatter.new(
+      filename: new_tempfile(contents, '1000-10-01-file-name'),
+      baseurl: '/events/'
+    )
+  end
 
   it 'has a title' do
     document.title.must_equal('A Title')

--- a/tests/ep/people_by_legislature.rb
+++ b/tests/ep/people_by_legislature.rb
@@ -5,11 +5,13 @@ require_relative '../../lib/ep/people_by_legislature'
 describe 'EP::PeopleByLegislature' do
   let(:legislature) { nigeria_at_known_revision.legislature('Representatives') }
   describe 'class methods' do
-    let(:people) { EP::PeopleByLegislature.new(
-      legislature: legislature,
-      mapit: 'irrelevant',
-      baseurl: '/baseurl/'
-    ) }
+    let(:people) do
+      EP::PeopleByLegislature.new(
+        legislature: legislature,
+        mapit: 'irrelevant',
+        baseurl: '/baseurl/'
+      )
+    end
 
     it 'has a list of all the people' do
       people.find_all.count.must_equal(364)
@@ -52,11 +54,13 @@ describe 'EP::PeopleByLegislature' do
   end
 
   describe 'extra mapit functionality' do
-    let(:people) { EP::PeopleByLegislature.new(
-      legislature: legislature,
-      mapit: FakeMapit.new(1),
-      baseurl: '/baseurl/'
-    ) }
+    let(:people) do
+      EP::PeopleByLegislature.new(
+        legislature: legislature,
+        mapit: FakeMapit.new(1),
+        baseurl: '/baseurl/'
+      )
+    end
 
     it 'assigns a mapit area to the person' do
       people.find_single('b2a7f72a-9ecf-4263-83f1-cb0f8783053c').area.id

--- a/tests/ep/people_by_legislature.rb
+++ b/tests/ep/people_by_legislature.rb
@@ -33,7 +33,7 @@ describe 'EP::PeopleByLegislature' do
 
     it 'finds a single person by id' do
       people.find_single('b2a7f72a-9ecf-4263-83f1-cb0f8783053c').name
-        .must_equal('ABDUKADIR RAHIS')
+            .must_equal('ABDUKADIR RAHIS')
     end
 
     it 'can check if id does not exist in this legislature' do
@@ -60,7 +60,7 @@ describe 'EP::PeopleByLegislature' do
 
     it 'assigns a mapit area to the person' do
       people.find_single('b2a7f72a-9ecf-4263-83f1-cb0f8783053c').area.id
-        .must_equal(1)
+            .must_equal(1)
     end
 
     it 'finds all people in a mapit area' do

--- a/tests/ep/person.rb
+++ b/tests/ep/person.rb
@@ -215,7 +215,7 @@ describe 'EP::Person' do
 
   def latest_term
     legislature = nigeria_at_known_revision.legislature('Senate')
-    legislature.legislative_periods.sort_by { |term| term.start_date }.last
+    legislature.legislative_periods.sort_by(&:start_date).last
   end
 
   module Facebook

--- a/tests/mapit/mappings.rb
+++ b/tests/mapit/mappings.rb
@@ -4,12 +4,15 @@ require_relative '../../lib/mapit/mappings'
 
 describe 'Mapit::Mappings' do
   describe 'FED to STA mappings' do
-    let(:fed_to_sta) { new_tempfile('949,16
+    let(:fed_to_sta) do
+      new_tempfile(
+        '949,16
 1091,12'
-    ) }
-    let(:mappings) { Mapit::Mappings.new(
-      parent_mapping_filenames: [fed_to_sta],
-    ) }
+      )
+    end
+    let(:mappings) do
+      Mapit::Mappings.new(parent_mapping_filenames: [fed_to_sta])
+    end
 
     it 'can map all constituencies to their state' do
       mappings.child_to_parent.count.must_equal(2)
@@ -29,14 +32,17 @@ describe 'Mapit::Mappings' do
   end
 
   describe 'Mapit ids to Pombola slugs' do
-    let(:pombola_to_mapit) { new_tempfile('gwagwaladakuje,949,FED
+    let(:pombola_to_mapit) do
+      new_tempfile(
+        'gwagwaladakuje,949,FED
 federal-capital-territory,16,STA
 abakalikiizzi,1091,FED
 ebonyi,12,STA'
-    ) }
-    let(:mappings) { Mapit::Mappings.new(
-      pombola_slugs_to_mapit_ids_filename: pombola_to_mapit,
-    ) }
+      )
+    end
+    let(:mappings) do
+      Mapit::Mappings.new(pombola_slugs_to_mapit_ids_filename: pombola_to_mapit)
+    end
 
     it 'can map all mapit ids to their Pombola slug' do
       mappings.mapit_ids_to_pombola_slugs.count.must_equal(4)
@@ -64,15 +70,23 @@ ebonyi,12,STA'
   end
 
   describe 'EP to mapit area mappings' do
-    let(:mapit_to_ep_fed) { new_tempfile('1139,"area/adavi/okehi,_kogi_state"
+    let(:mapit_to_ep_fed) do
+      new_tempfile(
+        '1139,"area/adavi/okehi,_kogi_state"
 1203,"area/ado-odo/ota,_ogun_state"'
-    ) }
-    let(:mapit_to_ep_sen) { new_tempfile('832,"area/borno_south,_borno_state"
+      )
+    end
+    let(:mapit_to_ep_sen) do
+      new_tempfile(
+        '832,"area/borno_south,_borno_state"
 836,"area/delta_central,_delta_state"'
-    ) }
-    let(:mappings) { Mapit::Mappings.new(
-      mapit_to_ep_areas_filenames: [mapit_to_ep_fed, mapit_to_ep_sen]
-    ) }
+      )
+    end
+    let(:mappings) do
+      Mapit::Mappings.new(
+        mapit_to_ep_areas_filenames: [mapit_to_ep_fed, mapit_to_ep_sen]
+      )
+    end
 
     it 'can map all ep areas to their mapit area' do
       mappings.ep_to_mapit_ids.count.must_equal(4)

--- a/tests/mapit/place.rb
+++ b/tests/mapit/place.rb
@@ -40,7 +40,7 @@ describe 'Place' do
     end
 
     it 'knows it is a child' do
-      assert(place.is_child_area?)
+      assert(place.child_area?)
     end
 
     it 'the parent returns nil for its parent' do
@@ -48,7 +48,7 @@ describe 'Place' do
     end
 
     it 'the parent knows it is not a child' do
-      refute(place.parent.is_child_area?)
+      refute(place.parent.child_area?)
     end
   end
 

--- a/tests/mapit/place.rb
+++ b/tests/mapit/place.rb
@@ -4,16 +4,18 @@ require_relative '../../lib/mapit/place'
 
 describe 'Place' do
   describe 'when area has a parent' do
-    let(:place) { Mapit::Place.new(
-      mapit_area_data: area_with_parent,
-      pombola_slug: 'gwagwaladakuje',
-      baseurl: '/baseurl/',
-      parent: Mapit::Place.new(
-        mapit_area_data: area_with_no_parent,
-        pombola_slug: 'federal-capital-territory',
-        baseurl: '/baseurl/'
+    let(:place) do
+      Mapit::Place.new(
+        mapit_area_data: area_with_parent,
+        pombola_slug: 'gwagwaladakuje',
+        baseurl: '/baseurl/',
+        parent: Mapit::Place.new(
+          mapit_area_data: area_with_no_parent,
+          pombola_slug: 'federal-capital-territory',
+          baseurl: '/baseurl/'
+        )
       )
-    ) }
+    end
 
     it 'knows its id' do
       place.id.must_equal(949)

--- a/tests/mapit/wrapper.rb
+++ b/tests/mapit/wrapper.rb
@@ -3,12 +3,14 @@ require 'test_helper'
 require_relative '../../lib/mapit/wrapper'
 
 describe 'Mappit::Wrapper' do
-  let(:mapit) { Mapit::Wrapper.new(
-    mapit_mappings: FakeMappings.new,
-    baseurl: '/baseurl/',
-    area_types: %w(FED SEN STA),
-    data_directory: 'mapit'
-  ) }
+  let(:mapit) do
+    Mapit::Wrapper.new(
+      mapit_mappings: FakeMappings.new,
+      baseurl: '/baseurl/',
+      area_types: %w(FED SEN STA),
+      data_directory: 'mapit'
+    )
+  end
 
   describe 'when getting the states' do
     it 'gets a list of all the states' do

--- a/tests/membership_csv/people.rb
+++ b/tests/membership_csv/people.rb
@@ -3,16 +3,19 @@ require 'test_helper'
 require_relative '../../lib/membership_csv/people'
 
 describe 'MembershipCSV::People' do
-  let(:contents) { 'id,name,identifier__shineyoureye,phone
+  let(:contents) do
+    'id,name,identifier__shineyoureye,phone
 id1,name1,name-1,1234
 id2,name2,name-2,5678
 id3,name3,name-3,'
-  }
-  let(:people) { MembershipCSV::People.new(
-    csv_filename: new_tempfile(contents),
-    mapit: 'irrelevant',
-    baseurl: '/baseurl/'
-  ) }
+  end
+  let(:people) do
+    MembershipCSV::People.new(
+      csv_filename: new_tempfile(contents),
+      mapit: 'irrelevant',
+      baseurl: '/baseurl/'
+    )
+  end
 
   it 'finds all people' do
     people.find_all.count.must_equal(3)
@@ -44,11 +47,13 @@ id3,name3,name-3,'
   end
 
   describe 'extra mapit functionality' do
-    let(:people) { MembershipCSV::People.new(
-      csv_filename: new_tempfile(contents),
-      mapit: FakeMapit.new(1),
-      baseurl: '/baseurl/'
-    ) }
+    let(:people) do
+      MembershipCSV::People.new(
+        csv_filename: new_tempfile(contents),
+        mapit: FakeMapit.new(1),
+        baseurl: '/baseurl/'
+      )
+    end
 
     it 'assigns a mapit area to the person' do
       people.find_single('id3').area.id.must_equal(1)

--- a/tests/membership_csv/person.rb
+++ b/tests/membership_csv/person.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 require_relative '../../lib/membership_csv/person'
 
 describe 'MembershipCSV::Person' do
-  let(:person) { morph_person(person_filled) }
+  let(:person) { morph_person(PERSON_FILLED) }
 
   describe 'person proxy images' do
     it 'has a thumbnail image' do
@@ -203,27 +203,25 @@ describe 'MembershipCSV::Person' do
     )
   end
 
-  def person_filled
-    {
-      'honorific_prefix' => 'Dr',
-      'name' => 'Victor Okezie Ikpeazu',
-      'id' => 'gov:victor-okezie-ikpeazu',
-      'state' => 'Abia',
-      'party' => 'PDP',
-      'email' => 'info@abiastate.gov.ng;person@example.com',
-      'phone' => '7030152466;08063496033;08035879790',
-      'twitter' => 'GovDickson;DicksonSeriake',
-      'facebook_url' => 'https://www.facebook.com/OyoStateGovernment;http://www.facebook.com/AbiolaAjimobi',
-      'birth_date' => '1964-10-18',
-      'gender' => 'Male',
-      'identifier__shineyoureye' => 'okezie-ikpeazu',
-      'image_url' => 'http://www.shineyoureye.org/media_root/images/Abia_-_Okezie_Ikpeazu.jpg',
-      'website_url' => 'http://ekitistate.gov.ng/',
-      'other_names' => 'Okezie Ikpeazu'
-    }
-  end
+  PERSON_FILLED = {
+    'honorific_prefix' => 'Dr',
+    'name' => 'Victor Okezie Ikpeazu',
+    'id' => 'gov:victor-okezie-ikpeazu',
+    'state' => 'Abia',
+    'party' => 'PDP',
+    'email' => 'info@abiastate.gov.ng;person@example.com',
+    'phone' => '7030152466;08063496033;08035879790',
+    'twitter' => 'GovDickson;DicksonSeriake',
+    'facebook_url' => 'https://www.facebook.com/OyoStateGovernment;http://www.facebook.com/AbiolaAjimobi',
+    'birth_date' => '1964-10-18',
+    'gender' => 'Male',
+    'identifier__shineyoureye' => 'okezie-ikpeazu',
+    'image_url' => 'http://www.shineyoureye.org/media_root/images/Abia_-_Okezie_Ikpeazu.jpg',
+    'website_url' => 'http://ekitistate.gov.ng/',
+    'other_names' => 'Okezie Ikpeazu'
+  }.freeze
 
   def person_empty
-    person_filled.each_with_object({}) { |(key, _), memo| memo[key] = nil }
+    PERSON_FILLED.each_with_object({}) { |(key, _), memo| memo[key] = nil }
   end
 end

--- a/tests/page/homepage.rb
+++ b/tests/page/homepage.rb
@@ -5,11 +5,11 @@ require_relative '../../lib/page/homepage'
 describe 'Page::Homepage' do
   let(:documents) do
     [
-      FakeDocument.new('1000-01-11-foo', "#{yesterday}"),
-      FakeDocument.new('1000-01-12-bar', "#{today}"),
-      FakeDocument.new('1000-01-13-qux', "#{tomorrow}"),
-      FakeDocument.new('1000-01-14-qux', "#{in_two_weeks}"),
-      FakeDocument.new('1000-01-15-qux', "#{in_two_weeks}")
+      FakeDocument.new('1000-01-11-foo', yesterday.to_s),
+      FakeDocument.new('1000-01-12-bar', today.to_s),
+      FakeDocument.new('1000-01-13-qux', tomorrow.to_s),
+      FakeDocument.new('1000-01-14-qux', in_two_weeks.to_s),
+      FakeDocument.new('1000-01-15-qux', in_two_weeks.to_s)
     ]
   end
   let(:page) { Page::Homepage.new(posts: documents, events: documents) }

--- a/tests/page/homepage.rb
+++ b/tests/page/homepage.rb
@@ -3,13 +3,15 @@ require 'test_helper'
 require_relative '../../lib/page/homepage'
 
 describe 'Page::Homepage' do
-  let(:documents) { [
-    FakeDocument.new('1000-01-11-foo', "#{yesterday}"),
-    FakeDocument.new('1000-01-12-bar', "#{today}"),
-    FakeDocument.new('1000-01-13-qux', "#{tomorrow}"),
-    FakeDocument.new('1000-01-14-qux', "#{in_two_weeks}"),
-    FakeDocument.new('1000-01-15-qux', "#{in_two_weeks}")
-  ] }
+  let(:documents) do
+    [
+      FakeDocument.new('1000-01-11-foo', "#{yesterday}"),
+      FakeDocument.new('1000-01-12-bar', "#{today}"),
+      FakeDocument.new('1000-01-13-qux', "#{tomorrow}"),
+      FakeDocument.new('1000-01-14-qux', "#{in_two_weeks}"),
+      FakeDocument.new('1000-01-15-qux', "#{in_two_weeks}")
+    ]
+  end
   let(:page) { Page::Homepage.new(posts: documents, events: documents) }
 
   describe 'featured posts' do

--- a/tests/page/info.rb
+++ b/tests/page/info.rb
@@ -5,7 +5,6 @@ require_relative '../../lib/page/info'
 describe 'Page::Info' do
   let(:page) { Page::Info.new(static_page: FakeInfo.new) }
 
-
   it 'has a title' do
     page.title.must_equal('A Title')
   end

--- a/tests/page/people.rb
+++ b/tests/page/people.rb
@@ -4,15 +4,19 @@ require_relative '../../lib/ep/people_by_legislature'
 require_relative '../../lib/page/people'
 
 describe 'Page::People' do
-  let(:people) { EP::PeopleByLegislature.new(
-    legislature: nigeria_at_known_revision.legislature('Representatives'),
-    mapit: 'irrelevant',
-    baseurl: '/baseurl/'
-  ) }
-  let(:page) { Page::People.new(
-    title: 'Federal Representative',
-    people_by_legislature: people
-  ) }
+  let(:people) do
+    EP::PeopleByLegislature.new(
+      legislature: nigeria_at_known_revision.legislature('Representatives'),
+      mapit: 'irrelevant',
+      baseurl: '/baseurl/'
+    )
+  end
+  let(:page) do
+    Page::People.new(
+      title: 'Federal Representative',
+      people_by_legislature: people
+    )
+  end
 
   it 'has a title' do
     page.title.must_equal('Federal Representative')

--- a/tests/page/person.rb
+++ b/tests/page/person.rb
@@ -6,16 +6,20 @@ require_relative '../../lib/page/person'
 require_relative 'person_interface_test'
 
 describe 'Page::Person' do
-  let(:people) { EP::PeopleByLegislature.new(
-    legislature: nigeria_at_known_revision.legislature('Representatives'),
-    mapit: 'irrelevant',
-    baseurl: 'irrelevant'
-  ) }
-  let(:page) { Page::Person.new(
-    person: people.find_single('b2a7f72a-9ecf-4263-83f1-cb0f8783053c'),
-    position: 'Position',
-    summary_doc: FakeSummary.new('<p>foo</p>')
-  ) }
+  let(:people) do
+    EP::PeopleByLegislature.new(
+      legislature: nigeria_at_known_revision.legislature('Representatives'),
+      mapit: 'irrelevant',
+      baseurl: 'irrelevant'
+    )
+  end
+  let(:page) do
+    Page::Person.new(
+      person: people.find_single('b2a7f72a-9ecf-4263-83f1-cb0f8783053c'),
+      position: 'Position',
+      summary_doc: FakeSummary.new('<p>foo</p>')
+    )
+  end
 
   it 'knows the position' do
     page.position.must_equal('Position')
@@ -40,20 +44,27 @@ describe 'Page::Person' do
 
   describe 'when page is a Morph person' do
     include PersonInterfaceTest
-    let(:contents) { 'id
+    let(:contents) do
+      'id
 1'
-    }
-    let(:people) { MembershipCSV::People.new(
-      csv_filename: new_tempfile(contents),
-      mapit: 'irrelevant',
-      baseurl: 'irrelevant'
-    ) }
-    let(:page) { Page::Person.new(
-      person: people.find_single('1'),
-      position: 'irrelevant',
-      summary_doc: 'irrelevant'
-    ) }
-    let(:person) { page.person }
+    end
+    let(:people) do
+      MembershipCSV::People.new(
+        csv_filename: new_tempfile(contents),
+        mapit: 'irrelevant',
+        baseurl: 'irrelevant'
+      )
+    end
+    let(:page) do
+      Page::Person.new(
+        person: people.find_single('1'),
+        position: 'irrelevant',
+        summary_doc: 'irrelevant'
+      )
+    end
+    let(:person) do
+      page.person
+    end
   end
 
   FakeSummary = Struct.new(:body)

--- a/tests/page/person_interface_test.rb
+++ b/tests/page/person_interface_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Module
   include Minitest::Spec::DSL
 end

--- a/tests/page/place.rb
+++ b/tests/page/place.rb
@@ -5,21 +5,27 @@ require_relative '../../lib/mapit/place'
 require_relative '../../lib/page/place'
 
 describe 'Page::Place' do
-  let(:place) { Mapit::Place.new(
-    mapit_area_data: area,
-    pombola_slug: 'gwagwaladakuje',
-    baseurl: '/baseurl/'
-  ) }
-  let(:people) { EP::PeopleByLegislature.new(
-    legislature: nigeria_at_known_revision.legislature('Representatives'),
-    mapit: FakeMapit.new(949),
-    baseurl: '/baseurl/'
-  ) }
-  let(:page) { Page::Place.new(
-    place: place,
-    people_by_legislature: people,
-    people_path: '/people/'
-  ) }
+  let(:place) do
+    Mapit::Place.new(
+      mapit_area_data: area,
+      pombola_slug: 'gwagwaladakuje',
+      baseurl: '/baseurl/'
+    )
+  end
+  let(:people) do
+    EP::PeopleByLegislature.new(
+      legislature: nigeria_at_known_revision.legislature('Representatives'),
+      mapit: FakeMapit.new(949),
+      baseurl: '/baseurl/'
+    )
+  end
+  let(:page) do
+    Page::Place.new(
+      place: place,
+      people_by_legislature: people,
+      people_path: '/people/'
+    )
+  end
 
   it 'has a title' do
     page.title.must_equal('Abaji/Gwagwalada/Kwali/Kuje')

--- a/tests/page/places.rb
+++ b/tests/page/places.rb
@@ -11,7 +11,7 @@ describe 'Page::Places' do
   ) }
   let(:page) { Page::Places.new(
     title: 'Constituencies',
-    places: ['irrelevant', 'irrelevant'],
+    places: %w(irrelevant irrelevant),
     people_by_legislature: people
   ) }
 

--- a/tests/page/places.rb
+++ b/tests/page/places.rb
@@ -4,16 +4,20 @@ require_relative '../../lib/ep/people_by_legislature'
 require_relative '../../lib/page/places'
 
 describe 'Page::Places' do
-  let(:people) { EP::PeopleByLegislature.new(
-    legislature: nigeria_at_known_revision.legislature('Representatives'),
-    mapit: FakeMapit.new(1),
-    baseurl: '/baseurl/'
-  ) }
-  let(:page) { Page::Places.new(
-    title: 'Constituencies',
-    places: %w(irrelevant irrelevant),
-    people_by_legislature: people
-  ) }
+  let(:people) do
+    EP::PeopleByLegislature.new(
+      legislature: nigeria_at_known_revision.legislature('Representatives'),
+      mapit: FakeMapit.new(1),
+      baseurl: '/baseurl/'
+    )
+  end
+  let(:page) do
+    Page::Places.new(
+      title: 'Constituencies',
+      places: %w(irrelevant irrelevant),
+      people_by_legislature: people
+    )
+  end
 
   it 'has a title' do
     page.title.must_equal('Constituencies')

--- a/tests/page/posts.rb
+++ b/tests/page/posts.rb
@@ -18,8 +18,8 @@ describe 'Page::Posts' do
   end
 
   it 'links posts to a url under the blog path' do
-    first.url.must_equal("/blog/foo")
-    last.url.must_equal("/blog/bar")
+    first.url.must_equal('/blog/foo')
+    last.url.must_equal('/blog/bar')
   end
 
   it 'sorts the posts from newer to older' do

--- a/tests/page/posts.rb
+++ b/tests/page/posts.rb
@@ -3,10 +3,12 @@ require 'test_helper'
 require_relative '../../lib/page/posts'
 
 describe 'Page::Posts' do
-  let(:posts) { [
-    FakeDoc.new('2016-01-01-foo', '/blog/'),
-    FakeDoc.new('2012-01-01-bar', '/blog/')
-  ] }
+  let(:posts) do
+    [
+      FakeDoc.new('2016-01-01-foo', '/blog/'),
+      FakeDoc.new('2012-01-01-bar', '/blog/')
+    ]
+  end
   let(:page) { Page::Posts.new(posts: posts, title: 'Blog') }
 
   it 'has a title' do

--- a/tests/test_doubles.rb
+++ b/tests/test_doubles.rb
@@ -6,7 +6,7 @@ FakeMapit = Struct.new(:mapit_id) do
     FakePlace.new(mapit_id, 'Mapit Area Name', '/place/pombola-slug/')
   end
 
-  def area_from_mapit_name(name)
+  def area_from_mapit_name(_name)
     FakePlace.new(mapit_id)
   end
 end

--- a/tests/test_doubles.rb
+++ b/tests/test_doubles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FakePlace = Struct.new(:id, :name, :url)
 FakeMapit = Struct.new(:mapit_id) do
   def area_from_ep_id(id)

--- a/tests/test_doubles.rb
+++ b/tests/test_doubles.rb
@@ -2,7 +2,7 @@
 
 FakePlace = Struct.new(:id, :name, :url)
 FakeMapit = Struct.new(:mapit_id) do
-  def area_from_ep_id(id)
+  def area_from_ep_id(_id)
     FakePlace.new(mapit_id, 'Mapit Area Name', '/place/pombola-slug/')
   end
 

--- a/tests/web/constituency.rb
+++ b/tests/web/constituency.rb
@@ -33,12 +33,12 @@ describe 'Federal Constituency Place Page' do
 
   it 'displays the place type name' do
     subject.css('.person__key-info h2').first.text
-    .must_include('Federal Constituency')
+           .must_include('Federal Constituency')
   end
 
   it 'displays the house name' do
     subject.css('.person__key-info h2').first.text
-    .must_include('House of Representatives')
+           .must_include('House of Representatives')
   end
 
   it 'displays all people associated with the place' do
@@ -50,29 +50,29 @@ describe 'Federal Constituency Place Page' do
 
     it 'links to the person page' do
       person.css('.media-left a/@href').text
-      .must_equal('/person/ea083b8f-f370-484e-bb84-63541cd0cc1c/')
+            .must_equal('/person/ea083b8f-f370-484e-bb84-63541cd0cc1c/')
       person.css('.media-body a/@href').first.text
-      .must_equal('/person/ea083b8f-f370-484e-bb84-63541cd0cc1c/')
+            .must_equal('/person/ea083b8f-f370-484e-bb84-63541cd0cc1c/')
     end
 
     it 'has an image that points to the thumbnail proxy image' do
       person.css('.media-left img/@src').text
-      .must_include('/ea083b8f-f370-484e-bb84-63541cd0cc1c/100x100.jpeg')
+            .must_include('/ea083b8f-f370-484e-bb84-63541cd0cc1c/100x100.jpeg')
     end
 
     it 'has an image whose srcset that points to the thumbnail proxy image' do
       person.css('.media-left img/@srcset').text
-      .must_include('/ea083b8f-f370-484e-bb84-63541cd0cc1c/100x100.jpeg')
+            .must_include('/ea083b8f-f370-484e-bb84-63541cd0cc1c/100x100.jpeg')
     end
 
     it 'has an image whose alternative text is the person name' do
       person.css('.media-left img/@alt').text
-      .must_equal('SYLVESTER OGBAGA')
+            .must_equal('SYLVESTER OGBAGA')
     end
 
     it 'displays the person name' do
       person.css('.media-body a').first.text
-      .must_equal('SYLVESTER OGBAGA')
+            .must_equal('SYLVESTER OGBAGA')
     end
 
     it 'shows right area type name' do
@@ -81,22 +81,22 @@ describe 'Federal Constituency Place Page' do
 
     it 'links to the person area' do
       person.css('.listing__area @href').text
-      .must_equal('/place/abakalikiizzi/')
+            .must_equal('/place/abakalikiizzi/')
     end
 
     it 'displays the person area name' do
       person.css('.listing__area').text
-      .must_equal('Abakaliki/Izzi')
+            .must_equal('Abakaliki/Izzi')
     end
 
     it 'links to the person party' do
       person.css('.listing__party @href').text
-      .must_equal('/organisation/pdp/')
+            .must_equal('/organisation/pdp/')
     end
 
     it 'displays the person party name' do
       person.css('.listing__party').text
-      .must_equal('Peoples Democratic Party')
+            .must_equal('Peoples Democratic Party')
     end
   end
 end

--- a/tests/web/district.rb
+++ b/tests/web/district.rb
@@ -33,12 +33,12 @@ describe 'Senatorial District Place Page' do
 
   it 'displays the place type name' do
     subject.css('.person__key-info h2').first.text
-    .must_include('Senatorial District')
+           .must_include('Senatorial District')
   end
 
   it 'displays the house name' do
     subject.css('.person__key-info h2').first.text
-    .must_include('Senate')
+           .must_include('Senate')
   end
 
   it 'displays all people associated with the place' do
@@ -50,29 +50,29 @@ describe 'Senatorial District Place Page' do
 
     it 'links to the person page' do
       person.css('.media-left a/@href').text
-      .must_equal('/person/73f394c3-b0ae-4154-b86c-8e5b7b637df8/')
+            .must_equal('/person/73f394c3-b0ae-4154-b86c-8e5b7b637df8/')
       person.css('.media-body a/@href').first.text
-      .must_equal('/person/73f394c3-b0ae-4154-b86c-8e5b7b637df8/')
+            .must_equal('/person/73f394c3-b0ae-4154-b86c-8e5b7b637df8/')
     end
 
     it 'has an image that points to the thumbnail proxy image' do
       person.css('.media-left img/@src').text
-      .must_include('/73f394c3-b0ae-4154-b86c-8e5b7b637df8/100x100.jpeg')
+            .must_include('/73f394c3-b0ae-4154-b86c-8e5b7b637df8/100x100.jpeg')
     end
 
     it 'has an image whose srcset that points to the thumbnail proxy image' do
       person.css('.media-left img/@srcset').text
-      .must_include('/73f394c3-b0ae-4154-b86c-8e5b7b637df8/100x100.jpeg')
+            .must_include('/73f394c3-b0ae-4154-b86c-8e5b7b637df8/100x100.jpeg')
     end
 
     it 'has an image whose alternative text is the person name' do
       person.css('.media-left img/@alt').text
-      .must_equal('THEODORE ORJI')
+            .must_equal('THEODORE ORJI')
     end
 
     it 'displays the person name' do
       person.css('.media-body a').first.text
-      .must_equal('THEODORE ORJI')
+            .must_equal('THEODORE ORJI')
     end
 
     it 'shows right area type name' do
@@ -81,22 +81,22 @@ describe 'Senatorial District Place Page' do
 
     it 'links to the person area' do
       person.css('.listing__area @href').text
-      .must_equal('/place/abia-central/')
+            .must_equal('/place/abia-central/')
     end
 
     it 'displays the person area name' do
       person.css('.listing__area').text
-      .must_equal('ABIA CENTRAL')
+            .must_equal('ABIA CENTRAL')
     end
 
     it 'links to the person party' do
       person.css('.listing__party @href').text
-      .must_equal('/organisation/pdp/')
+            .must_equal('/organisation/pdp/')
     end
 
     it 'displays the person party name' do
       person.css('.listing__party').text
-      .must_equal('Peoples Democratic Party')
+            .must_equal('Peoples Democratic Party')
     end
   end
 end

--- a/tests/web/event.rb
+++ b/tests/web/event.rb
@@ -6,7 +6,7 @@ describe 'Event Page' do
   subject { Nokogiri::HTML(last_response.body) }
 
   it 'shows the event title' do
-    subject.css('.page-title').text.must_equal("FCT LGA Polls 2016")
+    subject.css('.page-title').text.must_equal('FCT LGA Polls 2016')
   end
 
   it 'shows the publication date with the right format' do

--- a/tests/web/governors.rb
+++ b/tests/web/governors.rb
@@ -20,20 +20,20 @@ describe 'List of Governors' do
 
     it 'links to the person page' do
       person.css('.media-left a/@href').first.text
-        .must_equal('/person/gov:abdulaziz-abubakar-yari/')
+            .must_equal('/person/gov:abdulaziz-abubakar-yari/')
       person.css('.media-body a/@href').first.text
-        .must_equal('/person/gov:abdulaziz-abubakar-yari/')
+            .must_equal('/person/gov:abdulaziz-abubakar-yari/')
     end
 
     describe 'when person has an image' do
       it 'points to the right path' do
         person.css('a img/@src').first.text
-          .must_include('/gov:abdulaziz-abubakar-yari/100x100.jpeg')
+              .must_include('/gov:abdulaziz-abubakar-yari/100x100.jpeg')
       end
 
       it 'has an srcset' do
         person.css('a img/@srcset').first.text
-          .must_include('/gov:abdulaziz-abubakar-yari/100x100.jpeg')
+              .must_include('/gov:abdulaziz-abubakar-yari/100x100.jpeg')
       end
 
       it 'has the name as alternative text' do
@@ -46,7 +46,7 @@ describe 'List of Governors' do
 
       it 'shows a picture anyway (empty avatar)' do
         person.css('.media-object/@src').first.text
-          .must_include('/images/person-250x250.png')
+              .must_include('/images/person-250x250.png')
       end
     end
 

--- a/tests/web/info.rb
+++ b/tests/web/info.rb
@@ -6,7 +6,7 @@ describe 'Info Page' do
   subject { Nokogiri::HTML(last_response.body) }
 
   it 'shows the post title' do
-    subject.css('.page-title').text.must_equal("About")
+    subject.css('.page-title').text.must_equal('About')
   end
 
   it 'displays the contents of the page' do

--- a/tests/web/info.rb
+++ b/tests/web/info.rb
@@ -11,7 +11,7 @@ describe 'Info Page' do
 
   it 'displays the contents of the page' do
     subject.css('.markdown.infopage').text
-      .must_include('Shine your Eye is an initiative of Enough is Enough Nigeria')
+           .must_include('Shine your Eye is an initiative of Enough is Enough Nigeria')
   end
 
   it 'throws a 404 error if no file is found' do

--- a/tests/web/layout.rb
+++ b/tests/web/layout.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 describe 'Layout' do
-  before  { get '/info/about' }
+  before { get '/info/about' }
   subject { Nokogiri::HTML(last_response.body) }
 
   it 'includes the head' do
@@ -22,7 +22,7 @@ describe 'Layout' do
   end
 
   describe 'fonts' do
-    before  { get '/fonts/bootstrap/glyphicons-halflings-regular.woff2' }
+    before { get '/fonts/bootstrap/glyphicons-halflings-regular.woff2' }
 
     it 'loads fonts' do
       last_response.content_type.must_equal('application/font-woff2')
@@ -30,7 +30,7 @@ describe 'Layout' do
   end
 
   describe 'javascript' do
-    before  { get '/javascripts/bootstrap/bootstrap.min.js' }
+    before { get '/javascripts/bootstrap/bootstrap.min.js' }
 
     it 'loads javascript' do
       last_response.content_type.must_equal('application/javascript;charset=utf-8')
@@ -38,7 +38,7 @@ describe 'Layout' do
   end
 
   describe 'robots' do
-    before  { get '/robots.txt' }
+    before { get '/robots.txt' }
 
     it 'disallows robots' do
       last_response.body.must_equal("User-agent: *\nDisallow:\n")

--- a/tests/web/person.rb
+++ b/tests/web/person.rb
@@ -189,7 +189,9 @@ describe 'Person Page' do
 
   describe 'social block' do
     it 'links to facebook share' do
-      subject.css('.btn-facebook/@href').text.must_include('/person/b2a7f72a-9ecf-4263-83f1-cb0f8783053c/&t=ABDUKADIR RAHIS')
+      subject.css('.btn-facebook/@href').text.must_include(
+        '/person/b2a7f72a-9ecf-4263-83f1-cb0f8783053c/&t=ABDUKADIR RAHIS'
+      )
     end
 
     it 'links to twitter share' do

--- a/tests/web/person.rb
+++ b/tests/web/person.rb
@@ -20,7 +20,7 @@ describe 'Person Page' do
   describe 'when person has an image' do
     it 'points to the right path' do
       subject.css('img.person__image/@src').first.text
-        .must_equal('https://theyworkforyou.github.io/shineyoureye-images/Representatives/b2a7f72a-9ecf-4263-83f1-cb0f8783053c/250x250.jpeg')
+             .must_equal('https://theyworkforyou.github.io/shineyoureye-images/Representatives/b2a7f72a-9ecf-4263-83f1-cb0f8783053c/250x250.jpeg')
     end
 
     it 'displays the name as alternative text' do
@@ -33,24 +33,24 @@ describe 'Person Page' do
 
     it 'shows a picture anyway (empty avatar)' do
       subject.css('img.person__image/@src').first.text
-        .must_equal('/images/person-250x250.png')
+             .must_equal('/images/person-250x250.png')
     end
   end
 
   describe 'when person has an area' do
     it 'shows the area type name' do
       subject.css('.person__key-info h2').text
-        .must_include('Federal Constituency')
+             .must_include('Federal Constituency')
     end
 
     it 'links to the area page' do
       subject.css('.person__area a/@href').first.text
-        .must_equal('/place/maiduguri/')
+             .must_equal('/place/maiduguri/')
     end
 
     it 'displays the area name' do
       subject.css('.person__area a').first.text
-        .must_equal('Maiduguri (Metropolitan)')
+             .must_equal('Maiduguri (Metropolitan)')
     end
   end
 
@@ -81,7 +81,7 @@ describe 'Person Page' do
 
     it 'links to it' do
       subject.css('.person__twitter a/@href').first.text
-        .must_equal('https://twitter.com/benmurraybruce')
+             .must_equal('https://twitter.com/benmurraybruce')
     end
 
     it 'displays it' do
@@ -94,7 +94,7 @@ describe 'Person Page' do
 
     it 'links to it' do
       subject.css('.person__facebook a/@href').first.text
-        .must_equal('https://www.facebook.com/WillieObiano')
+             .must_equal('https://www.facebook.com/WillieObiano')
     end
 
     it 'displays it' do
@@ -107,12 +107,12 @@ describe 'Person Page' do
 
     it 'links to the email' do
       subject.css('.person__email a/@href').first.text
-        .must_equal('mailto:adamu.abdullahi@gmail.com')
+             .must_equal('mailto:adamu.abdullahi@gmail.com')
     end
 
     it 'displays the email' do
       subject.css('.person__email a').first.text
-        .must_equal('adamu.abdullahi@gmail.com')
+             .must_equal('adamu.abdullahi@gmail.com')
     end
   end
 
@@ -121,12 +121,12 @@ describe 'Person Page' do
 
     it 'links to it' do
       subject.css('.person__wikipedia a/@href').first.text
-        .must_equal('https://en.wikipedia.org/wiki/Fatimat_Olufunke_Raji-Rasaki')
+             .must_equal('https://en.wikipedia.org/wiki/Fatimat_Olufunke_Raji-Rasaki')
     end
 
     it 'displays it' do
       subject.css('.person__wikipedia a').first.text
-        .must_equal('https://en.wikipedia.org/wiki/Fatimat_Olufunke_Raji-Rasaki')
+             .must_equal('https://en.wikipedia.org/wiki/Fatimat_Olufunke_Raji-Rasaki')
     end
   end
 
@@ -135,19 +135,19 @@ describe 'Person Page' do
 
     it 'edit link points to the right person id' do
       subject.css('.person-edit-link/@href').text
-        .must_include('/summaries/0baa5a03-b1e0-4e66-b3f9-daee8bacb87d.md')
+             .must_include('/summaries/0baa5a03-b1e0-4e66-b3f9-daee8bacb87d.md')
     end
 
     it 'shows summary contents if person has summary' do
       subject.css('.person-summary li').last.text
-        .must_include('Student at LEA PRI.SCH. from 1969 to 1974')
+             .must_include('Student at LEA PRI.SCH. from 1969 to 1974')
     end
   end
 
   describe 'when person has no summary' do
     it 'edit link points to the right person id' do
       subject.css('.person-edit-link/@href').text
-        .must_include('/summaries/b2a7f72a-9ecf-4263-83f1-cb0f8783053c.md')
+             .must_include('/summaries/b2a7f72a-9ecf-4263-83f1-cb0f8783053c.md')
     end
 
     it 'shows nothing in the summary' do

--- a/tests/web/person.rb
+++ b/tests/web/person.rb
@@ -77,7 +77,7 @@ describe 'Person Page' do
   end
 
   describe 'when person has a Twitter' do
-    before { get '/person/13721811-4357-419c-8ca7-8f1170b36f1a/'}
+    before { get '/person/13721811-4357-419c-8ca7-8f1170b36f1a/' }
 
     it 'links to it' do
       subject.css('.person__twitter a/@href').first.text
@@ -117,7 +117,7 @@ describe 'Person Page' do
   end
 
   describe 'when person has wikipedia url' do
-    before { get '/person/0577f346-e883-4e1d-94eb-e3050d5c15f1/'}
+    before { get '/person/0577f346-e883-4e1d-94eb-e3050d5c15f1/' }
 
     it 'links to it' do
       subject.css('.person__wikipedia a/@href').first.text

--- a/tests/web/post.rb
+++ b/tests/web/post.rb
@@ -6,7 +6,7 @@ describe 'Post Page' do
   subject { Nokogiri::HTML(last_response.body) }
 
   it 'shows the post title' do
-    subject.css('.page-title').text.must_equal("Citizens’ Solutions to End Terrorism")
+    subject.css('.page-title').text.must_equal('Citizens’ Solutions to End Terrorism')
   end
 
   it 'shows the date with the right format' do

--- a/tests/web/representatives.rb
+++ b/tests/web/representatives.rb
@@ -26,12 +26,12 @@ describe 'List of Representatives' do
     describe 'when person has an image' do
       it 'points to the right path' do
         person.css('a img/@src').first.text
-          .must_include('/b2a7f72a-9ecf-4263-83f1-cb0f8783053c/100x100.jpeg')
+              .must_include('/b2a7f72a-9ecf-4263-83f1-cb0f8783053c/100x100.jpeg')
       end
 
       it 'has an srcset' do
         person.css('a img/@srcset').first.text
-          .must_include('/b2a7f72a-9ecf-4263-83f1-cb0f8783053c/100x100.jpeg')
+              .must_include('/b2a7f72a-9ecf-4263-83f1-cb0f8783053c/100x100.jpeg')
       end
 
       it 'has the name as alternative text' do
@@ -44,7 +44,7 @@ describe 'List of Representatives' do
 
       it 'shows a picture anyway (empty avatar)' do
         person.css('.media-object/@src').first.text
-          .must_include('/images/person-250x250.png')
+              .must_include('/images/person-250x250.png')
       end
     end
 

--- a/tests/web/senators.rb
+++ b/tests/web/senators.rb
@@ -42,7 +42,7 @@ describe 'Senate' do
 
       it 'shows a picture anyway (empty avatar)' do
         person.css('.media-object/@src').first.text
-          .must_include('/images/person-250x250.png')
+              .must_include('/images/person-250x250.png')
       end
     end
 

--- a/tests/web/unlinked_pages.rb
+++ b/tests/web/unlinked_pages.rb
@@ -19,6 +19,11 @@ describe 'The Jinja2 Template' do
   subject { Nokogiri::HTML(last_response.body) }
 
   it 'must have the right <div>s around a Jinja2 include of \'content\'' do
-    refute_empty(subject.xpath('//div[@id="page"]/div[@class="page-section"]/div[@class="container" and contains(text(), "{% include content %}")]'))
+    refute_empty(
+      subject.xpath(
+        '//div[@id="page"]/div[@class="page-section"] ' \
+        '/div[@class="container" and contains(text(), "{% include content %}")]'
+      )
+    )
   end
 end

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -3,7 +3,7 @@
 
   <%= erb :_head %>
 
-  <body class="<% if is_homepage? %>page--homepage<% end %>">
+  <body class="<% if homepage? %>page--homepage<% end %>">
     <!-- {% if jekyll.environment == 'production' %}
       {% google_analytics %}
     {% endif %}
@@ -16,7 +16,7 @@
 
     <div id="page">
 
-      <% if is_homepage? %>
+      <% if homepage? %>
         <%= yield %>
 
       <% else %>

--- a/views/place.erb
+++ b/views/place.erb
@@ -30,7 +30,7 @@
           <h1 class="person__name"><%= @page.title %></h1>
           <h2>
             <%= @page.place.type_name %>
-            <%= " #{(@page.legislature_name)}" if @page.place.is_child_area? %>
+            <%= " #{(@page.legislature_name)}" if @page.place.child_area? %>
           </h2>
         </header>
 

--- a/views/places.erb
+++ b/views/places.erb
@@ -37,12 +37,12 @@
       </div>
       <div class="media-body">
         <a href="<%= place.url %>"><h3 class="media-heading"><%= place.name %></h3></a>
-        <% if place.is_child_area? %>
+        <% if place.child_area? %>
         <p class="parent-place">Parent place: <a href="<%= place.parent.url %>"><%= place.parent.name %></a></p>
         <% end %>
         <div class="kind">
           <p><%= place.type_name %></p>
-          <% if place.is_child_area? %>
+          <% if place.child_area? %>
           <p><%= @page.legislature_name %> <%= @page.current_term_start_year %>-current</p>
           <% end %>
         </div>


### PR DESCRIPTION
This pull requests adds the RuboCop gem, adds a Rake task
to run its checks, gets Travis to run those checks, and adds
fixes for all the problems it finds. The only cops I've disabled
or changed are:

* Documentation
* Increased the maximum line length to 120
* Metrics/BlockLength within the tests directory (since some
  of the `describe` blocks are long, and that's not a problem)

In the future, we should work towards reenabling the
`Documentation` checks, though, and I would hope to reduce
the maximum line as well.

[n.b. This pull requests changes a lot of code so there are likely
to be conflicts with branches other open pull requests are based
on. These should be easy conflicts to fix, but we need to pick an
order to merge these in.]