### PR TITLE
Use https with a GitHub personal access token if possible

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -20,8 +20,16 @@ SINATRA_BASE_URL="http://localhost:$SINATRA_PORT"
 GH_PAGES_REPO='shineyoureye-static'
 GH_PAGES_USER='theyworkforyou'
 
-# GH_PAGES_GIT_URL="https://github.com/$GH_PAGES_USER/$GH_PAGES_REPO.git"
-GH_PAGES_GIT_URL="git@github.com:$GH_PAGES_USER/$GH_PAGES_REPO.git"
+if [ x = x"$GITHUB_ACCESS_TOKEN" ]
+then
+    GH_PAGES_GIT_URL="git@github.com:$GH_PAGES_USER/$GH_PAGES_REPO.git"
+    GH_PAGES_GIT_URL_REDACTED="$GH_PAGES_GIT_URL"
+    echo "GITHUB_ACCESS_TOKEN is not set, so using an scp-style Git SSH URL instead: $GH_PAGES_GIT_URL"
+else
+    GH_PAGES_GIT_URL="https://${GITHUB_ACCESS_TOKEN}@github.com/$GH_PAGES_USER/$GH_PAGES_REPO.git"
+    GH_PAGES_GIT_URL_REDACTED="https://XXXXXXXXXXXXX@github.com/$GH_PAGES_USER/$GH_PAGES_REPO.git"
+    echo "GITHUB_ACCESS_TOKEN was set, so using an https URL containing that: $GH_PAGES_GIT_URL_REDACTED"
+fi
 
 start_sinatra() {
     # Start the Sinatra server in the background:
@@ -56,7 +64,7 @@ crawl_site() {
 deploy_site() {
     (
         cd "$BUILD_DIR"
-        echo "Cloning: $GH_PAGES_GIT_URL"
+        echo "Cloning: $GH_PAGES_GIT_URL_REDACTED"
         git clone --depth=1 "$GH_PAGES_GIT_URL" -b gh-pages
         cd "$GH_PAGES_REPO"
         git rm -r .

--- a/bin/deploy
+++ b/bin/deploy
@@ -67,7 +67,7 @@ deploy_site() {
         echo "Cloning: $GH_PAGES_GIT_URL_REDACTED"
         git clone --depth=1 "$GH_PAGES_GIT_URL" -b gh-pages
         cd "$GH_PAGES_REPO"
-        git rm -r .
+        git rm -rq .
         # But keep the CNAME file!
         git checkout HEAD -- CNAME
         cp -R ../"${SINATRA_BASE_URL##*//}"/* .


### PR DESCRIPTION
Previously this script only supported pushing to the
shineyoureye-sinatra repository over SSH. This commit changes that so
that if GITHUB_ACCESS_TOKEN is set to an appropriate personal access
token in the environment that will be used to authenticate and push over
HTTPS instead. This is important so that we can use a token to enable
pushing to the repository in the context of automated deployments.