### PR TITLE
Need to change sye-prose when updating Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@
 
 source 'https://rubygems.org'
 
-# Warning: update the README, .travis.yml and TargetRubyVersion in .rubocop.yml
-# if this version is changed:
+# Warning: update the README, .travis.yml, TargetRubyVersion in .rubocop.yml
+# and .travis.yml in shineyoureye-prose if this version is changed:
 ruby '2.5.3'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }


### PR DESCRIPTION
I had to update the version of Ruby in `.travis.yml` in the shineyoureye-prose repo to reflect the Ruby version bump in this repo in https://github.com/theyworkforyou/shineyoureye-prose/commit/2223ef882e4bd4455886074afdebedf5f5fb86a3. Update the docs to mention that.