### PR TITLE
Remove Polldaddy poll from homepage

### DIFF
--- a/lib/page/homepage.rb
+++ b/lib/page/homepage.rb
@@ -12,7 +12,7 @@ module Page
     end
 
     def featured_posts
-      posts.sort_by(&:date).reverse.first(3)
+      posts.sort_by(&:date).reverse.first(2)
     end
 
     def featured_events

--- a/public/stylesheets/sass/_homepage.scss
+++ b/public/stylesheets/sass/_homepage.scss
@@ -62,8 +62,3 @@
         display: block;
     }
 }
-
-.polldaddy {
-    width: 300px; // This is the width defined by PollDaddy-generated `.pds-box` element
-    margin: auto;
-}

--- a/tests/page/homepage.rb
+++ b/tests/page/homepage.rb
@@ -21,8 +21,8 @@ describe 'Page::Homepage' do
       first_is_newer.must_equal(true)
     end
 
-    it 'has a maximum of three featured posts' do
-      page.featured_posts.count(3)
+    it 'has a maximum of two featured posts' do
+      page.featured_posts.count(2)
     end
   end
 

--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -40,38 +40,24 @@
   </div>
 </div>
 
-<% if @page.featured_events.empty? %>
-  <% @colwidth = 6 %>
-<% else %>
-  <% @colwidth = 4 %>
-<% end %>
-
 <div class="page-section">
   <div class="container">
     <div class="row">
-
-      <div class="col-sm-<%= @colwidth %>">
-        <h2><a href="/blog/">News</a></h2>
+      <div class="col-sm-<% if @page.featured_events.empty? %>12<% else %>8<% end %>">
         <% unless @page.featured_posts.empty? %>
-          <% @page.featured_posts.each do |post| %>
-            <a href="<%= post.url %>"><h3><%= post.title %></h3></a>
-            <p><%= @page.format_date(post.date) %></p>
-          <% end %>
-        <% else %>
-          <p>There are no blog posts.</p>
+          <h2><a href="/blog/">News</a></h2>
+          <div class="row">
+            <% @page.featured_posts.each do |post| %>
+              <div class="col-sm-6">
+                <a href="<%= post.url %>"><h3><%= post.title %></h3></a>
+                <p><%= @page.format_date(post.date) %></p>
+              </div>
+            <% end %>
+          </div>
         <% end %>
       </div>
-
-      <div class="col-sm-<%= @colwidth %>">
-        <div id="polldaddy" class="polldaddy">
-          <h2>Latest Poll</h2>
-          <script type="text/javascript" charset="utf-8" src="https://static.polldaddy.com/w/57906.js"></script>
-          <noscript><a href="https://polldaddy.com/w.php?p=57906">Take Our Poll</a></noscript>
-        </div>
-      </div>
-
       <% unless @page.featured_events.empty? %>
-        <div class="col-sm-<%= @colwidth %>">
+        <div class="col-sm-4">
           <h2><a href="/events/">Events</a></h2>
           <% @page.featured_events.each do |event| %>
             <a href="<%= event.url %>"><h3><%= event.title %></h3></a>
@@ -79,7 +65,6 @@
           <% end %>
         </div>
       <% end %>
-
     </div>
   </div>
 </div>


### PR DESCRIPTION
The space freed up by removing the poll allows us to spread the blog posts across two columns.

Fixes #181.

![screen shot 2018-10-04 at 14 20 35](https://user-images.githubusercontent.com/739624/46476700-ba7a9e80-c7e0-11e8-988c-92d3d6ad1d5c.png)
