### PR TITLE
Upgrade Ruby to 2.5.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   Exclude:
     - build/**/*
     - vendor/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ script:
   - bundle exec rake
 sudo: false
 rvm:
-  - 2.3.1
+  - 2.5.3

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@
 
 source 'https://rubygems.org'
 
-# Warning: update the README and TargetRubyVersion in .rubocop.yml if
-# this version is changed:
+# Warning: update the README, .travis.yml and TargetRubyVersion in .rubocop.yml
+# if this version is changed:
 ruby '2.3.1'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 # Warning: update the README, .travis.yml and TargetRubyVersion in .rubocop.yml
 # if this version is changed:
-ruby '2.3.1'
+ruby '2.5.3'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
@@ -23,5 +23,5 @@ group :test do
   gem 'pry'
   gem 'rack-test'
   gem 'rubocop'
-  gem 'webmock'
+  gem 'webmock', '~> 3.4.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,10 +134,10 @@ DEPENDENCIES
   sass
   sinatra
   sinatra-contrib
-  webmock
+  webmock (~> 3.4.2)
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.5.3p105
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ For example, if you are using
 [rbenv](https://cbednarski.com/articles/installing-ruby/):
 
 1. Install the right Ruby version. That would be the version specified at the
-beginning of the Gemfile. For example, if it was `ruby '2.3.1'`, you would type:
+beginning of the Gemfile. For example, if it was `ruby '2.5.3'`, you would type:
 ```bash
-rbenv install 2.3.1
+rbenv install 2.5.3
 rbenv rehash
 ```
 2. Then you would move to the root directory of this project and type:
 ```bash
-rbenv local 2.3.1
+rbenv local 2.5.3
 ruby -v
 ```
 

--- a/bin/build_summaries.rb
+++ b/bin/build_summaries.rb
@@ -45,7 +45,7 @@ end
 def format_date(partial_iso8601)
   return partial_iso8601 if partial_iso8601 =~ /^\d{4}$/
 
-  if /^\d{4}-\d{2}/ =~ partial_iso8601
+  if /^\d{4}-\d{2}/.match?(partial_iso8601)
     d = Date.parse(partial_iso8601 + '-01')
     return d.strftime('%B %Y')
   end


### PR DESCRIPTION
The current version of Ruby, 2.3.1, is "In security maintenance phase (will EOL soon!)", so upgrade to the newest available stable version of Ruby.

I had to update Webmock as well because the version we were on is incompatible with Ruby >= 2.4, see bblimke/webmock#683.

Fixes https://github.com/theyworkforyou/shineyoureye-sinatra/issues/203