### PR TITLE
Add a person factory

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -6,6 +6,7 @@ require 'sinatra'
 require_relative 'lib/featured_person'
 require_relative 'lib/document/finder'
 require_relative 'lib/ep/people_by_legislature'
+require_relative 'lib/factory/person'
 require_relative 'lib/helpers/filepaths_helper'
 require_relative 'lib/helpers/layout_helper'
 require_relative 'lib/helpers/settings_helper'
@@ -53,24 +54,20 @@ mapit = Mapit::Wrapper.new(
   data_directory: 'mapit'
 )
 
+person_factory = Factory::Person.new(mapit: mapit, baseurl: '/person/', identifier_scheme: 'shineyoureye')
+
 # Assemble data on the members of the various legislatures we support:
 governors = MembershipCSV::People.new(
   csv_filename: 'morph/nigeria-state-governors.csv',
-  mapit: mapit,
-  baseurl: '/person/',
-  identifier_scheme: 'shineyoureye'
+  person_factory: person_factory
 )
 representatives = EP::PeopleByLegislature.new(
   legislature: settings.index.country('Nigeria').legislature('Representatives'),
-  mapit: mapit,
-  baseurl: '/person/',
-  identifier_scheme: 'shineyoureye'
+  person_factory: person_factory
 )
 senators = EP::PeopleByLegislature.new(
   legislature: settings.index.country('Nigeria').legislature('Senate'),
-  mapit: mapit,
-  baseurl: '/person/',
-  identifier_scheme: 'shineyoureye'
+  person_factory: person_factory
 )
 
 get '/' do

--- a/lib/ep/people_by_legislature.rb
+++ b/lib/ep/people_by_legislature.rb
@@ -4,11 +4,9 @@ require_relative 'person'
 
 module EP
   class PeopleByLegislature
-    def initialize(legislature:, mapit:, baseurl:, identifier_scheme:)
+    def initialize(legislature:, person_factory:)
       @legislature = legislature
-      @mapit = mapit
-      @baseurl = baseurl
-      @identifier_scheme = identifier_scheme
+      @person_factory = person_factory
     end
 
     def find_all
@@ -37,7 +35,7 @@ module EP
 
     private
 
-    attr_reader :legislature, :mapit, :baseurl, :identifier_scheme
+    attr_reader :legislature, :person_factory
 
     def people_sorted_by_name
       latest_term.people.sort_by { |person| [person.sort_name, person.name] }
@@ -56,13 +54,7 @@ module EP
     end
 
     def create_person(person)
-      Person.new(
-        person: person,
-        term: latest_term,
-        mapit: mapit,
-        baseurl: baseurl,
-        identifier_scheme: identifier_scheme
-      )
+      person_factory.build_ep_person(person, latest_term)
     end
   end
 end

--- a/lib/factory/person.rb
+++ b/lib/factory/person.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require_relative '../ep/person'
+require_relative '../membership_csv/person'
+
+module Factory
+  class Person
+    def initialize(mapit:, baseurl:, identifier_scheme:)
+      @mapit = mapit
+      @baseurl = baseurl
+      @identifier_scheme = identifier_scheme
+    end
+
+    def build_ep_person(person, term)
+      EP::Person.new(
+        person: person,
+        term: term,
+        mapit: mapit,
+        baseurl: baseurl,
+        identifier_scheme: identifier_scheme
+      )
+    end
+
+    def build_csv_person(person)
+      MembershipCSV::Person.new(
+        person: person,
+        mapit: mapit,
+        baseurl: baseurl,
+        identifier_scheme: identifier_scheme
+      )
+    end
+
+    private
+
+    attr_reader :mapit, :baseurl, :identifier_scheme
+  end
+end

--- a/lib/membership_csv/people.rb
+++ b/lib/membership_csv/people.rb
@@ -4,11 +4,9 @@ require_relative 'person'
 
 module MembershipCSV
   class People
-    def initialize(csv_filename:, mapit:, baseurl:, identifier_scheme:)
+    def initialize(csv_filename:, person_factory:)
       @csv_filename = csv_filename
-      @mapit = mapit
-      @baseurl = baseurl
-      @identifier_scheme = identifier_scheme
+      @person_factory = person_factory
     end
 
     def find_all
