### PR TITLE
Scrollable Twitter feed on homepage

### DIFF
--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -112,7 +112,7 @@
         <div style="text-align: center; margin-bottom: 1em;">
             <a class="btn btn-default" href="https://twitter.com/<%= settings.twitter_user %>">Shine Your Eye on Twitter</a>
         </div>
-        <a style="color: white !important;" class="twitter-timeline"  href="https://twitter.com/<%= settings.twitter_user %>" data-widget-id="661503293731000320" width="600px" data-chrome="nofooter noborders noheader noscrollbar transparent"  data-tweet-limit="1">Tweets by @<%= settings.twitter_user %></a>
+        <a style="color: white !important;" class="twitter-timeline"  href="https://twitter.com/<%= settings.twitter_user %>" data-widget-id="661503293731000320" data-width="600" data-height="400" data-chrome="nofooter noborders noheader transparent">Tweets by @<%= settings.twitter_user %></a>
         <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
       </div>
     </div>


### PR DESCRIPTION
Fixes #175.

Removes the 1-tweet limit from the homepage Twitter widget, meaning it now displays the entire Twitter timeline, in a scrollable container.

### Mobile

![screen shot 2018-04-20 at 15 10 04](https://user-images.githubusercontent.com/739624/39055822-19429b46-44ad-11e8-950d-88bf7304df12.png)

### Desktop

![screen shot 2018-04-20 at 15 10 29](https://user-images.githubusercontent.com/739624/39055827-1bb96bb6-44ad-11e8-8558-9b92cdec8d69.png)