### PR TITLE
Make email on politician profile plain text

### DIFF
--- a/tests/web/person.rb
+++ b/tests/web/person.rb
@@ -102,13 +102,8 @@ describe 'Person Page' do
   describe 'when person has an email' do
     before { get '/person/adamu-abdullahi/' }
 
-    it 'links to the email' do
-      subject.css('.person__email a/@href').first.text
-             .must_equal('mailto:adamu.abdullahi@gmail.com')
-    end
-
     it 'displays the email' do
-      subject.css('.person__email a').first.text
+      subject.css('.person__email').first.text
              .must_equal('adamu.abdullahi@gmail.com')
     end
   end

--- a/views/person.erb
+++ b/views/person.erb
@@ -44,7 +44,7 @@
 
           <% if @page.person.email %>
             <h2>Email</h2>
-            <p class="person__email"><a href="<%= @page.person.email_url %>"><%= @page.person.email %></a></p>
+            <p class="person__email"><%= @page.person.email %></p>
           <% end %>
 
           <% if @page.person.wikipedia_url %>


### PR DESCRIPTION
Our partners have told us that having this as a link is confusing because their mail client isn't setup properly, so it doesn't work as expected.

They originally asked us if we could add a contact form to this page, but that's going to take a lot of time and add a lot of complexity. So as an alternative solution we're simply making the email plain text, which makes it easier to simply copy/paste it into your email client.

Fixes #187 

---

![image](https://user-images.githubusercontent.com/22996/49436579-6294ef80-f7b1-11e8-911b-86e209147e30.png)
