### PR TITLE
Set mapit user agent

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -27,6 +27,7 @@ set :datasource, ENV.fetch('DATASOURCE', 'https://github.com/everypolitician/eve
 set :index, EveryPolitician::Index.new(index_url: settings.datasource)
 set :mapit_url, 'http://nigeria.mapit.mysociety.org'
 set :twitter_user, 'NGShineyoureye'
+set :mapit_user_agent, ENV.fetch('MAPIT_USER_AGENT', nil)
 
 # Create a wrapper for the mappings between the various IDs we have
 # to use for areas / places.
@@ -160,7 +161,8 @@ get '/place/:slug/' do |slug|
   }
   geometry = Mapit::Geometry.new(
     geojson_url: "#{settings.mapit_url}/area/#{area.id}.geojson",
-    geometry_url: "#{settings.mapit_url}/area/#{area.id}/geometry"
+    geometry_url: "#{settings.mapit_url}/area/#{area.id}/geometry",
+    user_agent: settings.mapit_user_agent
   )
   @page = Page::Place.new(place: area, people_by_legislature: people[area.type_name], geometry: geometry)
   erb :place

--- a/lib/mapit/geometry.rb
+++ b/lib/mapit/geometry.rb
@@ -3,9 +3,10 @@ require_relative 'coordinate'
 
 module Mapit
   class Geometry
-    def initialize(geojson_url:, geometry_url:)
+    def initialize(geojson_url:, geometry_url:, user_agent:)
       @geojson_url = geojson_url
       @geometry_url = geometry_url
+      @user_agent = user_agent
     end
 
     def geojson
@@ -19,12 +20,21 @@ module Mapit
 
     private
 
-    attr_reader :geojson_url, :geometry_url
+    attr_reader :geojson_url, :geometry_url, :user_agent
 
     def get(url)
-      response = Net::HTTP.get_response(URI(url))
+      response = http(URI(url)).request(request(URI(url)))
       raise_if_response_not_ok(url, response.code)
       response.body
+    end
+
+    def http(uri)
+      Net::HTTP.new(uri.host, uri.port)
+    end
+
+    def request(uri)
+      headers = { 'User-Agent' => user_agent } if user_agent
+      Net::HTTP::Get.new(uri.request_uri, headers)
     end
 
     def raise_if_response_not_ok(url, status_code)


### PR DESCRIPTION
This PR adds a user agent header to GET requests to Mapit geometry.

This is done to avoid reaching the "Rate limit exceeded" when
running the deploy script, since it has to hit the Mapit API
for all the areas of the site in a very short span of time.

The `MAPIT_USER_AGENT` environment variable was set in Travis.