### PR TITLE
Add Mapit::Place#state method

### DIFF
--- a/lib/mapit/place.rb
+++ b/lib/mapit/place.rb
@@ -25,6 +25,14 @@ module Mapit
 
     alias child_area? parent
 
+    def state
+      if type_name == 'State'
+        self
+      elsif parent && parent.type_name == 'State'
+        parent
+      end
+    end
+
     def url
       "#{baseurl}#{pombola_slug}/"
     end

--- a/tests/mapit/place.rb
+++ b/tests/mapit/place.rb
@@ -53,6 +53,30 @@ describe 'Place' do
     it 'the parent knows it is not a child' do
       refute(place.parent.child_area?)
     end
+
+    describe '#state' do
+      it 'returns the parent object if that is a state' do
+        place.parent.type_name.must_equal('State')
+        place.state.must_equal(place.parent)
+      end
+    end
+  end
+
+  describe 'state with no parent' do
+    let(:place) do
+      Mapit::Place.new(
+        mapit_area_data: area_with_no_parent,
+        pombola_slug: 'gwagwaladakuje',
+        baseurl: '/baseurl/'
+      )
+    end
+
+    describe '#state' do
+      it 'returns the current object' do
+        place.type_name.must_equal('State')
+        place.state.must_equal(place)
+      end
+    end
   end
 
   def area_with_parent


### PR DESCRIPTION
This makes it easier to get the state for an area, without having to worry about what kind of area you're dealing with. This should make it easier to do https://github.com/theyworkforyou/shineyoureye-sinatra/issues/117, which needs to group people by state.

Fixes https://github.com/theyworkforyou/shineyoureye-sinatra/issues/195