### PR TITLE
Rewrite the event routes so that they work as the blog ones

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -112,6 +112,11 @@ get '/blog/:slug' do |slug|
   erb :post
 end
 
+get '/info/events' do
+  @redirect_to = '/events/'
+  erb :redirect, layout: false
+end
+
 get '/events/' do
   finder = Document::Finder.new(pattern: events_pattern, baseurl: '/events/')
   @page = Page::Posts.new(posts: finder.find_all, title: 'Events')

--- a/app.rb
+++ b/app.rb
@@ -75,7 +75,7 @@ senators = EP::PeopleByLegislature.new(
 
 get '/' do
   posts_finder = Document::Finder.new(pattern: posts_pattern, baseurl: '/blog/')
-  events_finder = Document::Finder.new(pattern: events_pattern, baseurl: '/info/events/')
+  events_finder = Document::Finder.new(pattern: events_pattern, baseurl: '/events/')
   summaries_finder = Document::Finder.new(pattern: summaries_pattern, baseurl: '')
   featured_summaries = summaries_finder.find_featured
   people = [
@@ -112,14 +112,14 @@ get '/blog/:slug' do |slug|
   erb :post
 end
 
-get '/info/events' do
-  finder = Document::Finder.new(pattern: events_pattern, baseurl: '/info/events/')
+get '/events/' do
+  finder = Document::Finder.new(pattern: events_pattern, baseurl: '/events/')
   @page = Page::Posts.new(posts: finder.find_all, title: 'Events')
   erb :posts
 end
 
-get '/info/events/:slug' do |slug|
-  finder = Document::Finder.new(pattern: event_pattern(slug), baseurl: '/info/events/')
+get '/events/:slug' do |slug|
+  finder = Document::Finder.new(pattern: event_pattern(slug), baseurl: '/events/')
   pass if finder.none?
   @page = Page::Post.new(post: finder.find_single)
   erb :post

--- a/tests/web/event.rb
+++ b/tests/web/event.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 describe 'Event Page' do
-  before { get '/info/events/fct-lga-polls-2016' }
+  before { get '/events/fct-lga-polls-2016' }
   subject { Nokogiri::HTML(last_response.body) }
 
   it 'shows the event title' do
@@ -18,7 +18,7 @@ describe 'Event Page' do
   end
 
   it 'throws a 404 error if no file is found' do
-    get '/info/events/i-dont-exist'
+    get '/events/i-dont-exist'
     subject = Nokogiri::HTML(last_response.body)
     subject.css('h1').first.text.must_equal('Not Found')
   end

--- a/tests/web/events.rb
+++ b/tests/web/events.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 describe 'Events Page' do
-  before { get '/info/events' }
+  before { get '/events/' }
   subject { Nokogiri::HTML(last_response.body) }
 
   it 'shows the title' do
@@ -18,7 +18,7 @@ describe 'Events Page' do
     let(:single_event) { subject.css('.blog-in-a-list').last }
 
     it 'links to event url' do
-      single_event.css('h2 a/@href').text.must_equal('/info/events/fct-lga-polls-2016')
+      single_event.css('h2 a/@href').text.must_equal('/events/fct-lga-polls-2016')
     end
 
     it 'displays event title' do

--- a/tests/web/events.rb
+++ b/tests/web/events.rb
@@ -33,4 +33,13 @@ describe 'Events Page' do
       refute_empty(single_event.css('div'))
     end
   end
+
+  describe 'redirection from old route' do
+    before { get '/info/events' }
+
+    it 'loads the redirect view' do
+      subject.css('meta @content').first.text.must_equal('0; url=/events/')
+      subject.css('a @href').first.text.must_equal('/events/')
+    end
+  end
 end

--- a/views/_footer.erb
+++ b/views/_footer.erb
@@ -14,7 +14,7 @@
           <li><a class="btn btn-default" href="/blog/">Latest News</a></li>
           <li><a class="btn btn-default" href="/info/democracy-resources">Democractic Resources</a></li>
           <li><a class="btn btn-default" href="/info/elections">Elections</a></li>
-          <li><a class="btn btn-default" href="/info/events">Events</a></li>
+          <li><a class="btn btn-default" href="/events/">Events</a></li>
         </li>
       </div>
     </div>

--- a/views/_main_menu.erb
+++ b/views/_main_menu.erb
@@ -50,7 +50,7 @@
           </ul>
         </li>
 
-        <li><a href="/info/events">Events</a></li>
+        <li><a href="/events/">Events</a></li>
 
         <li><a href="/blog/">Blog</a></li>
 

--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -56,7 +56,7 @@
         <% end %>
       </div>
       <div class="col-sm-6">
-        <h2><a href="/info/events">Events</a></h2>
+        <h2><a href="/events/">Events</a></h2>
         <% unless @page.featured_events.empty? %>
           <% @page.featured_events.each do |event| %>
             <a href="<%= event.url %>"><h3><%= event.title %></h3></a>

--- a/views/scraper_start_page.erb
+++ b/views/scraper_start_page.erb
@@ -1,2 +1,3 @@
 <a href="/">Site homepage</a>
 <a href="/jinja2-template.html">Jinja2 template</a>
+<a href="/info/events">Old events page route, must trigger redirect to new route</a>


### PR DESCRIPTION
In order to serve the site, we run the Sinatra app and then wget it
and push it to a gh-pages branch, so that it is served as a static site.

The event list page at `/info/events` works when running the app
locally, but it throws a 404 once we wget it and serve it as static.

This is because the route /info/events (the event list page) is scraped
first by wget, creating an HTML file info/events.html. Later the route
/info/events/EVENT_SLUG is scraped, and wget replaces info/events.html
with an info/events directory containing a EVENT_SLUG.html file.

In other words, the index page is saved and then deleted by wget.

To solve this, we are making the URL path for an individual event
look like /events/EVENT_SLUG instead of /info/events/EVENT_SLUG.

## Related issues

Closes #48 