### PR TITLE
Change search buttons to use type="submit"

### DIFF
--- a/views/_header.erb
+++ b/views/_header.erb
@@ -10,7 +10,7 @@
         <span class="input-group">
           <input name="pu-number" id="site-search" type="search" class="form-control" placeholder="e.g. 1:1:1">
           <span class="input-group-btn">
-            <button class="btn btn-primary" type="button"><i class="glyphicon glyphicon-search" aria-label="Search"></i></button>
+            <button class="btn btn-primary" type="submit"><i class="glyphicon glyphicon-search" aria-label="Search"></i></button>
           </span>
         </span>
       </p>

--- a/views/search.erb
+++ b/views/search.erb
@@ -4,7 +4,7 @@
     <p class="input-group">
         <input name="pu-number" id="search-input" type="search" class="form-control input-lg" placeholder="e.g. 1:1:1">
         <span class="input-group-btn">
-            <button class="btn btn-primary btn-lg" type="button"><i class="glyphicon glyphicon-search"></i> Search</button>
+            <button class="btn btn-primary btn-lg" type="submit"><i class="glyphicon glyphicon-search"></i> Search</button>
         </span>
     </p>
 </form>


### PR DESCRIPTION
We've had a report that the search buttons aren't working on mobile. We think this is because the buttons had `type="button"` rather than `type="submit"` on them.

This fix changes them to be proper submit buttons, which in my testing makes them work as expected.

Fixes #170 