### PR TITLE
Remove party links

### DIFF
--- a/lib/ep/person.rb
+++ b/lib/ep/person.rb
@@ -40,10 +40,6 @@ module EP
       current_memberships.first.party.name
     end
 
-    def party_url
-      "/organisation/#{party_id.downcase}/"
-    end
-
     def url
       baseurl + id + '/'
     end

--- a/lib/membership_csv/person.rb
+++ b/lib/membership_csv/person.rb
@@ -61,10 +61,6 @@ module MembershipCSV
       person['party']
     end
 
-    def party_url
-      "/organisation/#{person['party'].downcase}/"
-    end
-
     def slug
       person['identifier__shineyoureye']
     end

--- a/tests/ep/person.rb
+++ b/tests/ep/person.rb
@@ -192,10 +192,6 @@ describe 'EP::Person' do
     person.party_name.must_equal('All Progressives Congress')
   end
 
-  it 'knows its party url' do
-    person.party_url.must_equal('/organisation/apc/')
-  end
-
   it 'has a url' do
     person.url.must_equal('/baseurl/9de46243-685e-4902-81d4-b3e01faa93d5/')
   end

--- a/tests/membership_csv/person.rb
+++ b/tests/membership_csv/person.rb
@@ -176,10 +176,6 @@ describe 'MembershipCSV::Person' do
     person.party_name.must_equal('PDP')
   end
 
-  it 'knows its party url' do
-    person.party_url.must_equal('/organisation/pdp/')
-  end
-
   it 'has a slug' do
     person.slug.must_equal('okezie-ikpeazu')
   end

--- a/tests/web/constituency.rb
+++ b/tests/web/constituency.rb
@@ -89,11 +89,6 @@ describe 'Federal Constituency Place Page' do
             .must_equal('Abakaliki/Izzi')
     end
 
-    it 'links to the person party' do
-      person.css('.listing__party @href').text
-            .must_equal('/organisation/pdp/')
-    end
-
     it 'displays the person party name' do
       person.css('.listing__party').text
             .must_equal('Peoples Democratic Party')

--- a/tests/web/district.rb
+++ b/tests/web/district.rb
@@ -89,11 +89,6 @@ describe 'Senatorial District Place Page' do
             .must_equal('ABIA CENTRAL')
     end
 
-    it 'links to the person party' do
-      person.css('.listing__party @href').text
-            .must_equal('/organisation/pdp/')
-    end
-
     it 'displays the person party name' do
       person.css('.listing__party').text
             .must_equal('Peoples Democratic Party')

--- a/tests/web/governors.rb
+++ b/tests/web/governors.rb
@@ -66,10 +66,6 @@ describe 'List of Governors' do
       person.css('.listing__area').text.must_equal('Zamfara')
     end
 
-    it 'links to party page' do
-      person.css('.listing__party/@href').text.must_equal('/organisation/apc/')
-    end
-
     it 'displays party name' do
       person.css('.listing__party').text.must_equal('APC')
     end

--- a/tests/web/person.rb
+++ b/tests/web/person.rb
@@ -54,12 +54,8 @@ describe 'Person Page' do
     end
   end
 
-  it 'links to the party page' do
-    subject.css('.person__party a/@href').first.text.must_equal('/organisation/apc/')
-  end
-
   it 'displays the party name' do
-    subject.css('.person__party a').first.text.must_equal('All Progressives Congress')
+    subject.css('.person__party').first.text.must_equal('All Progressives Congress')
   end
 
   describe 'when person has a birth date' do

--- a/tests/web/representatives.rb
+++ b/tests/web/representatives.rb
@@ -64,10 +64,6 @@ describe 'List of Representatives' do
       person.css('.listing__area').text.must_equal('Maiduguri (Metropolitan)')
     end
 
-    it 'links to party page' do
-      person.css('.listing__party/@href').text.must_equal('/organisation/apc/')
-    end
-
     it 'displays party name' do
       person.css('.listing__party').text.must_equal('All Progressives Congress')
     end

--- a/tests/web/senators.rb
+++ b/tests/web/senators.rb
@@ -62,10 +62,6 @@ describe 'Senate' do
       person.css('.listing__area').text.must_equal('ABIA SOUTH')
     end
 
-    it 'links to party page' do
-      person.css('.listing__party/@href').text.must_equal('/organisation/pdp/')
-    end
-
     it 'displays party name' do
       person.css('.listing__party').text.must_equal('Peoples Democratic Party')
     end

--- a/tests/web/state.rb
+++ b/tests/web/state.rb
@@ -88,11 +88,6 @@ describe 'State Place Page' do
             .must_equal('Abia')
     end
 
-    it 'links to the person party' do
-      person.css('.listing__party @href').text
-            .must_equal('/organisation/pdp/')
-    end
-
     it 'displays the person party name' do
       person.css('.listing__party').text
             .must_equal('PDP')

--- a/views/_list_of_people.erb
+++ b/views/_list_of_people.erb
@@ -20,7 +20,7 @@
             <% end %>
             <p>
               Party:
-              <a class="listing__party" href="<%= person.party_url %>"><%= person.party_name %></a>
+              <span class="listing__party"><%= person.party_name %></span>
             </p>
         </div>
     </li>

--- a/views/person.erb
+++ b/views/person.erb
@@ -20,7 +20,7 @@
           <% end %>
 
             <h2>Party</h2>
-            <p class="person__party"><a href="<%= @page.person.party_url %>"><%= @page.person.party_name %></a></p>
+            <p class="person__party"><%= @page.person.party_name %></p>
 
           <% if @page.person.birth_date %>
             <h2>Birth date</h2>


### PR DESCRIPTION
Party links are showing a 404 at the moment. Since there is no trace in the requirements document that party pages have to be implemented, I think it may be better to remove this code.

Fixes https://github.com/theyworkforyou/shineyoureye-sinatra/issues/68

## Screenshots

### Person page

![person-page](https://cloud.githubusercontent.com/assets/2157089/23775361/a03db506-0528-11e7-80ee-c2ef5c2d608f.png)

### People page

![people-page](https://cloud.githubusercontent.com/assets/2157089/23775371/ac0e2db6-0528-11e7-9337-96e2c4fc9853.png)

### Place page

![place-page](https://cloud.githubusercontent.com/assets/2157089/23775380/b54744b2-0528-11e7-897f-c667f383a7f2.png)

