### PR TITLE
bin/deploy: Detect if the Sinatra server startup fails

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -36,10 +36,12 @@ start_sinatra() {
     bundle exec rackup > "$BUILD_DIR/sinatra.log" 2>&1 &
     SINATRA_PID=$!
     echo "Waiting for Sinatra to start..."
-    while ! nc -z localhost "$SINATRA_PORT"; do sleep 1; done
+    while kill -0 "$SINATRA_PID" 2> /dev/null && ! nc -z localhost "$SINATRA_PORT"
+    do
+        sleep 1
+    done
     # Make sure it's not an old one server still running:
-    sleep 1
-    kill -0 "$SINATRA_PID" ||
+    kill -0 "$SINATRA_PID" 2> /dev/null ||
         { echo "Couldn't start Sinatra - is an old server running?"; exit 1; }
     echo "done"
 }


### PR DESCRIPTION
If the deploy script tried to start the Sinatra server, but it
immediately failed (e.g. because the bundle wasn't installed correctly)
the deploy script used to just get stuck at "Waiting for Sinatra to
start..."  This change fixes that - instead it will break from the loop
that waits for the server to start if it detects that the server process
has died.