### PR TITLE
Add a PollDady poll to the front page

### DIFF
--- a/public/stylesheets/sass/_homepage.scss
+++ b/public/stylesheets/sass/_homepage.scss
@@ -60,6 +60,6 @@
 }
 
 .polldaddy {
-  width: 20%;
-  margin: auto;
+    width: 300px; // This is the width defined by PollDaddy-generated `.pds-box` element
+    margin: auto;
 }

--- a/public/stylesheets/sass/_homepage.scss
+++ b/public/stylesheets/sass/_homepage.scss
@@ -58,3 +58,8 @@
         margin: 0;
     }
 }
+
+.polldaddy {
+  width: 20%;
+  margin: auto;
+}

--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -41,6 +41,16 @@
 </div>
 
 
+
+<div id="polldaddy" class="polldaddy">
+  <h2>Latest Poll</h2>
+  <script type="text/javascript" charset="utf-8" src="http://static.polldaddy.com/w/57906.js"></script>
+  <noscript><a href="http://polldaddy.com/w.php?p=57906">Take Our Poll</a></noscript>
+</div>
+
+
+
+
 <div class="page-section">
   <div class="container">
     <div class="row">

--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -40,21 +40,17 @@
   </div>
 </div>
 
-
-
-<div id="polldaddy" class="polldaddy">
-  <h2>Latest Poll</h2>
-  <script type="text/javascript" charset="utf-8" src="http://static.polldaddy.com/w/57906.js"></script>
-  <noscript><a href="http://polldaddy.com/w.php?p=57906">Take Our Poll</a></noscript>
-</div>
-
-
-
+<% if @page.featured_events.empty? %>
+  <% @colwidth = 6 %>
+<% else %>
+  <% @colwidth = 4 %>
+<% end %>
 
 <div class="page-section">
   <div class="container">
     <div class="row">
-      <div class="col-sm-6">
+
+      <div class="col-sm-<%= @colwidth %>">
         <h2><a href="/blog/">News</a></h2>
         <% unless @page.featured_posts.empty? %>
           <% @page.featured_posts.each do |post| %>
@@ -65,17 +61,25 @@
           <p>There are no blog posts.</p>
         <% end %>
       </div>
-      <div class="col-sm-6">
-        <h2><a href="/events/">Events</a></h2>
-        <% unless @page.featured_events.empty? %>
+
+      <div class="col-sm-<%= @colwidth %>">
+        <div id="polldaddy" class="polldaddy">
+          <h2>Latest Poll</h2>
+          <script type="text/javascript" charset="utf-8" src="http://static.polldaddy.com/w/57906.js"></script>
+          <noscript><a href="http://polldaddy.com/w.php?p=57906">Take Our Poll</a></noscript>
+        </div>
+      </div>
+
+      <% unless @page.featured_events.empty? %>
+        <div class="col-sm-<%= @colwidth %>">
+          <h2><a href="/events/">Events</a></h2>
           <% @page.featured_events.each do |event| %>
             <a href="<%= event.url %>"><h3><%= event.title %></h3></a>
             <p><%= @page.format_date(event.date) %></p>
           <% end %>
-        <% else %>
-          <p>There are no upcoming events.</p>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
The code was taken from the Pombola version of the site.

Poll is placed between "News" and "Events". If there are no events, the "Events" column is hidden.

## Screenshots

When there are no events:

![screen shot 2017-04-21 at 11 23 58](https://cloud.githubusercontent.com/assets/739624/25273787/3df19e48-2685-11e7-8daa-5ec582f207cc.png)

When there are events:

![screen shot 2017-04-21 at 11 23 43](https://cloud.githubusercontent.com/assets/739624/25273791/44afbf62-2685-11e7-9383-03c919e988c2.png)

## Relevant issues

Closes https://github.com/theyworkforyou/shineyoureye-sinatra/issues/150

(Screenshots by @zarino :slightly_smiling_face: )