### PR TITLE
Only deploy the site if the wget crawl succeeded

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -107,13 +107,13 @@ crawl_site
 
 stop_sinatra
 
-if [ "$ONLY_BUILD" != 1 ]
+if [ "$WGET_EXIT_CODE" = 0 ]
 then
-    deploy_site
-fi
-
-if [ "$WGET_EXIT_CODE" != 0 ]
-then
+    if [ "$ONLY_BUILD" != 1 ]
+    then
+        deploy_site
+    fi
+else
     echo "The errors were:"
     egrep -B 3 ' ERROR [0-9]{3}' "$BUILD_DIR/wget.log"
     exit $WGET_EXIT_CODE


### PR DESCRIPTION
This means, for example, that getting a 4xx or 5xx error from any
page when crawling the Sinatra site will cause an error and not
deploy the site. This is good, because we should be investigating
and fixing any such errors.

This is related to: https://github.com/theyworkforyou/shineyoureye-prose/pull/13 which
makes sure we're emailed on such failures.

## Related issues

Fixes #95