@@ -33,7 +31,7 @@ module MembershipCSV
 
     private
 
-    attr_reader :csv_filename, :mapit, :baseurl, :identifier_scheme
+    attr_reader :csv_filename, :person_factory
 
     def all_people
       @all_people ||= read_with_headers.map { |row| create_person(remove_empty_cells(row)) }
@@ -65,12 +63,7 @@ module MembershipCSV
     end
 
     def create_person(row)
-      Person.new(
-        person: row,
-        mapit: mapit,
-        baseurl: baseurl,
-        identifier_scheme: identifier_scheme
-      )
+      person_factory.build_csv_person(row)
     end
   end
 end

--- a/tests/ep/people_by_legislature.rb
+++ b/tests/ep/people_by_legislature.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../lib/ep/people_by_legislature'
 require_relative '../shared_examples/people_interface_test'
+require_relative '../../lib/ep/people_by_legislature'
 
 describe 'EP::PeopleByLegislature' do
   include PeopleInterfaceTest
@@ -10,9 +10,7 @@ describe 'EP::PeopleByLegislature' do
   let(:people) do
     EP::PeopleByLegislature.new(
       legislature: legislature,
-      mapit: FakeMapit.new(1),
-      baseurl: '/baseurl/',
-      identifier_scheme: 'shineyoureye'
+      person_factory: FakePersonFactory.new(FakeMapit.new(1))
     )
   end
 
@@ -28,12 +26,8 @@ describe 'EP::PeopleByLegislature' do
     people.find_all.first.id.must_equal('b2a7f72a-9ecf-4263-83f1-cb0f8783053c')
   end
 
-  it 'uses the baseurl in the person url' do
-    people.find_all.first.url.must_equal('/baseurl/abdukadir-rahis/')
-  end
-
   it 'finds a single person by slug' do
-    people.find_single('abdukadir-rahis').name.must_equal('ABDUKADIR RAHIS')
+    people.find_single('abdullahi-muhammed-wamakko').name.must_equal('ABDULLAHI MOHAMMED')
   end
 
   it 'knows the start date of the current term' do
@@ -57,10 +51,6 @@ describe 'EP::PeopleByLegislature' do
   it 'returns nil if no featured person' do
     featured_summaries = [FakeSummary.new('foo'), FakeSummary.new('bar')]
     assert_nil(people.featured_person(featured_summaries))
-  end
-
-  it 'assigns a mapit area to the person' do
-    people.find_single('abdukadir-rahis').area.id.must_equal(1)
   end
 
   it 'finds all people in a mapit area' do

--- a/tests/factory/person.rb
+++ b/tests/factory/person.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../lib/factory/person'
+
+describe 'Factory::Person' do
+  let(:factory) do
+    Factory::Person.new(
+      mapit: FakeMapit.new(1),
+      baseurl: '/baseurl/',
+      identifier_scheme: 'shineyoureye'
+    )
+  end
+
+  describe 'EP Person' do
+    let(:person) { factory.build_ep_person(people.first, FakeTerm.new('term/8')) }
+
+    it 'creates an EP Person' do
+      person.class.must_equal(EP::Person)
+    end
+
+    it 'uses the person object from the EP gem' do
+      person.id.must_equal('003e0736-add0-4997-9444-94fac606bb95')
+    end
+
+    it 'uses the term' do
+      person.party_id.must_equal('APC')
+    end
+
+    it 'uses the Mapit object' do
+      person.area.id.must_equal(1)
+    end
+
+    it 'uses the baseurl' do
+      person.url.must_include('/baseurl/')
+    end
+
+    it 'uses the identifier_scheme' do
+      person.slug.must_equal('mallam-gana')
+    end
+
+    def people
+      @people ||= nigeria_at_known_revision.legislature('Representatives').popolo.persons
+    end
+
+    FakeTerm = Struct.new(:id)
+  end
+
+  describe 'MembershipCSV' do
+    let(:person) { factory.build_csv_person(csv_person) }
+
+    it 'creates a CSV Person' do
+      person.class.must_equal(MembershipCSV::Person)
+    end
+
+    it 'uses the person hash from the CSV file' do
+      person.id.must_equal('gov:victor-okezie-ikpeazu')
+    end
+
+    it 'uses the Mapit object' do
+      person.area.id.must_equal(1)
+    end
+
+    it 'uses the baseurl' do
+      person.url.must_include('/baseurl/')
+    end
+
+    it 'uses the identifier_scheme' do
+      person.slug.must_equal('okezie-ikpeazu')
+    end
+
+    def csv_person
+      {
+        'id' => 'gov:victor-okezie-ikpeazu',
+        'state' => 'Abia',
+        'identifier__shineyoureye' => 'okezie-ikpeazu'
+      }
+    end
+  end
+end

