### PR TITLE
Add redirects for the old routes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -160,6 +160,16 @@ get '/place/is/senatorial-district/' do
   erb :places
 end
 
+get '/place/:slug/people/' do |slug|
+  @redirect_to = "/place/#{slug}/"
+  erb :redirect, layout: false
+end
+
+get '/place/:slug/places/' do |slug|
+  @redirect_to = "/place/#{slug}/"
+  erb :redirect, layout: false
+end
+
 get '/place/:slug/' do |slug|
   area = mapit.area_from_pombola_slug(slug)
   pass unless area
@@ -274,5 +284,6 @@ end
 
 get '/scraper-start-page.html' do
   @people = representatives.find_all + senators.find_all + governors.find_all
+  @places = mapit.places_of_type('FED') + mapit.places_of_type('SEN') + mapit.places_of_type('STA')
   erb :scraper_start_page, layout: false
 end

--- a/app.rb
+++ b/app.rb
@@ -234,6 +234,11 @@ get '/search/' do
   erb :search
 end
 
+get '/feedback' do
+  @redirect_to = '/contact/'
+  erb :redirect, layout: false
+end
+
 get '/contact/' do
   @page = Page::Basic.new(title: 'Contact')
   erb :contact

--- a/app.rb
+++ b/app.rb
@@ -60,7 +60,6 @@ governors = MembershipCSV::People.new(
   baseurl: '/person/',
   identifier_scheme: 'shineyoureye'
 )
