### PR TITLE
Tell Rubocop to ignore builds/ directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: 2.3
+  Exclude:
+    - build/**/*
 
 Metrics/LineLength:
   Max: 120

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
   TargetRubyVersion: 2.3
   Exclude:
     - build/**/*
+    - vendor/**/*
 
 Metrics/LineLength:
   Max: 120


### PR DESCRIPTION
Every time you do a deploy a static version of the site is added to the `builds/` directory. Over time this directory becomes huge and contains loads of files. When Rubocop runs it scans all files looking for ones that look like Ruby files. This means that Rubocop takes ages to start when you have a big builds/ directory. So to fix this just tell Rubocop to ignore everything in that directory.

I've also ignored the vendor directory to avoid failures on Travis. See the commit message for more details.