### PR TITLE
Combine blog and social sections on homepage

### DIFF
--- a/public/stylesheets/sass/_bootstrap.scss
+++ b/public/stylesheets/sass/_bootstrap.scss
@@ -41,7 +41,7 @@
 @import "bootstrap/media";
 // @import "bootstrap/list-group";
 @import "bootstrap/panels";
-// @import "bootstrap/responsive-embed";
+@import "bootstrap/responsive-embed";
 // @import "bootstrap/wells";
 // @import "bootstrap/close";
 

--- a/public/stylesheets/sass/_homepage.scss
+++ b/public/stylesheets/sass/_homepage.scss
@@ -38,7 +38,3 @@
         margin-bottom: 1em;
     }
 }
-
-.homepage__social {
-    border-top: 1px solid #ddd;
-}

--- a/tests/web/homepage.rb
+++ b/tests/web/homepage.rb
@@ -56,7 +56,6 @@ describe 'Homepage' do
 
   describe 'twitter widget' do
     it 'links to the site twitter account' do
-      subject.css('.btn-default/@href').text.must_include('NGShineYourEye')
       subject.css('.twitter-timeline/@href').text.must_include('NGShineYourEye')
     end
 

--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -43,44 +43,29 @@
 <div class="page-section">
   <div class="container">
     <div class="row">
-      <div class="col-sm-<% if @page.featured_events.empty? %>12<% else %>8<% end %>">
+      <div class="col-sm-6">
         <% unless @page.featured_posts.empty? %>
           <h2><a href="/blog/">News</a></h2>
-          <div class="row">
-            <% @page.featured_posts.each do |post| %>
-              <div class="col-sm-6">
-                <a href="<%= post.url %>"><h3><%= post.title %></h3></a>
-                <p><%= @page.format_date(post.date) %></p>
-              </div>
-            <% end %>
-          </div>
+          <% @page.featured_posts.each do |post| %>
+            <a href="<%= post.url %>"><h3><%= post.title %></h3></a>
+            <p><%= @page.format_date(post.date) %></p>
+          <% end %>
         <% end %>
-      </div>
-      <% unless @page.featured_events.empty? %>
-        <div class="col-sm-4">
+        <% unless @page.featured_events.empty? %>
           <h2><a href="/events/">Events</a></h2>
           <% @page.featured_events.each do |event| %>
             <a href="<%= event.url %>"><h3><%= event.title %></h3></a>
             <p><%= @page.format_date(event.date) %></p>
           <% end %>
+        <% end %>
+        <h2 style="margin-top: 1.2em"><a href="https://www.youtube.com/watch?v=NDSIJfYWgko">How it works</a></h2>
+        <div class="embed-responsive embed-responsive-16by9">
+          <iframe src="https://www.youtube.com/embed/NDSIJfYWgko" frameborder="0" allowfullscreen></iframe>
         </div>
-      <% end %>
-    </div>
-  </div>
-</div>
-
-
-<div class="page-section homepage__social">
-  <div class="container">
-    <div class="row">
-      <div class="col-sm-6">
-        <iframe style="width: 100%; height: 315px; margin-bottom: 1em;" src="https://www.youtube.com/embed/NDSIJfYWgko" frameborder="0" allowfullscreen></iframe>
       </div>
       <div class="col-sm-6">
-        <div style="text-align: center; margin-bottom: 1em;">
-            <a class="btn btn-default" href="https://twitter.com/<%= settings.twitter_user %>">Shine Your Eye on Twitter</a>
-        </div>
-        <a style="color: white !important;" class="twitter-timeline"  href="https://twitter.com/<%= settings.twitter_user %>" data-widget-id="661503293731000320" data-width="600" data-height="400" data-chrome="nofooter noborders noheader transparent">Tweets by @<%= settings.twitter_user %></a>
+        <h2><a href="https://twitter.com/<%= settings.twitter_user %>">Twitter</a></h2>
+        <a class="twitter-timeline"  href="https://twitter.com/<%= settings.twitter_user %>" data-widget-id="661503293731000320" data-width="600" data-height="600" data-chrome="nofooter noborders noheader transparent">Tweets by @<%= settings.twitter_user %></a>
         <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
       </div>
     </div>


### PR DESCRIPTION
Putting the blog posts and video into a single column means the twitter timeline can be much taller, beside the two of them, rather than being limited to the height of the video alone.

This commit also makes the height of the video responsive to its width, so it looks more natural on medium and small screens.

Fixes #180.

# Wide screens

![screenshot_2018-10-18 shine your eye](https://user-images.githubusercontent.com/739624/47148096-b2822a80-d2c7-11e8-9702-d2f6978900bd.png)

# Medium screens

![screenshot_2018-10-18 shine your eye 1](https://user-images.githubusercontent.com/739624/47148103-b57d1b00-d2c7-11e8-8b67-4ca4423013c7.png)

# Small screens

![screenshot_2018-10-18 shine your eye 2](https://user-images.githubusercontent.com/739624/47148110-bb72fc00-d2c7-11e8-9245-6814f32d42fd.png)
