### PR TITLE
Fix a bug where WGET_EXIT_CODE was always unset

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -52,12 +52,12 @@ stop_sinatra() {
 
 crawl_site() {
     echo "Crawling $SINATRA_BASE_URL...."
+    WGET_EXIT_CODE=0
     (
-        WGET_EXIT_CODE=0
         cd "$BUILD_DIR" &&
             wget -o wget.log -r -l 5 --domains='localhost' \
-                 "$SINATRA_BASE_URL"/scraper-start-page.html || WGET_EXIT_CODE="$?"
-    )
+                 "$SINATRA_BASE_URL"/scraper-start-page.html
+    ) || WGET_EXIT_CODE="$?"
     echo done
 }
 


### PR DESCRIPTION
WGET_EXIT_CODE was being set in a subshell (the open bracket and close
bracket create a subshell) so wasn't available at the top level of the
script. This commit fixes that.