### PR TITLE
Delete line causing Rubocop Style/EmptyLinesAroundBlockBody error

### DIFF
--- a/tests/document/markdown_parser.rb
+++ b/tests/document/markdown_parser.rb
@@ -47,7 +47,6 @@ foo: bar
                  'alt="infographic.png" /></p>'
       parser(contents).as_html.strip.must_equal(expected)
     end
-
   end
 
   def parser(contents)


### PR DESCRIPTION
This was left by Friday's refactoring :smile: 