### PR TITLE
Enable general site search, not just PU number lookups

### DIFF
--- a/public/javascripts/multipurpose-search.js
+++ b/public/javascripts/multipurpose-search.js
@@ -1,0 +1,46 @@
+var looksLikePuNumber = function(str) {
+    return /^[0-9.:/-]+$/.test(str);
+};
+
+var parseParams = function (str) {
+    return str.split('&').reduce( function(params, param) {
+        var paramSplit = param.split('=').map( function(value) {
+            return decodeURIComponent(value.replace(/\+/g, ' '));
+        });
+        params[paramSplit[0]] = paramSplit[1];
+        return params;
+    }, {});
+};
+
+var getQueryStringValue = function (key) {
+    if ( window.location.search ) {
+        var params = parseParams( window.location.search.substr(1) );
+        if ( params.hasOwnProperty(key) ) {
+            return params[key];
+        }
+    }
+    return '';
+};
+
+$(function() {
+    $('.js-multipurpose-search').each( function() {
+        var $form = $(this);
+        var $q = $form.find('input[type="search"]');
+        var $label = $form.find('.js-multipurpose-search-label');
+
+        $form.on('submit', function(e) {
+            var q = $.trim( $q.val() );
+            if ( ! looksLikePuNumber(q) ) {
+                e.preventDefault();
+                window.location.href = '/search/?' + $.param({q: q});
+            }
+        });
+
+        $label.text('Enter a name, location, or Polling Unit (PU) number');
+
+        var q = getQueryStringValue('q');
+        if ( q ) {
+            $q.val(q);
+        }
+    });
+});

--- a/views/_footer.erb
+++ b/views/_footer.erb
@@ -24,6 +24,7 @@
 <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
 <script src="/javascripts/jquery-ui-1.11.4.custom/jquery-ui.min.js"></script>
 <script src="/javascripts/bootstrap/bootstrap.min.js"></script>
+<script src="/javascripts/multipurpose-search.js"></script>
 <script>
   (function() {
     var cx = '009849292720701569670:dnm2ccnvkai';

--- a/views/_footer.erb
+++ b/views/_footer.erb
@@ -24,4 +24,15 @@
 <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
 <script src="/javascripts/jquery-ui-1.11.4.custom/jquery-ui.min.js"></script>
 <script src="/javascripts/bootstrap/bootstrap.min.js"></script>
+<script>
+  (function() {
+    var cx = '009849292720701569670:dnm2ccnvkai';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
 <%= yield_content :footer_extra_js %>

--- a/views/_header.erb
+++ b/views/_header.erb
@@ -1,10 +1,10 @@
 <div class="site-header">
   <div class="container">
 
-    <form class="site-header__search" action="https://sye-pu-lookup-frontend.herokuapp.com/lookup" method="post">
+    <form class="site-header__search js-multipurpose-search" action="https://sye-pu-lookup-frontend.herokuapp.com/lookup" method="post">
       <label for="site-search">
         <strong>Find your representative</strong>
-        <span>Enter your Polling Unit (PU) number</span>
+        <span class="js-multipurpose-search-label">Enter your Polling Unit (PU) number</span>
       </label>
       <p>
         <span class="input-group">

--- a/views/search.erb
+++ b/views/search.erb
@@ -8,3 +8,9 @@
         </span>
     </p>
 </form>
+
+<div class="row">
+    <div class="col-md-10 col-md-push-1">
+        <gcse:searchresults-only></gcse:searchresults-only>
+    </div>
+</div>

--- a/views/search.erb
+++ b/views/search.erb
@@ -1,6 +1,6 @@
-<form class="big-form big-form--short" action="https://sye-pu-lookup-frontend.herokuapp.com/lookup" method="post">
+<form class="big-form big-form--short js-multipurpose-search" action="https://sye-pu-lookup-frontend.herokuapp.com/lookup" method="post">
     <h1>Find your representative</h1>
-    <label for="search-input">Enter your Polling Unit (PU) number</label>
+    <label for="search-input" class="js-multipurpose-search-label">Enter your Polling Unit (PU) number</label>
     <p class="input-group">
         <input name="pu-number" id="search-input" type="search" class="form-control input-lg" placeholder="e.g. 1:1:1">
         <span class="input-group-btn">


### PR DESCRIPTION
Client-side handling of generic search terms, in the "PU number" search box, via Google Custom Search.

Fixes #113.

![image](https://user-images.githubusercontent.com/739624/47207106-4dd7d600-d382-11e8-8427-71b80b84e80a.png)

`009849292720701569670:dnm2ccnvkai` is the ID of the Custom Search Engine I had to create to get it working. Annoyingly, it doesn’t seem possible to create these under an "organisational" account, only a personal one. So right now it’s "owned" by my @mysociety.org Google account. I can invite other Google accounts as administrators, but they won’t be able to invite more users. I wonder whether there’s a better account we should be storing this CSE under?