### PR TITLE
Editing the title of a blog post should not make it 404

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -81,27 +81,19 @@ get '/' do
   summaries_finder = Document::Finder.new(pattern: summaries_pattern, baseurl: '')
   quote_finder = Document::Finder.new(pattern: info_pattern('quote-of-the-week'), baseurl: '')
   featured_summaries = summaries_finder.find_featured
-  people = [
+  featured_people = [
+    [governors, 'Governors', '/position/executive-governor/'],
+    [senators, 'Senators', '/position/senator/'],
+    [representatives, 'Representatives', '/position/representative/']
+  ].map do |collection, display_text, url|
     PageFragment::FeaturedPerson.new(
-      governors.featured_person(featured_summaries),
-      'Governors',
-      '/position/executive-governor/'
-    ),
-    PageFragment::FeaturedPerson.new(
-      senators.featured_person(featured_summaries),
-      'Senators',
-      '/position/senator/'
-    ),
-    PageFragment::FeaturedPerson.new(
-      representatives.featured_person(featured_summaries),
-      'Representatives',
-      '/position/representative/'
+      collection.featured_person(featured_summaries), display_text, url
     )
-  ]
+  end
   @page = Page::Homepage.new(
     posts: posts_finder.find_all,
     events: events_finder.find_all,
-    featured_people: people,
+    featured_people: featured_people,
     quote: quote_finder.find_single
   )
   erb :homepage

--- a/app.rb
+++ b/app.rb
@@ -102,7 +102,7 @@ get '/' do
     posts: posts_finder.find_all,
     events: events_finder.find_all,
     featured_people: people,
-    quote: quote_finder.find_single,
+    quote: quote_finder.find_single
   )
   erb :homepage
 end

--- a/lib/document/markdown_with_frontmatter.rb
+++ b/lib/document/markdown_with_frontmatter.rb
@@ -40,8 +40,7 @@ module Document
     end
 
     def slug
-      slug = frontmatter.slug
-      slug.empty? ? rawname : slug
+      rawname
     end
 
     private

--- a/tests/document/finder.rb
+++ b/tests/document/finder.rb
@@ -17,7 +17,8 @@ describe 'Document::Finder' do
 slug: a-slug
 ---'
     Dir.stub :glob, [new_tempfile(contents, filename)] do
-      finder.find_single.url.must_equal('/path/a-slug')
+      expected_slug = File.basename(Dir.glob[0], '.*')
+      finder.find_single.url.must_equal("/path/#{expected_slug}")
     end
   end
 

--- a/tests/document/markdown_with_frontmatter.rb
+++ b/tests/document/markdown_with_frontmatter.rb
@@ -24,7 +24,8 @@ eventdate: '2000-01-01 15:00 +0000'
   end
 
   it 'has a url' do
-    document.url.must_equal('/events/a-slug')
+    expected_slug = File.basename(document.send(:filename), '.*').gsub(/^1000-10-01-/, '')
+    document.url.must_equal("/events/#{expected_slug}")
   end
 
   it 'has a published field' do


### PR DESCRIPTION
We found a problem with the site which occurs in the following
situation:

 - Someone creates a new post in prose.io. (That creates a file
   in the repository with a filename baseed on slug of the post
   which is based on its title. The slug is stored in the post's
   YAML frontmatter as well.)

 - Someone edits the title of the post in prose.io. This changes
   the slug which is stored in the YAML frontmatter, but not the
   filename in the repository.)

In our code what was happening is that any list of multiple posts
(e.g. on the front page) would generate links based on the slug
in the YAML frontmatter. However, when looking up an individual
post for display, the slug in the URL is used to form a glob
pattern to find in the appropriate directory in the repository.

This means that changes in the title of a blog post in prose.io
can cause broken links on the site (and we currently don't
automatically deploy if any such broken links are found).

To fix this, this commit changes the slug which is returned by a
MarkdownWithFrontmatter document to be based on its filename, not
the slug found in its frontmatter.

Fixes #166
