### PR TITLE
Fix slug_to_person method's bug

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -165,6 +165,10 @@ keep adding things here, for the newcomers.
   adding a new fake is worth checking that it doesn't exist
   there :smiley:
 
+* Persons should always have a slug. If they don't, or if the
+  slug is not unique, that should be fixed upstream. The code
+  will throw an error.
+
 
 ## Questions
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ ruby '2.3.1'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-gem 'babosa'
 gem 'bootstrap-sass'
 gem 'coveralls', require: false
 gem 'everypolitician', '~> 0.20.0', github: 'everypolitician/everypolitician-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,6 @@ GEM
     ast (2.3.0)
     autoprefixer-rails (6.7.0)
       execjs
-    babosa (1.0.2)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -89,7 +88,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  babosa
   bootstrap-sass
   coveralls
   everypolitician (~> 0.20.0)!

--- a/app.rb
+++ b/app.rb
@@ -3,6 +3,7 @@ require 'bootstrap-sass'
 require 'everypolitician'
 require 'sinatra'
 
+require_relative 'lib/checks'
 require_relative 'lib/featured_person'
 require_relative 'lib/document/finder'
 require_relative 'lib/ep/people_by_legislature'
@@ -69,6 +70,8 @@ senators = EP::PeopleByLegislature.new(
   legislature: settings.index.country('Nigeria').legislature('Senate'),
   person_factory: person_factory
 )
+
+raise_if_missing_slugs(governors, representatives, senators)
 
 get '/' do
   posts_finder = Document::Finder.new(pattern: posts_pattern, baseurl: '/blog/')

--- a/bin/deploy
+++ b/bin/deploy
@@ -62,12 +62,16 @@ ln -snf "${BUILD_DIR##*/}" build/current
 SINATRA_PORT=9292
 SINATRA_BASE_URL="http://localhost:$SINATRA_PORT"
 
