### PR TITLE
Clean before person slugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby '2.3.1'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
+gem 'babosa'
 gem 'bootstrap-sass'
 gem 'coveralls', require: false
 gem 'everypolitician', '~> 0.20.0', github: 'everypolitician/everypolitician-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
     ast (2.3.0)
     autoprefixer-rails (6.7.0)
       execjs
+    babosa (1.0.2)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -88,6 +89,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  babosa
   bootstrap-sass
   coveralls
   everypolitician (~> 0.20.0)!

--- a/app.rb
+++ b/app.rb
@@ -61,12 +61,14 @@ governors = MembershipCSV::People.new(
 representatives = EP::PeopleByLegislature.new(
   legislature: settings.index.country('Nigeria').legislature('Representatives'),
   mapit: mapit,
-  baseurl: '/person/'
+  baseurl: '/person/',
+  identifier_scheme: 'shineyoureye'
 )
 senators = EP::PeopleByLegislature.new(
   legislature: settings.index.country('Nigeria').legislature('Senate'),
   mapit: mapit,
-  baseurl: '/person/'
+  baseurl: '/person/',
+  identifier_scheme: 'shineyoureye'
 )
 
 get '/' do

--- a/app.rb
+++ b/app.rb
@@ -56,8 +56,10 @@ mapit = Mapit::Wrapper.new(
 governors = MembershipCSV::People.new(
   csv_filename: 'morph/nigeria-state-governors.csv',
   mapit: mapit,
-  baseurl: '/person/'
+  baseurl: '/person/',
+  identifier_scheme: 'shineyoureye'
 )
+
 representatives = EP::PeopleByLegislature.new(
   legislature: settings.index.country('Nigeria').legislature('Representatives'),
   mapit: mapit,

--- a/lib/ep/people_by_legislature.rb
+++ b/lib/ep/people_by_legislature.rb
@@ -4,10 +4,11 @@ require_relative 'person'
 
 module EP
   class PeopleByLegislature
-    def initialize(legislature:, mapit:, baseurl:)
+    def initialize(legislature:, mapit:, baseurl:, identifier_scheme:)
       @legislature = legislature
       @mapit = mapit
       @baseurl = baseurl
+      @identifier_scheme = identifier_scheme
     end
 
     def find_all
@@ -40,7 +41,7 @@ module EP
 
     private
 
-    attr_reader :legislature, :mapit, :baseurl
+    attr_reader :legislature, :mapit, :baseurl, :identifier_scheme
 
     def people_sorted_by_name
       latest_term.people.sort_by { |person| [person.sort_name, person.name] }
@@ -55,7 +56,13 @@ module EP
     end
 
     def create_person(person)
-      Person.new(person: person, term: latest_term, mapit: mapit, baseurl: baseurl)
+      Person.new(
+        person: person,
+        term: latest_term,
+        mapit: mapit,
+        baseurl: baseurl,
+        identifier_scheme: identifier_scheme
+      )
     end
   end
 end

--- a/lib/ep/people_by_legislature.rb
+++ b/lib/ep/people_by_legislature.rb
@@ -15,7 +15,7 @@ module EP
     end
 
     def find_single(id)
-      find_all.find { |person| person.id == id }
+      id_to_person[id]
     end
 
     def none?(id)
@@ -48,6 +48,10 @@ module EP
 
     def latest_term
       legislature.legislative_periods.sort_by(&:start_date).last
+    end
+
+    def id_to_person
+      @id_to_person ||= find_all.map { |person| [person.id, person] }.to_h
     end
 
     def create_person(person)

--- a/lib/ep/person.rb
+++ b/lib/ep/person.rb
@@ -4,11 +4,12 @@ require_relative '../person_social'
 
 module EP
   class Person
-    def initialize(person:, term:, mapit:, baseurl:)
+    def initialize(person:, term:, mapit:, baseurl:, identifier_scheme:)
       @person = person
       @term = term
       @mapit = mapit
       @baseurl = baseurl
+      @identifier_scheme = identifier_scheme
     end
 
     extend Forwardable
@@ -46,7 +47,7 @@ module EP
 
     private
 
-    attr_reader :person, :term, :mapit, :baseurl
+    attr_reader :person, :term, :mapit, :baseurl, :identifier_scheme
 
     def ep_area
       current_memberships.first.area

--- a/lib/ep/person.rb
+++ b/lib/ep/person.rb
@@ -45,6 +45,10 @@ module EP
       baseurl + id + '/'
     end
 
+    def slug
+      site_identifier[:identifier]
+    end
+
     private
 
     attr_reader :person, :term, :mapit, :baseurl, :identifier_scheme
@@ -60,6 +64,10 @@ module EP
     def proxy_image_base_url
       'https://theyworkforyou.github.io/shineyoureye-images' \
       "/#{legislature.slug}/#{id}/"
+    end
+
+    def site_identifier
+      person.identifiers.find { |identifier| identifier[:scheme] == identifier_scheme }
     end
   end
 end

--- a/lib/ep/person.rb
+++ b/lib/ep/person.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative '../person_proxy_images'
 require_relative '../person_social'
+require 'babosa'
 
 module EP
   class Person
@@ -46,7 +47,7 @@ module EP
     end
 
     def slug
-      site_identifier[:identifier]
+      site_identifier[:identifier] || slugify_name
     end
 
     private
@@ -67,7 +68,11 @@ module EP
     end
 
     def site_identifier
-      person.identifiers.find { |identifier| identifier[:scheme] == identifier_scheme }
+      person.identifiers.find { |identifier| identifier[:scheme] == identifier_scheme } || {}
+    end
+
+    def slugify_name
+      name.to_slug.normalize.to_s if name
     end
   end
 end

--- a/lib/membership_csv/people.rb
+++ b/lib/membership_csv/people.rb
@@ -4,10 +4,11 @@ require_relative 'person'
 
 module MembershipCSV
   class People
-    def initialize(csv_filename:, mapit:, baseurl:)
+    def initialize(csv_filename:, mapit:, baseurl:, identifier_scheme:)
       @csv_filename = csv_filename
       @mapit = mapit
       @baseurl = baseurl
+      @identifier_scheme = identifier_scheme
     end
 
     def find_all
@@ -40,7 +41,7 @@ module MembershipCSV
 
     private
 
-    attr_reader :csv_filename, :mapit, :baseurl
+    attr_reader :csv_filename, :mapit, :baseurl, :identifier_scheme
 
     def all_people
       @all_people ||= read_with_headers.map { |row| create_person(remove_empty_cells(row)) }
@@ -68,7 +69,12 @@ module MembershipCSV
     end
 
     def create_person(row)
-      Person.new(person: row, mapit: mapit, baseurl: baseurl)
+      Person.new(
+        person: row,
+        mapit: mapit,
+        baseurl: baseurl,
+        identifier_scheme: identifier_scheme
+      )
     end
   end
 end

--- a/lib/membership_csv/person.rb
+++ b/lib/membership_csv/person.rb
@@ -4,10 +4,11 @@ require_relative '../person_social'
 
 module MembershipCSV
   class Person
-    def initialize(person:, mapit:, baseurl:)
+    def initialize(person:, mapit:, baseurl:, identifier_scheme:)
       @person = person
       @mapit = mapit
       @baseurl = baseurl
+      @identifier_scheme = identifier_scheme
     end
 
     include PersonProxyImages
@@ -62,7 +63,7 @@ module MembershipCSV
     end
 
     def slug
-      person['identifier__shineyoureye']
+      person["identifier__#{identifier_scheme}"]
     end
 
     def url
@@ -71,7 +72,7 @@ module MembershipCSV
 
     private
 
-    attr_reader :person, :mapit, :baseurl
+    attr_reader :person, :mapit, :baseurl, :identifier_scheme
 
     def first(values)
       values.split(';').first

--- a/lib/membership_csv/person.rb
+++ b/lib/membership_csv/person.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative '../person_proxy_images'
 require_relative '../person_social'
+require 'babosa'
 
 module MembershipCSV
   class Person
@@ -63,7 +64,7 @@ module MembershipCSV
     end
 
     def slug
-      person["identifier__#{identifier_scheme}"]
+      person["identifier__#{identifier_scheme}"] || slugify_name
     end
 
     def url
@@ -81,6 +82,10 @@ module MembershipCSV
     def proxy_image_base_url
       'https://raw.githubusercontent.com/theyworkforyou/shineyoureye-images' \
       "/gh-pages/Governors/#{id}/"
+    end
+
+    def slugify_name
+      name.to_slug.normalize.to_s if name
     end
   end
 end

--- a/tests/ep/people_by_legislature.rb
+++ b/tests/ep/people_by_legislature.rb
@@ -13,7 +13,8 @@ describe 'EP::PeopleByLegislature' do
       EP::PeopleByLegislature.new(
         legislature: legislature,
         mapit: 'irrelevant',
-        baseurl: '/baseurl/'
+        baseurl: '/baseurl/',
+        identifier_scheme: 'shineyoureye'
       )
     end
 
@@ -75,7 +76,8 @@ describe 'EP::PeopleByLegislature' do
       EP::PeopleByLegislature.new(
         legislature: legislature,
         mapit: FakeMapit.new(1),
-        baseurl: '/baseurl/'
+        baseurl: '/baseurl/',
+        identifier_scheme: 'shineyoureye'
       )
     end
 

--- a/tests/ep/person.rb
+++ b/tests/ep/person.rb
@@ -200,6 +200,11 @@ describe 'EP::Person' do
     it 'has a slug' do
       person.slug.must_equal('adamu-abdullahi')
     end
+
+    it 'dashifies the name if no slug' do
+      person = ep_person('0b536a2c-2bc9-46a0-8d40-0deb9241cb31')
+      person.slug.must_equal('ahmad-abubakar')
+    end
   end
 
   def ep_person(id)

--- a/tests/ep/person.rb
+++ b/tests/ep/person.rb
@@ -201,7 +201,8 @@ describe 'EP::Person' do
       person: person_by_id(id),
       term: latest_term,
       mapit: FakeMapit.new(1),
-      baseurl: '/baseurl/'
+      baseurl: '/baseurl/',
+      identifier_scheme: 'shineyoureye'
     )
   end
 

--- a/tests/ep/person.rb
+++ b/tests/ep/person.rb
@@ -196,6 +196,12 @@ describe 'EP::Person' do
     person.url.must_equal('/baseurl/9de46243-685e-4902-81d4-b3e01faa93d5/')
   end
 
+  describe 'slug' do
+    it 'has a slug' do
+      person.slug.must_equal('adamu-abdullahi')
+    end
+  end
+
   def ep_person(id)
     EP::Person.new(
       person: person_by_id(id),

--- a/tests/membership_csv/people.rb
+++ b/tests/membership_csv/people.rb
@@ -18,7 +18,8 @@ id3,name3,name-3,'
       MembershipCSV::People.new(
         csv_filename: new_tempfile(contents),
         mapit: 'irrelevant',
-        baseurl: '/baseurl/'
+        baseurl: '/baseurl/',
+        identifier_scheme: 'shineyoureye'
       )
     end
 
@@ -78,7 +79,8 @@ id3,name3,name-3,'
       MembershipCSV::People.new(
         csv_filename: new_tempfile(contents),
         mapit: FakeMapit.new(1),
-        baseurl: '/baseurl/'
+        baseurl: '/baseurl/',
+        identifier_scheme: 'shineyoureye'
       )
     end
 

--- a/tests/membership_csv/person.rb
+++ b/tests/membership_csv/person.rb
@@ -176,8 +176,18 @@ describe 'MembershipCSV::Person' do
     person.party_name.must_equal('PDP')
   end
 
-  it 'has a slug' do
-    person.slug.must_equal('okezie-ikpeazu')
+  describe 'slug' do
+    it 'has a slug' do
+      person.slug.must_equal('okezie-ikpeazu')
+    end
+
+    it 'dashifies name if no slug' do
+      person = morph_person(
+        'name' => '$%^a&* /\b:;',
+        'identifier__shineyoureye' => nil
+      )
+      person.slug.must_equal('a-b')
+    end
   end
 
   describe 'url' do

--- a/tests/membership_csv/person.rb
+++ b/tests/membership_csv/person.rb
@@ -195,7 +195,8 @@ describe 'MembershipCSV::Person' do
     MembershipCSV::Person.new(
       person: person_info,
       mapit: FakeMapit.new(1),
-      baseurl: '/baseurl/'
+      baseurl: '/baseurl/',
+      identifier_scheme: 'shineyoureye'
     )
   end
 

--- a/tests/page/people.rb
+++ b/tests/page/people.rb
@@ -8,7 +8,8 @@ describe 'Page::People' do
     EP::PeopleByLegislature.new(
       legislature: nigeria_at_known_revision.legislature('Representatives'),
       mapit: 'irrelevant',
-      baseurl: '/baseurl/'
+      baseurl: '/baseurl/',
+      identifier_scheme: 'shineyoureye'
     )
   end
   let(:page) do

--- a/tests/page/person.rb
+++ b/tests/page/person.rb
@@ -10,7 +10,8 @@ describe 'Page::Person' do
     EP::PeopleByLegislature.new(
       legislature: nigeria_at_known_revision.legislature('Representatives'),
       mapit: 'irrelevant',
-      baseurl: 'irrelevant'
+      baseurl: 'irrelevant',
+      identifier_scheme: 'shineyoureye'
     )
   end
   let(:page) do

--- a/tests/page/person.rb
+++ b/tests/page/person.rb
@@ -53,7 +53,8 @@ describe 'Page::Person' do
       MembershipCSV::People.new(
         csv_filename: new_tempfile(contents),
         mapit: 'irrelevant',
-        baseurl: 'irrelevant'
+        baseurl: 'irrelevant',
+        identifier_scheme: 'shineyoureye'
       )
     end
     let(:page) do

--- a/tests/page/places.rb
+++ b/tests/page/places.rb
@@ -8,7 +8,8 @@ describe 'Page::Places' do
     EP::PeopleByLegislature.new(
       legislature: nigeria_at_known_revision.legislature('Representatives'),
       mapit: FakeMapit.new(1),
-      baseurl: '/baseurl/'
+      baseurl: '/baseurl/',
+      identifier_scheme: 'shineyoureye'
     )
   end
   let(:page) do

--- a/tests/shared_examples/person_interface_test.rb
+++ b/tests/shared_examples/person_interface_test.rb
@@ -68,4 +68,8 @@ module PersonInterfaceTest
   it 'has an id' do
     assert_respond_to(person, :id)
   end
+
+  it 'has a slug' do
+    assert_respond_to(person, :slug)
+  end
 end


### PR DESCRIPTION
This PR prepares the code for using Pombola slugs instead of person ids in person-page routes.

The site specific identifier scheme (`'shineyoureye'` in this case) had to be passed as an argument to both person and people classes.

A slug method was added to EP persons. If there is no `identifier__shineyoureye` column in a CSV source or if there is no identifier with a `shineyoureye` scheme in the EP person data, the name is downcased and dashified.