### PR TITLE
Gitignore the folder with the images uploaded to prose by users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .sass-cache
 /prose
+/public/prose
 /public/media_root
 /public/stylesheets/*.css
 /public/stylesheets/*.css.map


### PR DESCRIPTION
This was left from last Friday's pairing :slightly_smiling_face: 