### PR TITLE
Change the way we check for place type

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -151,37 +151,18 @@ get '/place/is/senatorial-district/' do
 end
 
 get '/place/:slug/' do |slug|
-  constituency = mapit.area_from_pombola_slug(slug)
-  pass unless constituency
-  pass if representatives.none_by_mapit_area?(constituency.id)
+  area = mapit.area_from_pombola_slug(slug)
+  pass unless area
+  people = {
+    'Federal Constituency' => representatives,
+    'Senatorial District' => senators,
+    'State' => governors
+  }
   geometry = Mapit::Geometry.new(
-    geojson_url: "#{settings.mapit_url}/area/#{constituency.id}.geojson",
-    geometry_url: "#{settings.mapit_url}/area/#{constituency.id}/geometry"
+    geojson_url: "#{settings.mapit_url}/area/#{area.id}.geojson",
+    geometry_url: "#{settings.mapit_url}/area/#{area.id}/geometry"
   )
-  @page = Page::Place.new(place: constituency, people_by_legislature: representatives, geometry: geometry)
-  erb :place
-end
-
-get '/place/:slug/' do |slug|
-  district = mapit.area_from_pombola_slug(slug)
-  pass unless district
-  pass if senators.none_by_mapit_area?(district.id)
-  geometry = Mapit::Geometry.new(
-    geojson_url: "#{settings.mapit_url}/area/#{district.id}.geojson",
-    geometry_url: "#{settings.mapit_url}/area/#{district.id}/geometry"
-  )
-  @page = Page::Place.new(place: district, people_by_legislature: senators, geometry: geometry)
-  erb :place
-end
-
-get '/place/:slug/' do |slug|
-  state = mapit.area_from_pombola_slug(slug)
-  pass unless state
-  geometry = Mapit::Geometry.new(
-    geojson_url: "#{settings.mapit_url}/area/#{state.id}.geojson",
-    geometry_url: "#{settings.mapit_url}/area/#{state.id}/geometry"
-  )
-  @page = Page::Place.new(place: state, people_by_legislature: governors, geometry: geometry)
+  @page = Page::Place.new(place: area, people_by_legislature: people[area.type_name], geometry: geometry)
   erb :place
 end
 

--- a/lib/ep/people_by_legislature.rb
+++ b/lib/ep/people_by_legislature.rb
@@ -26,10 +26,6 @@ module EP
       find_all.select { |person| person.area.id == mapit_id if person.area }
     end
 
-    def none_by_mapit_area?(mapit_id)
-      find_all_by_mapit_area(mapit_id).empty?
-    end
-
     def current_term_start_date
       latest_term.start_date
     end

--- a/lib/membership_csv/people.rb
+++ b/lib/membership_csv/people.rb
@@ -26,10 +26,6 @@ module MembershipCSV
       mapit_id_to_person[mapit_id.to_s] || []
     end
 
-    def none_by_mapit_area?(mapit_id)
-      find_all_by_mapit_area(mapit_id).empty?
-    end
-
     def current_term_start_date
       nil
     end

--- a/lib/page/place.rb
+++ b/lib/page/place.rb
@@ -26,7 +26,8 @@ module Page
     end
 
     def legislature_name
-      people_by_legislature.legislature_name
+      name = people_by_legislature.legislature_name
+      name ? "(#{name})" : ''
     end
 
     def geojson

--- a/tests/ep/people_by_legislature.rb
+++ b/tests/ep/people_by_legislature.rb
@@ -87,9 +87,5 @@ describe 'EP::PeopleByLegislature' do
     it 'finds all people in a mapit area' do
       people.find_all_by_mapit_area(1).count.must_equal(364)
     end
-
-    it 'can check if no people in this legislature for that mapit area' do
-      people.none_by_mapit_area?(0).must_equal(true)
-    end
   end
 end

--- a/tests/membership_csv/people.rb
+++ b/tests/membership_csv/people.rb
@@ -89,9 +89,5 @@ id3,name3,name-3,'
     it 'finds all people in a mapit area' do
       people.find_all_by_mapit_area(1).count.must_equal(3)
     end
-
-    it 'can check if no people in this legislature for that mapit area' do
-      people.none_by_mapit_area?(0).must_equal(true)
-    end
   end
 end

--- a/tests/page/place.rb
+++ b/tests/page/place.rb
@@ -32,8 +32,19 @@ describe 'Page::Place' do
     page.people.count.must_equal(2)
   end
 
-  it 'knows the legislature name' do
-    page.legislature_name.must_equal('House of Representatives')
+  describe 'when asking for the legislature name' do
+    it 'has one for child areas' do
+      page.legislature_name.must_equal('(House of Representatives)')
+    end
+
+    it 'has none for parent areas' do
+      page = Page::Place.new(
+        place: FakePlace.new(1, 'Abia'),
+        people_by_legislature: FakePeople.new(nil),
+        geometry: 'irrelevant'
+      )
+      page.legislature_name.must_equal('')
+    end
   end
 
   it 'has the geoJSON feature for that place' do

--- a/tests/shared_examples/people_interface_test.rb
+++ b/tests/shared_examples/people_interface_test.rb
@@ -21,10 +21,6 @@ module PeopleInterfaceTest
     assert_respond_to(people, :find_all_by_mapit_area)
   end
 
-  it 'can check if there is no person in a mapit area' do
-    assert_respond_to(people, :none_by_mapit_area?)
-  end
-
   it 'knows the current term start date' do
     assert_respond_to(people, :current_term_start_date)
   end

--- a/tests/web/constituency.rb
+++ b/tests/web/constituency.rb
@@ -102,4 +102,25 @@ describe 'Federal Constituency Place Page' do
             .must_equal('Peoples Democratic Party')
     end
   end
+
+  describe 'when constituency has no people' do
+    before do
+      get_from_disk(geojson_json_url(1209), geojson_json)
+      get_from_disk(geometry_json_url(1209), geometry_json)
+      get '/place/kaduna-north/'
+    end
+
+    it 'displays the right house name' do
+      subject.css('.person__key-info h2').first.text
+             .must_include('House of Representatives')
+    end
+  end
+
+  describe 'when place does not exist' do
+    before { get '/place/i-do-not-exist/' }
+
+    it 'shows a 404 page' do
+      subject.css('h1').first.text.must_equal('Not Found')
+    end
+  end
 end

--- a/views/place.erb
+++ b/views/place.erb
@@ -22,10 +22,7 @@
     <div class="col-sm-8 col-md-9">
         <header class="person__key-info">
           <h1 class="person__name"><%= @page.title %></h1>
-          <h2>
-            <%= @page.place.type_name %>
-            <%= " (#{@page.legislature_name})" if @page.place.child_area? %>
-          </h2>
+          <h2><%= @page.place.type_name %> <%= @page.legislature_name %></h2>
         </header>
 
         <section class="person__section">


### PR DESCRIPTION
This PR generalizes the three place routes that we had into a single one so that we always map the right type of people to the corresponding type of place.

Thanks to this fix, now the child places show their legislature name correctly.

Also there was some logic in the view for showing the legislature name that was moved to its page so that it can be properly tested.

Finally, after simplifying the place routes, the check for no people in an area is not needed anymore, so it was removed from the people API.

## Related issue

Fixes https://github.com/theyworkforyou/shineyoureye-sinatra/issues/102

## Screenshots

![house-name](https://cloud.githubusercontent.com/assets/2157089/24200926/7f90a1c8-0f06-11e7-8e63-3c30a59c4637.png)