### PR TITLE
Homepage search box

### DIFF
--- a/public/stylesheets/sass/_forms.scss
+++ b/public/stylesheets/sass/_forms.scss
@@ -24,3 +24,7 @@
         margin-bottom: 5em;
     }
 }
+
+.search-results {
+    margin-top: 2em;
+}

--- a/public/stylesheets/sass/_homepage.scss
+++ b/public/stylesheets/sass/_homepage.scss
@@ -17,6 +17,41 @@
 
 .homepage__hero__secondary {
     text-align: center;
+
+    img {
+        @media (min-width: $screen-sm-min) {
+            margin-top: 2em; // roughly vertically centred in parent
+        }
+    }
+}
+
+.homepage__hero__search {
+    margin-bottom: 24px; // match .homepage__hero margin-top
+
+    label {
+        strong {
+            display: block;
+            font-size: 1.2em;
+            margin: 0.5em 0 0 0;
+        }
+
+        span {
+            display: block;
+            margin: 0 0 0.2em 0;
+            font-weight: normal;
+        }
+    }
+
+    .input-group {
+        max-width: 28em;
+    }
+
+    @media (min-width: $screen-lg-min) {
+        .input-group-btn .btn {
+            padding-left: 1.5em;
+            padding-right: 1.5em;
+        }
+    }
 }
 
 .homepage__reps {

--- a/public/stylesheets/sass/_site-header.scss
+++ b/public/stylesheets/sass/_site-header.scss
@@ -4,13 +4,11 @@
     background-color: $site-header-background-color;
     padding-top: 1em;
     padding-bottom: 1em;
-}
 
-//.page--homepage {
-//    .site-header {
-//        display: none;
-//    }
-//}
+    .page--homepage & {
+        display: none; // homepage has its own search box in the .homepage__hero
+    }
+}
 
 .site-header__search {
     font-size: 14px;

--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -6,9 +6,18 @@
       </div>
       <div class="col-sm-7 homepage__hero__primary">
         <h1><strong>Shine Your Eye</strong> is an SMS and web platform that facilitates engagement with National Assembly members and other elected officials.</h1>
-        <a class="btn btn-primary" href="/search/">
-          Find your Representative
-        </a>
+        <form class="homepage__hero__search js-multipurpose-search" action="https://sye-pu-lookup-frontend.herokuapp.com/lookup" method="post">
+          <label for="site-search">
+            <strong>Find your representative</strong>
+            <span class="js-multipurpose-search-label">Enter your Polling Unit (PU) number</span>
+          </label>
+          <span class="input-group input-group-lg">
+            <input name="pu-number" id="site-search" type="search" class="form-control" placeholder="e.g. 1:1:1">
+            <span class="input-group-btn">
+              <button class="btn btn-primary" type="submit"><i class="glyphicon glyphicon-search" aria-label="Search"></i></button>
+            </span>
+          </span>
+        </form>
       </div>
     </div>
   </div>

--- a/views/search.erb
+++ b/views/search.erb
@@ -1,4 +1,4 @@
-<form class="big-form big-form--short js-multipurpose-search" action="https://sye-pu-lookup-frontend.herokuapp.com/lookup" method="post">
+<form class="big-form js-multipurpose-search" action="https://sye-pu-lookup-frontend.herokuapp.com/lookup" method="post">
     <h1>Find your representative</h1>
     <label for="search-input" class="js-multipurpose-search-label">Enter your Polling Unit (PU) number</label>
     <p class="input-group">
@@ -9,7 +9,7 @@
     </p>
 </form>
 
-<div class="row">
+<div class="row search-results">
     <div class="col-md-10 col-md-push-1">
         <gcse:searchresults-only></gcse:searchresults-only>
     </div>


### PR DESCRIPTION
Fixes #183. Avoids the duplication of the header search box and the "Find your Representative" button on the homepage.

Also, while I was there, I improved the vertical spacing on the search results page, so the form doesn’t appear so far from the top of the page.

## Screenshots

![screen shot 2018-11-06 at 11 14 40](https://user-images.githubusercontent.com/739624/48060919-3a67a000-e1b5-11e8-88a4-0302781e82fb.png)

![image](https://user-images.githubusercontent.com/739624/48060848-08eed480-e1b5-11e8-80f5-c7f2181c2db5.png)

![image](https://user-images.githubusercontent.com/739624/48060768-d0e79180-e1b4-11e8-8aa7-5a16d6acc298.png)
