### PR TITLE
Add a view to do a pseudo-redirect with <meta http-equiv="refresh" ..>

### DIFF
--- a/views/redirect.erb
+++ b/views/redirect.erb
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<head>
+  <meta http-equiv="Refresh" content="0; url=<%= @redirect_to %>">
+  <title>Redirecting to <%= @redirect_to %></title>
+</head>
+<body>
+  If this page doesn't automatically redirect, then you
+  can <a href="<%= @redirect_to %>">follow this link</a> to the
+  new location.
+</body>


### PR DESCRIPTION
Since this site is hosted as static files on GitHub pages, we can't
return proper HTTP 301 / 302 redirects. However, we still want some
mechanism to redirect to new page locations so that we don't break
bookmarks or search engine results that still point to the old site.
The old technique of adding the <meta http-equiv="refresh"> tag to
the <head> of a document still works, however, and Google and other
search engines will also use this to indicate that the resource
location has changed.

This commit only adds a simple view for returning such
pseudo-redirects; it's not used anywhere yet. You would use it
in app.rb in the following way:
    
    get '/redirect-me' do
      @redirect_to = '/somewhere-else.html'
      erb :redirect, layout: false
    end