--- a/tests/membership_csv/people.rb
+++ b/tests/membership_csv/people.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../../lib/membership_csv/people'
 require_relative '../shared_examples/people_interface_test'
+require_relative '../../lib/membership_csv/people'
 
 describe 'MembershipCSV::People' do
   include PeopleInterfaceTest
@@ -15,9 +15,7 @@ id3,name3,name-3,'
   let(:people) do
     MembershipCSV::People.new(
       csv_filename: new_tempfile(contents),
-      mapit: FakeMapit.new(1),
-      baseurl: '/baseurl/',
-      identifier_scheme: 'shineyoureye'
+      person_factory: FakePersonFactory.new(FakeMapit.new(1))
     )
   end
 
@@ -31,10 +29,6 @@ id3,name3,name-3,'
 
   it 'finds all people as person objects' do
     people.find_all.first.id.must_equal('id1')
-  end
-
-  it 'uses the baseurl in the person url' do
-    people.find_all.first.url.must_equal('/baseurl/name-1/')
   end
 
   it 'returns nil for empty fields' do
@@ -64,10 +58,6 @@ id3,name3,name-3,'
   it 'returns nil if no featured person' do
     featured_summaries = [FakeSummary.new('foo'), FakeSummary.new('bar')]
     assert_nil(people.featured_person(featured_summaries))
-  end
-
-  it 'assigns a mapit area to the person' do
-    people.find_single('name-3').area.id.must_equal(1)
   end
 
   it 'finds all people in a mapit area' do

--- a/tests/page/people.rb
+++ b/tests/page/people.rb
@@ -7,9 +7,7 @@ describe 'Page::People' do
   let(:people) do
     EP::PeopleByLegislature.new(
       legislature: nigeria_at_known_revision.legislature('Representatives'),
-      mapit: 'irrelevant',
-      baseurl: '/baseurl/',
-      identifier_scheme: 'shineyoureye'
+      person_factory: FakePersonFactory.new(FakeMapit.new(1))
     )
   end
   let(:page) do

--- a/tests/page/places.rb
+++ b/tests/page/places.rb
@@ -7,9 +7,7 @@ describe 'Page::Places' do
   let(:people) do
     EP::PeopleByLegislature.new(
       legislature: nigeria_at_known_revision.legislature('Representatives'),
-      mapit: FakeMapit.new(1),
-      baseurl: '/baseurl/',
-      identifier_scheme: 'shineyoureye'
+      person_factory: FakePersonFactory.new(FakeMapit.new(1))
     )
   end
   let(:page) do

--- a/tests/test_doubles.rb
+++ b/tests/test_doubles.rb
@@ -13,4 +13,18 @@ FakeMapit = Struct.new(:mapit_id) do
   end
 end
 
-FakePerson = Struct.new(:id, :name, :slug, :phone, :mapit)
+FakePerson = Struct.new(:id, :name, :slug, :phone, :mapit) do
+  def area
+    FakePlace.new(mapit.mapit_id)
+  end
+end
+
+FakePersonFactory = Struct.new(:mapit) do
+  def build_csv_person(row)
+    FakePerson.new(row['id'], row['name'], row['identifier__shineyoureye'], row['phone'], mapit)
+  end
+
+  def build_ep_person(person, _term)
+    FakePerson.new(person.id, person.name, person.identifier('shineyoureye'), '', mapit)
+  end
+end


### PR DESCRIPTION
This PR introduces a person factory to deal with person creation without coupling the created classes with the classes that create them, so that if the interface changes in the future, the changes don't cascade through the entire codebase.

## Relevant issue

Closes #123