+server_pid_listening() {
+    lsof -n -iTCP:"$SINATRA_PORT" | egrep "\b${1}\b.*LISTEN" > /dev/null
+}
+
 start_sinatra() {
     # Start the Sinatra server in the background:
     bundle exec rackup > "$BUILD_DIR/sinatra.log" 2>&1 &
     SINATRA_PID=$!
     echo "Waiting for Sinatra to start..."
-    while kill -0 "$SINATRA_PID" 2> /dev/null && ! nc -z localhost "$SINATRA_PORT"
+    while kill -0 "$SINATRA_PID" 2> /dev/null && ! server_pid_listening "$SINATRA_PID"
     do
         sleep 1
     done

--- a/bin/deploy
+++ b/bin/deploy
@@ -73,7 +73,12 @@ start_sinatra() {
     done
     # Make sure it's not an old one server still running:
     kill -0 "$SINATRA_PID" 2> /dev/null ||
-        { echo "Couldn't start Sinatra - is an old server running?"; exit 1; }
+        {
+            echo "Couldn't start Sinatra - is an old server running?"
+            echo "Server output was:"
+            cat "$BUILD_DIR/sinatra.log"
+            exit 1
+        }
     echo "done"
 }
 

--- a/data/extra-slugs.csv
+++ b/data/extra-slugs.csv
@@ -1,0 +1,277 @@
+uuid,name,legislature_name,slug
+gov:godwin-obaseki,Godwin Obaseki,,godwin-obaseki
+gov:oluwarontimi-akeredolu,Oluwarontimi Akeredolu,,oluwarontimi-akeredolu
+b2a7f72a-9ecf-4263-83f1-cb0f8783053c,ABDUKADIR RAHIS,House of Representatives,abdukadir-rahis
+8ab0069f-7c0f-4fcb-8b93-486432b7520a,ABDUL-MALIK ZUBAIRU,House of Representatives,abdul-malik-zubairu
+764fce72-c12a-42ad-ba84-d899f81f7a77,ABDULAHI FARUK,House of Representatives,abdulahi-faruk
+9cac82e2-515f-492b-90f5-343530a48f0a,ABDULLAHI HASSAN,House of Representatives,abdullahi-hassan
+8643dbb1-57e4-4c5a-a34d-dcc76eb18a0c,ABDULRAZAK NAMDAS,House of Representatives,abdulrazak-namdas
+b62f18fc-dd29-4b02-a5f7-95a42f956543,ABDUSSAMAD DASUKI,House of Representatives,abdussamad-dasuki
+50cb2a99-49a0-4ea7-b5a5-65a0bd7ede30,ABUBAKAR AMUDA-KANNIKE,House of Representatives,abubakar-amuda-kannike
+58a2855c-7b99-4837-b234-deed1fc2404a,ABUBAKAR DAHIRU,House of Representatives,abubakar-dahiru
+d1b39c93-9087-4da4-adc4-e1ae99b35fc3,ABUBAKAR LADO,House of Representatives,abubakar-lado
+5198eacc-97f8-4eb1-9ad9-1895cb5cb979,ABUBAKAR LAWAL,House of Representatives,abubakar-lawal
+c8f995d8-29b6-43d2-b2cb-77a12a68b588,ADAMU KAMALE,House of Representatives,adamu-kamale
+a4683308-694e-4907-8eca-a6a968d9f3b8,ADAMU MUHAMMADU,House of Representatives,adamu-muhammadu
+b4771d4f-81fb-47ef-9631-9f8520b391ad,ADEBUTU OLADIPUPO,House of Representatives,adebutu-oladipupo
+8ecd73b9-0119-4f2a-9514-cf441b8246a2,ADEDAPO LAM-ADESINA,House of Representatives,adedapo-lam-adesina
+dbbb2782-d52b-4594-8150-d98f73ad776e,ADEKOYA ADESEGUN,House of Representatives,adekoya-adesegun
+06356066-e59d-4182-b700-35120278bfdc,ADO MUSA,House of Representatives,ado-musa
+8d17036d-0d51-4fb3-82eb-d5c9f2e2b9e5,AFE OLOWOOKERE,House of Representatives,afe-olowookere
+4aa3a1f8-6788-4acd-ab49-7108b92b187a,AGBEDI YEITIEMONE,House of Representatives,agbedi-yeitiemone
+cacf9de6-c729-4ea1-904c-2ce0515940b8,AHMED ABU,House of Representatives,ahmed-abu
+ecad542f-6975-4a15-a31f-e2a8fbf041b4,AHMED YERIMA,House of Representatives,ahmed-yerima
+717fe4f9-c75a-475e-a549-84d845a34ab8,AISHATU DUKKU,House of Representatives,aishatu-dukku
+a038a9a0-3752-40cd-80ab-0cb42be9c973,AISOWIEREN PATRICK,House of Representatives,aisowieren-patrick
+360ff59a-7382-4154-8a30-69f7f13912e6,AJAYI ADEYINKA,House of Representatives,ajayi-adeyinka
+ade0005f-dccf-49dd-9f41-fefe8885beba,AKINJO VICTOR,House of Representatives,akinjo-victor
+9b34c9ba-428f-4c08-9e05-716de04fcb06,AKINTOLA TAIWO,House of Representatives,akintola-taiwo
+ed21de44-634c-469b-aeb4-6310664dfdad,ALABI MOJEED,House of Representatives,alabi-mojeed
+18dd9ba1-d20d-4eb6-89f0-b3db84c05246,ALBERT ADEOGUN,House of Representatives,albert-adeogun
+36aa99d5-6235-45b0-b831-58967b2555ed,ALIYU DANLADI,House of Representatives,aliyu-danladi
+3b78b18c-75cd-486f-905b-ee1291ff95c5,AMINU ASHIRU,House of Representatives,aminu-ashiru
+bf2e026d-c295-496f-ac19-b0897e5f8e0b,AMINU ISA,House of Representatives,aminu-isa
+ba539602-2401-4974-9ed9-1a5003028b39,ANAYO NNEBE,House of Representatives,anayo-nnebe
+35cc2522-e0d7-4e82-8619-2635bc60fd88,ASABE BASHIR,House of Representatives,asabe-bashir
+e8f3081e-2f66-408f-bc0b-7bb9f4d93ba7,AWAJI-INOMBEK ABIANTE,House of Representatives,awaji-inombek-abiante
+a037d5e6-cc05-4484-a1e4-87047c62a6b7,AYEOLA ABAYOMI,House of Representatives,ayeola-abayomi
+bd3ce3b6-9eb9-46a1-baf2-503e6f6a4858,AZUBAGO IFEANYI,House of Representatives,azubago-ifeanyi
+6706efee-7156-488a-95c4-4dd10b544c7a,Abdullahi Mohammed,House of Representatives,abdullahi-mohammed
+631c3523-c284-469d-8fdf-e30d147ee88a,Abiodun Olasupo,House of Representatives,abiodun-olasupo
+51c8fe3f-5e57-4e49-a373-fc9820a8802c,Abubakar Adamu,House of Representatives,abubakar-adamu
+8b910dbc-22e9-4408-8dcf-98276b530ad3,Adabah Christian,House of Representatives,adabah-christian
+78726e95-961f-461d-9bd1-ca226e30be4d,Adewale Oluwatayo,House of Representatives,adewale-oluwatayo
+868498bd-2a23-4477-96b9-17bf0dbf96ae,Agom Jarigbe,House of Representatives,agom-jarigbe
+790d799a-a330-416c-92dd-76b08676fc2c,Akinyede Awodumila,House of Representatives,akinyede-awodumila
+d5d7e6d0-c824-4790-b455-12c5f5b38a30,Ali Isa,House of Representatives,ali-isa
+0cfa657a-9ba3-4889-a30a-9c9c1040b9cb,Angulu Zakari,House of Representatives,angulu-zakari
+f57fe0a1-478c-4ec4-b89a-9c7e18c89b43,Ayodeji Joseph,House of Representatives,ayodeji-joseph
+5bca4ac7-190e-4cf1-a1a9-7c0735f4d764,BABATUNDE KOLAWOLE,House of Representatives,babatunde-kolawole
+60ac3d18-9946-41e9-a7cf-6a5d35b281ec,BADERINWA BAMIDELE WHITE,House of Representatives,baderinwa-bamidele-white
+25e4ad12-dcda-4fcc-ab3e-00c24dd3a711,BELLO ABDULLAHI,House of Representatives,bello-abdullahi
+24a57e06-1019-4ed5-a6a9-99af12871b17,BELLO SANI,House of Representatives,bello-sani
+7b93348e-4294-43a1-a6b2-5f32e478ad38,BOLAJI AYINLA,House of Representatives,bolaji-ayinla
+3acdf153-8e52-4c6a-854c-7a24869dd1b6,BULUS SOLOMON,House of Representatives,bulus-solomon
+902ca577-525c-46bb-8677-718d0e32ded5,BUSAYO OKE,House of Representatives,busayo-oke
+e5c64ded-fbca-42d0-903e-44618f4964bf,Babajimi Benson,House of Representatives,babajimi-benson
+f9a3b9d5-18f7-4d6c-a1b5-4c11be52e9cd,Ben Nwankwo,House of Representatives,ben-nwankwo
+3cb4be54-0692-41f3-9fde-aef403474774,CHIDOKA OBINNA,House of Representatives,chidoka-obinna
+b17b20ef-a8a0-481b-abba-8a9ceedaed1e,CHUKWUEMEKA ANOHU,House of Representatives,chukwuemeka-anohu
+d9936274-8b09-43dd-8289-2bdc96c0dfe0,CHUKWUEMEKA UJAM,House of Representatives,chukwuemeka-ujam
+e48fa637-1ddc-45e4-acaa-21a14127a330,CHUKWUKA ONYEMA,House of Representatives,chukwuka-onyema
+515d2b39-e318-47ac-992f-39b3c44acc56,CHUKWUKERE AUSTINE,House of Representatives,chukwukere-austine
+2112408c-3908-409b-826a-52fa59654163,Chukwuma Nwazunku,House of Representatives,chukwuma-nwazunku
+de9be2db-dc90-4d40-a967-e906ce7c2f99,D Boma,House of Representatives,d-boma
+eb96273d-62bb-4a48-8615-ae257b378389,DA'U MAGAJI,House of Representatives,dau-magaji
+9d4283cd-7e90-4c59-a428-346c95bbe0a6,DANBURAM NUHU,House of Representatives,danburam-nuhu
+d44924f4-be2d-4f5c-afa8-f4510e8d727a,DAYYABU AHMED,House of Representatives,dayyabu-ahmed
+00f8089e-cc28-4433-90fa-48852600a92b,DEKOR DUMNAMENE,House of Representatives,dekor-dumnamene
+a1fde7e8-6b68-4e69-9b87-f6d12b26cf88,DENNIS AMADI,House of Representatives,dennis-amadi
+cfbd55d3-3ce6-48e8-bfbc-bfc2b57e4f59,DOUYE DIRI,House of Representatives,douye-diri
+692c14c1-07cd-4bc7-bb09-0ade6b2b2f57,Danladi Baido,House of Representatives,danladi-baido
+c559cabf-04e8-468f-bc84-c3d52daf0e69,Darlington Nwokocha,House of Representatives,darlington-nwokocha
+a5a3bc2d-d074-4d77-8112-604ac7630c77,Dennis Agbo,House of Representatives,dennis-agbo
+02f6ec41-6711-434d-9bab-1e4143954edb,EDERIN IDISI,House of Representatives,ederin-idisi
+d7d9a7f3-972a-4ceb-9c97-a8787b86a673,EDIM ETA,House of Representatives,edim-eta
+7446df85-7895-4c1e-8431-28b8cf83f523,EDWIN ANAYO,House of Representatives,edwin-anayo
+ee50c7f9-787f-46eb-9c17-2d1b0d0dac56,EGWU EMMANUEL,House of Representatives,egwu-emmanuel
+02f60e2e-b2eb-49b1-ad43-efbc4809077d,EHIOZUWA AGBONAYINMA,House of Representatives,ehiozuwa-agbonayinma
+7a964ca1-67eb-43e9-8986-f2823bef710f,EMERENGWA BONIFACE,House of Representatives,emerengwa-boniface
+74b1390d-39d3-4ce1-9ef4-8f7e7641d0df,ENITAN BADRU,House of Representatives,enitan-badru
+ff5b5a16-9243-4cc0-83fc-b4c97f44ce63,Eke Bede,House of Representatives,eke-bede
+9ab7d672-3488-4ce7-83df-d85603c0b1d8,Emeka Idu,House of Representatives,emeka-idu
+8dd0112a-1805-44b8-9b7a-4c6a6faa5b70,Emmanuel Akpan,House of Representatives,emmanuel-akpan
+a1906a92-c207-444e-83c5-221f635d1c6d,FARUK MUHAMMADU,House of Representatives,faruk-muhammadu
+b32bbfd7-7e44-45e3-b1e1-fb5cff750021,FRANCIS UDUYOK,House of Representatives,francis-uduyok
+c30c00dc-f1c5-44f6-b42b-99be55b03589,Fulata Abubakar,House of Representatives,fulata-abubakar
+f02cddda-fddf-4cf8-8fc5-b36ee0fdd895,GABRIEL ONYENWIFE,House of Representatives,gabriel-onyenwife
+3cb8bc47-9681-409a-a602-f54c2be08b52,GARBA AHMED,House of Representatives,garba-ahmed
+ee784851-7a07-45d3-8314-b7d63bbd49aa,GARBA MOHAMMED,House of Representatives,garba-mohammed
+ec3ad0af-b8f7-4f12-8358-278ef53e6fc2,GARBA UMAR,House of Representatives,garba-umar
+e62ad765-bebf-4952-9814-629be886ceea,GAZA GBEFWI,House of Representatives,gaza-gbefwi
+875408c1-8bb0-4b66-9efb-defdeef28f47,GOODLUCK OPIAH,House of Representatives,goodluck-opiah
+da20ea9b-54e7-4caa-a508-5f425ac7b11a,Garba Sabo,House of Representatives,garba-sabo
+68ad0d36-e750-4486-83b0-f887cc360c78,Gideon Gwani,House of Representatives,gideon-gwani
+8ff5f0af-eaec-4e24-8896-eb41afbb9bd8,HAMMAN-JULDE GARBA,House of Representatives,hamman-julde-garba
+a13b0d31-cad2-49fa-9173-ee030984aca3,HASSAN ABUBAKAR III,House of Representatives,hassan-abubakar-iii
+f77669c1-8dbe-4747-aa68-f8c84dcd303d,HASSAN ADAMU,House of Representatives,hassan-adamu
+b77bf509-47ad-4a86-9188-401e18312e42,HASSAN SALEH,House of Representatives,hassan-saleh
+19333d94-5d10-4cb4-b94a-f919d6e090fa,HENRY ARCHIBONG,House of Representatives,henry-archibong
+e5360427-1eee-4606-ada6-89ca337d3780,HENRY NWAWUBA,House of Representatives,henry-nwawuba
+36f13d81-0781-45e7-b5de-0d5a71a9a69c,Hassan Omale,House of Representatives,hassan-omale
+4473b1c4-0423-46c9-bef0-57f768caa0f0,Husaini Abubakar,House of Representatives,husaini-abubakar
+0baf46e2-4521-4400-96f7-75137e68c6cb,Husseni Suleiman,House of Representatives,husseni-suleiman
+40ac5b78-a4f2-45e3-b380-1d7ff585257e,IBORO EKANEM,House of Representatives,iboro-ekanem
+7bd2a315-5a9f-495b-a766-d534c429a0da,IBRAHIM ABDULLAHI,House of Representatives,ibrahim-abdullahi
+1f2fdde9-40ee-4fa3-956f-039b8c07448d,IBRAHIM DANMAZARI,House of Representatives,ibrahim-danmazari
+ec925d92-5d97-477c-8b2a-c49064e7ffdc,IDAGBO OCHIGLEGOR,House of Representatives,idagbo-ochiglegor
+54898789-b7ed-4933-ad91-f26aae2cef42,IDUMA IGARIWEY,House of Representatives,iduma-igariwey
+bc3c9923-3157-4fbd-afe0-a0203e3f20d9,IKANI OKOLO,House of Representatives,ikani-okolo
+ff16e23f-3be0-4a89-a263-4d974d9c3f24,IOREMBER WAYO,House of Representatives,iorember-wayo
+94c7f532-97bf-411b-ba64-7a4cc612b97b,IROM MICHAEL,House of Representatives,irom-michael
+356c08ec-a215-4f99-904a-3640b4cdf98a,ISAH MURTALA,House of Representatives,isah-murtala
+746673b7-5fb2-4446-83ba-5f63b97028f1,Ibrahim Baba,House of Representatives,ibrahim-baba
+e214e2b1-4555-4b24-8e0e-20756b28c34b,Ibrahim Isiaka,House of Representatives,ibrahim-isiaka
+90960d4e-51fb-447b-bad5-5ff55391349a,Ismaila Hassan,House of Representatives,ismaila-hassan
+fd172c3e-4a15-498f-96e6-71a6573759cc,Istifanus Gyang,House of Representatives,istifanus-gyang
+a3c1d5ff-1271-484f-978a-11668e10b2fe,JACOBSON BARINEKA,House of Representatives,jacobson-barineka
+75d9a145-030a-48cb-875e-789db11e6b63,JIBRIN SANTUMARI,House of Representatives,jibrin-santumari
+79d811f8-36c2-4d9c-8cb2-c360f746c209,JIBRIN SATUMARI,House of Representatives,jibrin-satumari
+11b0606e-4b96-4228-9ee4-c78b653283c0,JIMOH ABDUL,House of Representatives,jimoh-abdul
+0c38ed75-9f5f-4821-998b-7d1537c761bd,JIMOH OJUGBELE,House of Representatives,jimoh-ojugbele
+cc0c8ee4-5f23-4e20-8e71-9f9341f5e6cf,JOAN MRAKPOR,House of Representatives,joan-mrakpor
+7d66426a-7fb1-4fb5-b111-4d8752365242,JOSEPH BAMGBOSE,House of Representatives,joseph-bamgbose
+182dbeaa-91bb-4138-854a-e78f4cb44eaa,JOSEPH EDIONWELE,House of Representatives,joseph-edionwele
+26b2faba-5957-49a2-a6d2-3645b0a0812e,Jerome Eke,House of Representatives,jerome-eke
+c9662b95-206c-4a9c-aa6a-5dda5c8e6aa7,Jika Haliru,House of Representatives,jika-haliru
+62874761-fd85-4dc5-a6bc-579b4f908086,Johnbull Shekarau,House of Representatives,johnbull-shekarau
+0e6c09f3-3b92-4bf4-9163-3175f142bbd8,Johnson Oghuma,House of Representatives,johnson-oghuma
+3e672fe3-54fd-4fe6-89d5-0bc6a34b0afc,KABIR SHAIBU,House of Representatives,kabir-shaibu
+29dfc79f-bd7c-49ef-a31b-913faabe8e4e,KAYODE OLADELE,House of Representatives,kayode-oladele
+b0057850-1a94-4576-aa0f-ed300209bb12,KWAMOTI LAORI,House of Representatives,kwamoti-laori
+22c21b1b-5e7b-4d81-b849-7a82aebfda26,Kehinde Agboola,House of Representatives,kehinde-agboola
+7d66d561-a926-41a3-9c6c-e72dad7eea98,Kurmi Gashaka,House of Representatives,kurmi-gashaka
+54790a50-af87-4d4d-ab8d-0798351c0d41,LAZARUS OGBEE,House of Representatives,lazarus-ogbee
+003e0736-add0-4997-9444-94fac606bb95,MALLAM GANA,House of Representatives,mallam-gana
+93e50fab-06e9-4cf0-b24d-1af1141a06a1,MARK GBILLAH,House of Representatives,mark-gbillah
+8e65e183-9e14-4029-b68b-4fa8a35d6179,MAYOWA AKINFOLARIN,House of Representatives,mayowa-akinfolarin
+b4e56469-45dd-4cfd-a258-8234f0f46e2b,MOHAMMED GARBA,House of Representatives,mohammed-garba
+46fddce6-2c5e-4b70-8eb4-843501b059b7,MOHAMMED MAHMUD,House of Representatives,mohammed-mahmud
+deac6723-504e-48ae-b116-5b319fe8ae54,MUHAMMAD ABDU,House of Representatives,muhammad-abdu
+b7d77f59-9d90-4d4a-8911-b096c921dc30,MUHAMMAD ABUBAKAR,House of Representatives,muhammad-abubakar
+f9c4b3ab-5844-48d0-9a99-d550dddbdf86,MUHAMMAD BOYI,House of Representatives,muhammad-boyi
+dcffcccf-4ca8-4fcb-8be4-27f7b60e4148,MUHAMMAD JEGA,House of Representatives,muhammad-jega
+90f3b0fb-54e4-4e37-a65b-81beffd10257,MUHAMMAD SOBA,House of Representatives,muhammad-soba
+c306f5a2-7830-4a0f-a217-03e27b096579,MUHAMMAD USMAN,House of Representatives,muhammad-usman
+8a0483b2-37d2-4abf-9ac1-24bf46fb34ec,MUHAMMED GUDAJI,House of Representatives,muhammed-gudaji
+8cc24ea0-7960-424e-b6c7-2f886057b775,MUHAMMED IDIRISU,House of Representatives,muhammed-idirisu
+74a6dad8-d6c5-4322-8f25-35c757bebb95,MUKAILA KASSIM,House of Representatives,mukaila-kassim
+557d08dc-0bc1-4129-b082-6ac8b938978a,MUNTARI DANDUTSE,House of Representatives,muntari-dandutse
+e35cd9c4-a48f-4158-ba49-f3637b273e27,MUTIU SHADIMU,House of Representatives,mutiu-shadimu
+4aeb2a50-a77d-42d2-b687-dc295090d2af,Marshal Sunday,House of Representatives,marshal-sunday
+debf0004-e243-4def-9040-43b63b658d5e,Mohammed Danlami,House of Representatives,mohammed-danlami
+090cdc38-e999-4530-af1f-f1b7ca7e4e01,Muhammed Ajanah,House of Representatives,muhammed-ajanah
+18e353f3-f57f-4646-bcd6-603cdda084c2,NGORO AGIBE,House of Representatives,ngoro-agibe
+726225dd-a03a-43b6-879a-414076ea6d27,NICHOLAS SHEHU,House of Representatives,nicholas-shehu
+395c7580-4078-44c5-98cd-445a371e1ffe,NSE EKPENYONG,House of Representatives,nse-ekpenyong
+83096a24-9560-4584-af40-d4140f2bb72c,OGBEIDE-IHAMA OMOREGIE,House of Representatives,ogbeide-ihama-omoregie
+4ef095c9-3402-4491-afce-59be3ad36187,OGHENE EMMANUEL,House of Representatives,oghene-emmanuel
+f8c1f144-b33e-4f31-b094-f7f7cb9d2b55,OGUNWUYI SEGUN,House of Representatives,ogunwuyi-segun
+284631bd-2803-4e50-906d-846a52923a32,OKAFOR JOHN,House of Representatives,okafor-john
+2ed2a5b2-882f-499d-9962-2ffc9a9e4555,OLAJIDE OLATUBOSUN,House of Representatives,olajide-olatubosun
+d3fae412-fb8b-4c59-8426-10a1c3f862fd,OLAMIDE ONI,House of Representatives,olamide-oni
+9d9b0610-b5f6-4f85-b6cf-d779a2aeeefe,OLARINOYE OLAYONU,House of Representatives,olarinoye-olayonu
+965f94df-c963-486d-9437-a0d5e2a24e88,OLUFEMI ADEBANJO,House of Representatives,olufemi-adebanjo
+dfb34e8f-f293-48a5-a492-e5591a474170,OLUFUNKE ADEDOYIN,House of Representatives,olufunke-adedoyin
+421c73dc-b657-454e-93dc-80a02640a6e9,OLUGBENGA AYODE,House of Representatives,olugbenga-ayode
+94f050f0-bda4-4a83-8913-db7940d66411,OLUSUNBO SAMSON,House of Representatives,olusunbo-samson
+c14f9e8b-fa61-47fd-bea8-de476895373a,OLUWAROTIMI AGUNSOYE,House of Representatives,oluwarotimi-agunsoye
+1a3d477f-10fe-4727-9212-d312e03bd55f,OMAR TATA,House of Representatives,omar-tata
+ce5bb010-0ada-40a2-9313-4f9e1d0824af,OMOSEDE IGBINEDION,House of Representatives,omosede-igbinedion
+beda968f-381d-47cb-b1a3-07806fe627d5,ONINUBUARIRI OBINNA,House of Representatives,oninubuariri-obinna
+9edd9f06-4880-49fe-89c7-68c473abb384,ONWANA MUSA,House of Representatives,onwana-musa
+65580dd7-a319-41b4-8e48-c88e50f5bcae,OWOIDIGHE EKPOATAI,House of Representatives,owoidighe-ekpoatai
+387498db-b8e3-4110-8dfe-8952999c126d,OYEWOLE DIYA,House of Representatives,oyewole-diya
+01fa4a69-45f0-42e2-812d-1a168b9356b4,Okechukwu Eze,House of Representatives,okechukwu-eze
+c7e9c2f7-02b2-43e9-a57d-42f54c7e01c7,Okon Michael,House of Representatives,okon-michael
+e848ce55-5b26-4ec1-9cf2-09889f0775d6,Olabode Ayorinde,House of Representatives,olabode-ayorinde
+5df2ecb5-be44-435e-864c-e5df712f9006,Olemija Stephen,House of Representatives,olemija-stephen
+50ec61a9-dca5-456a-8430-73b7fd89616f,PHILIP AHMAD,House of Representatives,philip-ahmad
+ed9e7d80-fafb-4d0a-93f9-a73adfd765db,PHILIP SHAIBU,House of Representatives,philip-shaibu
+2d5472ed-c775-4af9-9277-87c97ed667b4,PRESTIGE OSSY,House of Representatives,prestige-ossy
+767961bb-6ba5-46a8-a640-3f14220519db,PWAJOK GYANG,House of Representatives,pwajok-gyang
+fe1cd7cb-8c45-4886-a6ab-b93d9659979b,Peter Madubueze,House of Representatives,peter-madubueze
+4dded367-aad0-426b-a20e-a84d16f78f64,RAZAK ATUNWA,House of Representatives,razak-atunwa
+3438649a-0572-4d86-b47c-42b2bdcbd46a,RIMAMNDE KWEWUM,House of Representatives,rimamnde-kwewum
+296f1852-72c5-4b9e-94e4-b923ff9e309d,RITA ORJI,House of Representatives,rita-orji
+13690167-45a0-48c1-97f2-724e65341972,Rabiu Garba,House of Representatives,rabiu-garba
+7d679377-c418-4ed0-89c3-f2992a32aa35,Randolph Brown,House of Representatives,randolph-brown
+92dbd640-9b33-4732-bf85-d82c1a756326,SADIQ IBRAHIM,House of Representatives,sadiq-ibrahim
+dcb0a859-5def-46d2-ab8e-22f110c9db62,SALISU KOKO,House of Representatives,salisu-koko
+594f85ac-20a5-4758-bd2a-d8b28fe2d808,SAMAILA SULEIMAN,House of Representatives,samaila-suleiman
+fcdd186a-3e82-4d05-8f02-32b4b30dd6f5,SAMUEL IKON,House of Representatives,samuel-ikon
+e0167e52-a98b-44db-a385-e3c5b33c2969,SAMUEL ONUIGBO,House of Representatives,samuel-onuigbo
+b72e517d-600f-4421-8c18-76263d959a66,SANI AMINU,House of Representatives,sani-aminu
+13c712a7-44ab-4034-bbb8-30079b745cdf,SANI SAIDU,House of Representatives,sani-saidu
+763b937d-40c9-4510-baca-f5dafd339965,SANI UMAR,House of Representatives,sani-umar
+9ca6ab56-a7e0-4616-9e21-bed883d3e20c,SEGUN ADEKOLA,House of Representatives,segun-adekola
+e01dd914-0d13-4db4-bb54-a5a88b93a5be,SERGIUS OGUN,House of Representatives,sergius-ogun
+4c485a8d-f8c5-4287-8935-d4fd39f1b3f1,SHEHU SALEH,House of Representatives,shehu-saleh
+559e1aad-6916-4cae-9893-c3a742157fc9,SHOYINKA OLATUNJI,House of Representatives,shoyinka-olatunji
+e6bd93db-b6ce-466f-97b2-c5c42f208872,SIMON ARABO,House of Representatives,simon-arabo
+a64a8a2e-8638-41aa-9a8b-b336ec53934f,SODAGUNO FESTUS-OMONI,House of Representatives,sodaguno-festus-omoni
+5d985d83-c5e0-46ee-9e61-04594717a3b0,STELLA NGWU,House of Representatives,stella-ngwu
+d26a7682-d75e-49e1-b44d-582374e86951,SULAIMAN ROMO,House of Representatives,sulaiman-romo
+305500ed-340a-4ae1-83d3-68ead88a893c,SUNDAY OLADIMEJI,House of Representatives,sunday-oladimeji
+1134b7bc-a663-415b-8340-0d688aa77e2f,Sani Mohammed,House of Representatives,sani-mohammed
+2f3453b5-6567-4460-91f2-b388d1ab9099,Shehu Musa,House of Representatives,shehu-musa
+e47293a7-720a-4ea0-b61f-e16c80ffb511,Shuaibu Abdulraman,House of Representatives,shuaibu-abdulraman
+976be656-6c2d-461c-9b27-23ae8f307341,Sidi Yakubu,House of Representatives,sidi-yakubu
+bfab36c0-a199-42da-a005-94e31066d2be,Solomon Adaelu,House of Representatives,solomon-adaelu
+9c636dc2-431e-4ec9-8337-2211f6cf547e,Solomon Ahwinahwi,House of Representatives,solomon-ahwinahwi
+24548ea1-20ce-44bb-8995-5ea4d27a21c5,TAJUDEEN OBASA,House of Representatives,tajudeen-obasa
+b393127e-a630-43d9-8fba-0eb0f37a0e6d,TAOFEEK ADARANIJO,House of Representatives,taofeek-adaranijo
+52cec1d0-75a5-44c0-acfb-038a7f4cd5a0,TARKIGHIN DICKSON,House of Representatives,tarkighin-dickson
+5002acd7-8dd6-48ac-814f-c4c57a92e40a,TEMITOPE OLATOYE,House of Representatives,temitope-olatoye
+71228aab-a8fa-4592-a7e8-f512b77f3c67,THADDEUS AINA,House of Representatives,thaddeus-aina
+f0eb90f1-c40e-49e4-9def-75bda049c788,TIMOTHY GOLU,House of Representatives,timothy-golu
+3fb0cd5c-9cbf-42e6-a26d-ccf17e49443d,Talatu Yohanna,House of Representatives,talatu-yohanna
+1e32d025-0def-4efc-96c8-0d00d87de51e,Tasir Raji,House of Representatives,tasir-raji
+954eaef9-c9c4-40a6-be39-25339065e6ff,Tony Nwulu,House of Representatives,tony-nwulu
+9815f746-7531-4529-bdfb-1f3ba6e954bf,UCHECHIRUN NNAM-OBI,House of Representatives,uchechirun-nnam-obi
+ab2e3960-7d0f-45b9-825f-35c533ebf857,UMAR MUHAMMED,House of Representatives,umar-muhammed
+87fa5f5d-ea7d-4499-b032-5001192ceb68,USMAN IBRAHIM,House of Representatives,usman-ibrahim
+a7d48bda-e47d-4807-a9e6-07a790800d41,USMAN SHEHU,House of Representatives,usman-shehu
+0276a03a-323f-40ff-8e3f-d66f9c54bd0b,USMAN SHIDDI,House of Representatives,usman-shiddi
+af34db4e-cd4c-40aa-8197-b7a7dc45847b,Ugwuegede Ikechukwu,House of Representatives,ugwuegede-ikechukwu
+c460c61f-bdaf-40f5-b64f-2039604367a5,Uko Nkole,House of Representatives,uko-nkole
+651299a7-ecb5-465a-8262-4cbe728ea85f,Uthman Munir,House of Representatives,uthman-munir
+c2c2e02a-5840-496f-98ac-98671cdbdce6,YAHAYA CHADO,House of Representatives,yahaya-chado
+dd79529c-471d-4943-b3fa-6b5a36018b75,YAKUB BALOGUN,House of Representatives,yakub-balogun
+3d90055e-7223-4978-89c8-07685eb4b283,YUNUSA ABUBAKAR,House of Representatives,yunusa-abubakar
+1da348a6-3c05-498c-b1b9-74ecb747be49,YUSUF BUBA,House of Representatives,yusuf-buba
+d9b26731-6e74-4896-bedc-e924590fbe13,YUSUF SAIDU,House of Representatives,yusuf-saidu
+d0f0b376-5c1c-4bd4-bc29-84cb9269a7be,Yusuf Tijani,House of Representatives,yusuf-tijani
+77c0dd7a-dae7-461e-aa98-02dee6a79221,ZAKARI SALISU,House of Representatives,zakari-salisu
+5930bf13-221b-4b11-90ae-154cabd61af8,akeem adeyemi,House of Representatives,akeem-adeyemi
+fce6b6d3-4f57-42c0-bfdd-710d41a5d089,barambu kawuwa,House of Representatives,barambu-kawuwa
+6e824b24-29b3-43c1-aae9-15d556e014b9,chime oji,House of Representatives,chime-oji
+72be377a-ef68-44ab-a563-1958e4c74096,d. muhammad,House of Representatives,d-muhammad
+bd330f95-c1b8-4ae3-af52-61e2878f249c,galadima zakariya'u,House of Representatives,galadima-zakariyau
+946deeec-db1f-46b5-9769-f894f5a2b870,hassan yuguda,House of Representatives,hassan-yuguda
+648d4da1-86eb-4941-9104-7c7d2dc1ce63,isah ibrahim,House of Representatives,isah-ibrahim
+477b8b61-168f-47c1-b7c3-5b42c8e9453e,julius pondi,House of Representatives,julius-pondi
+a3e06cab-34c9-4180-9ad3-2433bfb8ec03,michael omobgehin,House of Representatives,michael-omobgehin
+bda297aa-6f98-4210-929d-c4814740dece,muhd lawal,House of Representatives,muhd-lawal
+640b41f9-1e8c-41b4-8e73-ac6c95b6c8bf,olatubosun oladele,House of Representatives,olatubosun-oladele
+a8bbe0eb-610d-4aaf-a783-1d39e14549c9,shriff mohammed,House of Representatives,shriff-mohammed
+6b0cdd74-7960-478f-ac93-d230f486a5b9,ABARIBE ENYNNAYA,Senate,abaribe-enynnaya
+d1ae196d-b203-4f62-8441-9d4bffa4566c,ABDUL ABUBAKAR,Senate,abdul-abubakar
+fa3e73e7-98b9-45f8-befb-3ba0884a8783,ABUBAKAR KYARI,Senate,abubakar-kyari
+0b536a2c-2bc9-46a0-8d40-0deb9241cb31,AHMAD ABUBAKAR,Senate,ahmad-abubakar
+945c1a0c-c1a1-4a67-8be1-8c9e756cdf8f,AISAGBONRIODION URHOGHIDE,Senate,aisagbonriodion-urhoghide
+df13478a-638f-4cec-8c58-360fc80eb1b0,ALIMIKHENA FRANCIS,Senate,alimikhena-francis
+78a5c98d-8bbb-45ec-8faa-937d77a93191,ATAI USMAN,Senate,atai-usman
+e344f2dd-a72b-4ca7-a259-59d8b81706fc,ATHANASIUS ACHONU,Senate,athanasius-achonu
+a1f70b6d-9b33-4780-a7fc-33565da69e97,Ahmed Ogembe,Senate,ahmed-ogembe
+70286a75-669d-4137-bab8-33d7350e3aaf,Aliyu Wamakko,Senate,aliyu-wamakko
+cf5aea30-b4fc-4eeb-b827-dd023e9ad0e6,BASSEY AKPAN,Senate,bassey-akpan
+9612c093-eb94-41b7-a713-3ca82b7f1e98,Baba Garba,Senate,baba-garba
+13721811-4357-419c-8ca7-8f1170b36f1a,Ben Murray-Bruce,Senate,ben-murray-bruce
+a16ff2f2-0df2-4372-a2a1-50faddd04c0a,Benjamin Uwajumogu,Senate,benjamin-uwajumogu
+1aec662e-0836-43d1-832a-0e65686766bb,FOSTER OGOLA,Senate,foster-ogola
+4c8ec63d-76c5-4452-934e-4c67e672b9d5,GEORGE SEKIBO,Senate,george-sekibo
+d9aa73bb-dea8-45c4-8eeb-0e66b5439e29,GODSWILL AKPABIO,Senate,godswill-akpabio
+29a44bbd-0dc5-433a-85b1-d75ac81023ba,ISAH MISAU,Senate,isah-misau
+30d9e31f-8113-423b-992b-124f97ea02aa,JOSEPH OGBA,Senate,joseph-ogba
+f8a2b149-a5ae-43c2-a3de-249c8da9e5fe,MAGNUS ABE,Senate,magnus-abe
+a4f78be5-607a-4663-9b3a-533464a962c1,NELSON EFFIONG,Senate,nelson-effiong
+b3c68cc0-3a3e-4d47-8feb-bb6d75c4f343,ODUAH STELLA,Senate,oduah-stella
+f842a937-4dd5-4011-aa52-4f025be06a74,OHUABUNWA MAO,Senate,ohuabunwa-mao
+ec8587fd-11f3-48f1-a830-267b8a5ad524,OLAKA NWOGU,Senate,olaka-nwogu
+fbe41710-70db-4640-b464-aa3b894031f9,ORDIA CLIFFORD,Senate,ordia-clifford
+452c8d72-b078-40fd-8d0c-cfff8cb199fa,OSINAKACHUKWU IDEOZU,Senate,osinakachukwu-ideozu
+af00a81c-21e0-49f9-b61b-e90b36fc8ba1,Ovie Omo-Agege,Senate,ovie-omo-agege
+e4840a77-41c5-4818-b0e8-54676f004239,PETER NWABOSHI,Senate,peter-nwaboshi
+96885e3b-9207-4db4-ab27-ceda4dff7d2e,SULEIMAN ADOKWE,Senate,suleiman-adokwe
+f95eee1d-5f81-4813-8164-7e1cc908e878,Yusuf Yusuf,Senate,yusuf-yusuf

--- a/lib/checks.rb
+++ b/lib/checks.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+def missing_slug_row(person, collection)
+  return nil if person.slug
+  {
+    uuid: person.id,
+    name: person.name,
+    legislature_name: collection.legislature_name,
+    suggested_slug: person.name.downcase.strip.gsub(/\s+/, '-').gsub(/[^\w-]/, '')
+  }
+end
+
+def missing_slugs_rows(*collections)
+  collections.flat_map do |collection|
+    collection.find_all.map { |person| missing_slug_row(person, collection) }.compact
+  end
+end
+
+# Find any people without slugs and report them:
+def raise_if_missing_slugs(*collections)
+  rows = missing_slugs_rows(*collections)
+  return if rows.empty?
+  CSV.open('missing-slugs.csv', 'wb') do |csv|
+    csv << rows.first.keys
+    rows.each do |row|
+      csv << row.values
+    end
+  end
+  raise 'Some people were missing slugs: see missing-slugs.csv'
+end

--- a/lib/ep/people_by_legislature.rb
+++ b/lib/ep/people_by_legislature.rb
@@ -50,7 +50,21 @@ module EP
     end
 
     def slug_to_person
-      @slug_to_person ||= find_all.map { |person| [person.slug, person] }.to_h
+      @slug_to_person ||= find_all.each_with_object({}) { |person, memo| ensure_unique_slug(person, memo) }
+    end
+
+    def ensure_unique_slug(person, memo)
+      raise_if_no_slug(person)
+      raise_if_repeated_slug(person, memo)
+      memo[person.slug] = person
+    end
+
+    def raise_if_no_slug(person)
+      raise "No slug for #{person.name}" unless person.slug
+    end
+
+    def raise_if_repeated_slug(person, memo)
+      raise "Slug #{person.slug} repeated for #{memo[person.slug].name} and #{person.name}" if memo[person.slug]
     end
 
     def create_person(person)

--- a/lib/ep/people_by_legislature.rb
+++ b/lib/ep/people_by_legislature.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require_relative 'everypolitician_extensions'
-require_relative 'person'
+require_relative '../people_slug_to_person'
 
 module EP
   class PeopleByLegislature
@@ -8,6 +8,8 @@ module EP
       @legislature = legislature
       @person_factory = person_factory
     end
+
+    include PeopleSlugToPerson
 
     def find_all
       @find_all ||= people_sorted_by_name.map { |person| create_person(person) }
@@ -47,24 +49,6 @@ module EP
 
     def id_to_person
       @id_to_person ||= find_all.map { |person| [person.id, person] }.to_h
-    end
-
-    def slug_to_person
-      @slug_to_person ||= find_all.each_with_object({}) { |person, memo| ensure_unique_slug(person, memo) }
-    end
-
-    def ensure_unique_slug(person, memo)
-      raise_if_no_slug(person)
-      raise_if_repeated_slug(person, memo)
-      memo[person.slug] = person
-    end
-
-    def raise_if_no_slug(person)
-      raise "No slug for #{person.name}" unless person.slug
-    end
-
-    def raise_if_repeated_slug(person, memo)
-      raise "Slug #{person.slug} repeated for #{memo[person.slug].name} and #{person.name}" if memo[person.slug]
     end
 
     def create_person(person)

--- a/lib/ep/person.rb
+++ b/lib/ep/person.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require_relative '../person_proxy_images'
 require_relative '../person_social'
-require 'babosa'
 
 module EP
   class Person
@@ -46,7 +45,7 @@ module EP
     end
 
     def slug
-      person.identifier(identifier_scheme) || slugify_name
+      person.identifier(identifier_scheme)
     end
 
     private
@@ -64,10 +63,6 @@ module EP
     def proxy_image_base_url
       'https://theyworkforyou.github.io/shineyoureye-images' \
       "/#{legislature.slug}/#{id}/"
-    end
-
-    def slugify_name
-      name.to_slug.normalize.to_s if name
     end
   end
 end

--- a/lib/ep/person.rb
+++ b/lib/ep/person.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative '../person_proxy_images'
 require_relative '../person_social'
+require_relative '../person_slug'
 
 module EP
   class Person
@@ -19,6 +20,7 @@ module EP
 
     include PersonProxyImages
     include PersonSocial
+    include PersonSlug
 
     def wikipedia_url
       person.link('Wikipedia (en)')
@@ -44,7 +46,7 @@ module EP
       baseurl + slug + '/'
     end
 
-    def slug
+    def source_slug
       person.identifier(identifier_scheme)
     end
 

--- a/lib/membership_csv/people.rb
+++ b/lib/membership_csv/people.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'csv'
-require_relative 'person'
+require_relative '../people_slug_to_person'
 
 module MembershipCSV
   class People
@@ -8,6 +8,8 @@ module MembershipCSV
       @csv_filename = csv_filename
       @person_factory = person_factory
     end
+
+    include PeopleSlugToPerson
 
     def find_all
       all_people.sort_by(&:name)
@@ -47,24 +49,6 @@ module MembershipCSV
 
     def id_to_person
       @id_to_person ||= all_people.map { |person| [person.id, person] }.to_h
-    end
-
-    def slug_to_person
-      @slug_to_person ||= all_people.each_with_object({}) { |person, memo| ensure_unique_slug(person, memo) }
-    end
-
-    def ensure_unique_slug(person, memo)
-      raise_if_no_slug(person)
-      raise_if_repeated_slug(person, memo)
-      memo[person.slug] = person
-    end
-
-    def raise_if_no_slug(person)
-      raise "No slug for #{person.name}" unless person.slug
-    end
-
-    def raise_if_repeated_slug(person, memo)
-      raise "Slug #{person.slug} repeated for #{memo[person.slug].name} and #{person.name}" if memo[person.slug]
     end
 
     def mapit_id_to_person

--- a/lib/membership_csv/people.rb
+++ b/lib/membership_csv/people.rb
@@ -50,7 +50,21 @@ module MembershipCSV
     end
 
     def slug_to_person
-      @slug_to_person ||= all_people.map { |person| [person.slug, person] }.to_h
+      @slug_to_person ||= all_people.each_with_object({}) { |person, memo| ensure_unique_slug(person, memo) }
+    end
+
+    def ensure_unique_slug(person, memo)
+      raise_if_no_slug(person)
+      raise_if_repeated_slug(person, memo)
+      memo[person.slug] = person
+    end
+
+    def raise_if_no_slug(person)
+      raise "No slug for #{person.name}" unless person.slug
+    end
+
+    def raise_if_repeated_slug(person, memo)
+      raise "Slug #{person.slug} repeated for #{memo[person.slug].name} and #{person.name}" if memo[person.slug]
     end
 
     def mapit_id_to_person

--- a/lib/membership_csv/person.rb
+++ b/lib/membership_csv/person.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require_relative '../person_proxy_images'
 require_relative '../person_social'
-require 'babosa'
 
 module MembershipCSV
   class Person
@@ -64,7 +63,7 @@ module MembershipCSV
     end
 
     def slug
-      person["identifier__#{identifier_scheme}"] || slugify_name
+      person["identifier__#{identifier_scheme}"]
     end
 
     def url
@@ -82,10 +81,6 @@ module MembershipCSV
     def proxy_image_base_url
       'https://raw.githubusercontent.com/theyworkforyou/shineyoureye-images' \
       "/gh-pages/Governors/#{id}/"
-    end
-
-    def slugify_name
-      name.to_slug.normalize.to_s if name
     end
   end
 end

--- a/lib/membership_csv/person.rb
+++ b/lib/membership_csv/person.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative '../person_proxy_images'
 require_relative '../person_social'
+require_relative '../person_slug'
 
 module MembershipCSV
   class Person
@@ -13,6 +14,7 @@ module MembershipCSV
 
     include PersonProxyImages
     include PersonSocial
+    include PersonSlug
 
     def id
       person['id']
@@ -62,7 +64,7 @@ module MembershipCSV
       person['party']
     end
 
-    def slug
+    def source_slug
       person["identifier__#{identifier_scheme}"]
     end
 

--- a/lib/people_slug_to_person.rb
+++ b/lib/people_slug_to_person.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module PeopleSlugToPerson
+  private
+
+  def slug_to_person
+    @slug_to_person ||= find_all.each_with_object({}) { |person, memo| ensure_unique_slug(person, memo) }
+  end
+
+  def ensure_unique_slug(person, memo)
+    raise_if_no_slug(person)
+    raise_if_repeated_slug(person, memo)
+    memo[person.slug] = person
+  end
+
+  def raise_if_no_slug(person)
+    raise "No slug for #{person.name}" unless person.slug
+  end
+
+  def raise_if_repeated_slug(person, memo)
+    raise "Slug #{person.slug} repeated for #{memo[person.slug].name} and #{person.name}" if memo[person.slug]
+  end
+end

--- a/lib/person_slug.rb
+++ b/lib/person_slug.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module PersonSlug
+  def extra_slugs_filename
+    File.join(__dir__, '..', 'data', 'extra-slugs.csv')
+  end
+
+  # rubocop:disable Style/ClassVars
+  def extra_slugs
+    # This won't change over the lifetime of the app, so memoize it to
+    # a class variable to avoid frequent reloading. RuboCop objects to
+    # this for reasons that I don't think apply here.
+    @@extra_slugs ||= CSV.read(extra_slugs_filename,
+                               headers: true,
+                               header_converters: :symbol,
+                               converters: nil).map do |row|
+      [row[:uuid], row[:slug]]
+    end.to_h
+  end
+  # rubocop:enable Style/ClassVars
+
+  # This is a separate method to make it easy to replace in tests.
+  def extra_slug
+    extra_slugs[id]
+  end
+
+  def slug
+    source_slug || extra_slug
+  end
+end

--- a/tests/ep/people_by_legislature.rb
+++ b/tests/ep/people_by_legislature.rb
@@ -26,8 +26,13 @@ describe 'EP::PeopleByLegislature' do
     people.find_all.first.id.must_equal('b2a7f72a-9ecf-4263-83f1-cb0f8783053c')
   end
 
-  it 'finds a single person by slug' do
-    people.find_single('abdullahi-muhammed-wamakko').name.must_equal('ABDULLAHI MOHAMMED')
+  # it 'finds a single person by slug' do
+  #   people.find_single('abdullahi-muhammed-wamakko').name.must_equal('ABDULLAHI MOHAMMED')
+  # end
+
+  it 'throws an exception if a slug is missing' do
+    error = assert_raises(RuntimeError) { people.find_single('trigger') }
+    error.message.must_include('ABDUKADIR RAHIS')
   end
 
   it 'knows the start date of the current term' do

--- a/tests/ep/person.rb
+++ b/tests/ep/person.rb
@@ -205,9 +205,9 @@ describe 'EP::Person' do
       person.slug.must_equal('adamu-abdullahi')
     end
 
-    it 'dashifies the name if no slug' do
+    it 'returns nil if no slug' do
       person = ep_person('0b536a2c-2bc9-46a0-8d40-0deb9241cb31')
-      person.slug.must_equal('ahmad-abubakar')
+      assert_nil(person.slug)
     end
   end
 

--- a/tests/ep/person.rb
+++ b/tests/ep/person.rb
@@ -207,6 +207,9 @@ describe 'EP::Person' do
 
     it 'returns nil if no slug' do
       person = ep_person('0b536a2c-2bc9-46a0-8d40-0deb9241cb31')
+      def person.extra_slug
+        nil
+      end
       assert_nil(person.slug)
     end
   end

--- a/tests/membership_csv/people.rb
+++ b/tests/membership_csv/people.rb
@@ -39,6 +39,31 @@ id3,name3,name-3,'
     people.find_single('name-2').name.must_equal('name2')
   end
 
+  it 'throws an exception if a slug is missing' do
+    contents = 'id,name,identifier__shineyoureye,phone
+id1,name1,,1234'
+    people = MembershipCSV::People.new(
+      csv_filename: new_tempfile(contents),
+      person_factory: FakePersonFactory.new(FakeMapit.new(1))
+    )
+    error = assert_raises(RuntimeError) { people.find_single('trigger') }
+    error.message.must_include('name1')
+  end
+
+  it 'throws an exception if a slug is repeated' do
+    contents = 'id,name,identifier__shineyoureye,phone
+id1,name1,name-1,1234
+id2,name2,name-1,5678'
+    people = MembershipCSV::People.new(
+      csv_filename: new_tempfile(contents),
+      person_factory: FakePersonFactory.new(FakeMapit.new(1))
+    )
+    error = assert_raises(RuntimeError) { people.find_single('name-1') }
+    error.message.must_include('name-1')
+    error.message.must_include('name1')
+    error.message.must_include('name2')
+  end
+
   it 'does not know the start date of the current term' do
     assert_nil(people.current_term_start_date)
   end

--- a/tests/membership_csv/person.rb
+++ b/tests/membership_csv/person.rb
@@ -183,12 +183,12 @@ describe 'MembershipCSV::Person' do
       person.slug.must_equal('okezie-ikpeazu')
     end
 
-    it 'dashifies name if no slug' do
+    it 'returns nil if no slug' do
       person = morph_person(
         'name' => '$%^a&* /\b:;',
         'identifier__shineyoureye' => nil
       )
-      person.slug.must_equal('a-b')
+      assert_nil(person.slug)
     end
   end
 


### PR DESCRIPTION
This PR is needed because there was a bug in the `slug_to_person` method, that made us loose a person if they had the same slug as another person whose name was coming later in the alphabet.

This is because of how we were storing the slugs as keys. Now, before storing them, a check is made to ensure that
1) a slug exists
2) the slug is unique

if one of these requirements is not met, an error is raised, so that we fix the slugs upstream.

The tribal knowledge section of the contributing guide was updated to explain this.

## Related issues

Closes #162 

## Notes to merger

At the moment, there are persons with no slugs, so the integration tests are failing, until these persons are added a slug.

[This spreadsheet ](https://docs.google.com/spreadsheets/d/18DGJ2NpZbwmUfmod9veIK1IFht9xTEonRq0fASxfoR4/edit#gid=0)contains slug suggestions for members with no slug