-
 representatives = EP::PeopleByLegislature.new(
   legislature: settings.index.country('Nigeria').legislature('Representatives'),
   mapit: mapit,
@@ -193,6 +192,16 @@ get '/position/executive-governor/' do
   erb :people
 end
 
+get '/person/:slug/contact_details/' do |slug|
+  @redirect_to = "/person/#{slug}/"
+  erb :redirect, layout: false
+end
+
+get '/person/:slug/experience/' do |slug|
+  @redirect_to = "/person/#{slug}/"
+  erb :redirect, layout: false
+end
+
 get '/person/:slug/' do |slug|
   person = representatives.find_single(slug)
   pass unless person
@@ -264,5 +273,6 @@ get '/jinja2-template.html' do
 end
 
 get '/scraper-start-page.html' do
+  @people = representatives.find_all + senators.find_all + governors.find_all
   erb :scraper_start_page, layout: false
 end

--- a/tests/web/contact.rb
+++ b/tests/web/contact.rb
@@ -16,4 +16,13 @@ describe 'Contact Page' do
   it 'includes the site email in the contact form' do
     subject.css('.big-form/@action').text.must_include('user@example.com')
   end
+
+  describe 'redirection from old route' do
+    before { get '/feedback' }
+
+    it 'loads the redirect view' do
+      subject.css('meta @content').first.text.must_equal('0; url=/contact/')
+      subject.css('a @href').first.text.must_equal('/contact/')
+    end
+  end
 end

--- a/tests/web/person.rb
+++ b/tests/web/person.rb
@@ -197,4 +197,18 @@ describe 'Person Page' do
       subject.css('.btn-twitter/@href').text.must_include('/person/abdukadir-rahis/')
     end
   end
+
+  describe 'redirection from old route' do
+    it 'loads the redirect view for contact details' do
+      get '/person/abdukadir-rahis/contact_details/'
+      subject.css('meta @content').first.text.must_equal('0; url=/person/abdukadir-rahis/')
+      subject.css('a @href').first.text.must_equal('/person/abdukadir-rahis/')
+    end
+
+    it 'loads the redirect view for experience' do
+      get '/person/abdukadir-rahis/experience/'
+      subject.css('meta @content').first.text.must_equal('0; url=/person/abdukadir-rahis/')
+      subject.css('a @href').first.text.must_equal('/person/abdukadir-rahis/')
+    end
+  end
 end

--- a/tests/web/place.rb
+++ b/tests/web/place.rb
@@ -24,4 +24,23 @@ describe 'Generic tests for the place page' do
       subject.css('h1').first.text.must_equal('Not Found')
     end
   end
+
+  describe 'redirection from old route' do
+    before do
+      get_from_disk(geojson_json_url(809), geojson_json)
+      get_from_disk(geometry_json_url(809), geometry_json)
+    end
+
+    it 'loads the redirect view for the people route' do
+      get '/place/abia-central/people/'
+      subject.css('meta @content').first.text.must_equal('0; url=/place/abia-central/')
+      subject.css('a @href').first.text.must_equal('/place/abia-central/')
+    end
+
+    it 'loads the redirect view for the places route' do
+      get '/place/abia-central/places/'
+      subject.css('meta @content').first.text.must_equal('0; url=/place/abia-central/')
+      subject.css('a @href').first.text.must_equal('/place/abia-central/')
+    end
+  end
 end

--- a/tests/web/unlinked_pages.rb
+++ b/tests/web/unlinked_pages.rb
@@ -35,6 +35,22 @@ describe 'The Scraper Start Page' do
     subject.xpath('//a[contains(@href, "/contact_details/")]').count.must_equal(ep + governors)
     subject.xpath('//a[contains(@href, "/experience/")]').count.must_equal(ep + governors)
   end
+
+  it 'must have links to the old place/people route' do
+    refute_empty(subject.xpath('//a[@href="/place/abia-central/people/"]'))
+  end
+
+  it 'must have links to the old place/places route' do
+    refute_empty(subject.xpath('//a[@href="/place/abia-central/places/"]'))
+  end
+
+  it 'lists all available places' do
+    fed = 360
+    sen = 109
+    sta = 37
+    subject.xpath('//a[contains(@href, "/people/")]').count.must_equal(fed + sen + sta)
+    subject.xpath('//a[contains(@href, "/places/")]').count.must_equal(fed + sen + sta)
+  end
 end
 
 describe 'The Jinja2 Template' do

--- a/tests/web/unlinked_pages.rb
+++ b/tests/web/unlinked_pages.rb
@@ -20,6 +20,21 @@ describe 'The Scraper Start Page' do
   it 'must have a link to the old contact route' do
     refute_empty(subject.xpath('//a[@href="/feedback"]'))
   end
+
+  it 'must have links to the old person/contact details route' do
+    refute_empty(subject.xpath('//a[@href="/person/abdukadir-rahis/contact_details/"]'))
+  end
+
+  it 'must have links to the old person/experience route' do
+    refute_empty(subject.xpath('//a[@href="/person/abdukadir-rahis/experience/"]'))
+  end
+
+  it 'lists all available people' do
+    ep = 476
+    governors = 36
+    subject.xpath('//a[contains(@href, "/contact_details/")]').count.must_equal(ep + governors)
+    subject.xpath('//a[contains(@href, "/experience/")]').count.must_equal(ep + governors)
+  end
 end
 
 describe 'The Jinja2 Template' do

--- a/tests/web/unlinked_pages.rb
+++ b/tests/web/unlinked_pages.rb
@@ -5,12 +5,20 @@ describe 'The Scraper Start Page' do
   before  { get '/scraper-start-page.html' }
   subject { Nokogiri::HTML(last_response.body) }
 
+  it 'must have a link to the home page' do
+    refute_empty(subject.xpath('//a[@href="/"]'))
+  end
+
   it 'must have a link to the Jinja2 template' do
     refute_empty(subject.xpath('//a[@href="/jinja2-template.html"]'))
   end
 
-  it 'must have a link to the home page' do
-    refute_empty(subject.xpath('//a[@href="/"]'))
+  it 'must have a link to the old events route' do
+    refute_empty(subject.xpath('//a[@href="/info/events"]'))
+  end
+
+  it 'must have a link to the old contact route' do
+    refute_empty(subject.xpath('//a[@href="/feedback"]'))
   end
 end
 

--- a/views/scraper_start_page.erb
+++ b/views/scraper_start_page.erb
@@ -2,3 +2,8 @@
 <a href="/jinja2-template.html">Jinja2 template</a>
 <a href="/info/events">Old events page route, must trigger redirect to new route</a>
 <a href="/feedback">Old contact page route, must trigger redirect to new route</a>
+
+<% @people.each do |person| %>
+<a href="<%= person.url %>contact_details/">Old contact details page route, must trigger redirect to <%= person.url %></a>
+<a href="<%= person.url %>experience/">Old experience page route, must trigger redirect to <%= person.url %></a>
+<% end %>

--- a/views/scraper_start_page.erb
+++ b/views/scraper_start_page.erb
@@ -1,3 +1,4 @@
 <a href="/">Site homepage</a>
 <a href="/jinja2-template.html">Jinja2 template</a>
 <a href="/info/events">Old events page route, must trigger redirect to new route</a>
+<a href="/feedback">Old contact page route, must trigger redirect to new route</a>

--- a/views/scraper_start_page.erb
+++ b/views/scraper_start_page.erb
@@ -7,3 +7,8 @@
 <a href="<%= person.url %>contact_details/">Old contact details page route, must trigger redirect to <%= person.url %></a>
 <a href="<%= person.url %>experience/">Old experience page route, must trigger redirect to <%= person.url %></a>
 <% end %>
+
+<% @places.each do |place| %>
+<a href="<%= place.url %>people/">Old people page route, must trigger redirect to <%= place.url %></a>
+<a href="<%= place.url %>places/">Old places page route, must trigger redirect to <%= place.url %></a>
+<% end %>


### PR DESCRIPTION
This PR redirects the old routes that no longer exist in the new version of the site according to [this list](https://gist.github.com/mhl/02324e71cb3aa36650444a909b6776a4).

## Notes to merger

Merge after #143 