### PR TITLE
Sort the filenames in the document finder

### DIFF
--- a/lib/document/finder.rb
+++ b/lib/document/finder.rb
@@ -50,7 +50,7 @@ module Document
     end
 
     def filenames
-      @filenames ||= Dir.glob(pattern)
+      @filenames ||= Dir.glob(pattern).sort
     end
 
     def create_document(filename)

--- a/tests/document/finder.rb
+++ b/tests/document/finder.rb
@@ -27,6 +27,12 @@ slug: a-slug
     end
   end
 
+  it 'sorts the found filenames alphabetically' do
+    Dir.stub :glob, %w(zed be) do
+      finder.find_all.first.send(:basename).must_equal('be')
+    end
+  end
+
   describe 'when it fails to find a document' do
     describe 'when multiple documents with same name and different dates' do
       it 'raises an exception if method is called directly' do


### PR DESCRIPTION
This is done so that the featured people are predictable,
since you could get test failures if you get the featured
summaries in a random order (the test data currently has
more than one representative with the featured field set
to true).