### PR TITLE
Show random people of each type on homepage

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -80,21 +80,12 @@ all_people = representatives.find_all + senators.find_all + governors.find_all
 get '/' do
   posts_finder = Document::Finder.new(pattern: posts_pattern, baseurl: '/blog/')
   events_finder = Document::Finder.new(pattern: events_pattern, baseurl: '/events/')
-  summaries_finder = Document::Finder.new(pattern: summaries_pattern, baseurl: '')
-  featured_summaries = summaries_finder.find_featured
-  featured_people = [
-    [governors, 'Governors', '/position/executive-governor/'],
-    [senators, 'Senators', '/position/senator/'],
-    [representatives, 'Representatives', '/position/representative/']
-  ].map do |collection, display_text, url|
-    PageFragment::FeaturedPerson.new(
-      collection.featured_person(featured_summaries), display_text, url
-    )
-  end
   @page = Page::Homepage.new(
     posts: posts_finder.find_all,
     events: events_finder.find_all,
-    featured_people: featured_people
+    governors: governors,
+    senators: senators,
+    representatives: representatives
   )
   erb :homepage
 end

--- a/lib/page/homepage.rb
+++ b/lib/page/homepage.rb
@@ -2,12 +2,14 @@
 
 module Page
   class Homepage
-    attr_reader :featured_people
+    RANDOM_PERSON_COUNT_PER_TYPE = 10
 
-    def initialize(posts:, events:, featured_people:)
+    def initialize(posts:, events:, governors:, senators:, representatives:)
       @posts = posts
       @events = events
-      @featured_people = featured_people
+      @governors = governors
+      @senators = senators
+      @representatives = representatives
     end
 
     def featured_posts
@@ -26,9 +28,17 @@ module Page
       date.strftime('%B %-d, %Y')
     end
 
+    def government_representative_types
+      [
+        build_representative_type(governors, 'Governors', '/position/executive-governor/'),
+        build_representative_type(senators, 'Senators', '/position/senator/'),
+        build_representative_type(representatives, 'Representatives', '/position/representative/')
+      ]
+    end
+
     private
 
-    attr_reader :posts, :events
+    attr_reader :posts, :events, :governors, :senators, :representatives
 
     def future_events
       events.select do |event|
@@ -39,6 +49,18 @@ module Page
 
     def raise_error_if_no_event_date(event)
       raise "No event date for #{event.title}" unless event.event_date
+    end
+
+    def sample_collection(collection, count = 1)
+      collection.find_all.reject { |item| item.image.nil? }.sample(count)
+    end
+
+    def build_representative_type(collection, link_text, link_url)
+      OpenStruct.new(
+        people: sample_collection(collection, RANDOM_PERSON_COUNT_PER_TYPE),
+        link_text: link_text,
+        link_url: link_url
+      )
     end
   end
 end

--- a/public/javascripts/show-random-child.js
+++ b/public/javascripts/show-random-child.js
@@ -1,0 +1,21 @@
+$.fn.random = function() {
+    var randomIndex = Math.floor(Math.random() * this.length);
+    return $( this[randomIndex] );
+};
+
+$.fn.loadLazyImage = function() {
+    if ( $(this).attr('data-src') && ! $(this).attr('src') ) {
+        $(this).attr('src', $(this).attr('data-src'));
+    }
+};
+
+$(function(){
+    $('.js-show-random-child').each(function(){
+        var $children = $(this).children();
+        $children.addClass('hidden');
+
+        var $randomChild = $children.random();
+        $randomChild.removeClass('hidden');
+        $randomChild.find('[data-src]').loadLazyImage();
+    });
+});

--- a/tests/page/homepage.rb
+++ b/tests/page/homepage.rb
@@ -13,7 +13,9 @@ describe 'Page::Homepage' do
       document_with_event_date('1000-01-15-qux', in_two_weeks.to_s)
     ]
   end
-  let(:page) { Page::Homepage.new(posts: documents, events: documents, featured_people: %w[foo bar]) }
+  let(:page) do
+    Page::Homepage.new(posts: documents, events: documents, governors: [], senators: [], representatives: [])
+  end
 
   describe 'featured posts' do
     it 'sorts featured posts from newer to older' do
@@ -43,7 +45,7 @@ describe 'Page::Homepage' do
     end
 
     it 'detects that there are no featured events' do
-      page = Page::Homepage.new(posts: documents, events: [], featured_people: [])
+      page = Page::Homepage.new(posts: documents, events: [], governors: [], senators: [], representatives: [])
       page.no_events?.must_equal(true)
     end
 
@@ -51,14 +53,14 @@ describe 'Page::Homepage' do
       document = basic_document(new_tempfile("---
 title: A Title
 ---", '2000-20-02-file-name'))
-      page = Page::Homepage.new(posts: [], events: [document], featured_people: [])
+      page = Page::Homepage.new(posts: [], events: [document], governors: [], senators: [], representatives: [])
       error = assert_raises(RuntimeError) { page.featured_events }
       error.message.must_include('A Title')
     end
   end
 
-  it 'has the featured people' do
-    page.featured_people.count.must_equal(2)
+  it 'has the government representative types' do
+    page.government_representative_types.count.must_equal(3)
   end
 
   it 'formats the date' do

--- a/tests/web/homepage.rb
+++ b/tests/web/homepage.rb
@@ -7,44 +7,58 @@ describe 'Homepage' do
   subject { Nokogiri::HTML(last_response.body) }
 
   describe 'featured people' do
-    let(:person) { subject.css('.homepage__reps__rep').first }
+    let(:governors) { subject.css('.homepage__reps .col-sm-4')[0] }
+    let(:senators) { subject.css('.homepage__reps .col-sm-4')[1] }
+    let(:representatives) { subject.css('.homepage__reps .col-sm-4')[2] }
 
-    it 'displays the person medium size image' do
-      person.css('img/@src').text
-            .must_include('250x250.jpeg')
+    it 'displays a medium size image for the first person of each type' do
+      governors.css('.homepage__reps__rep').first.css('img/@src').text
+               .must_include('250x250.jpeg')
+      senators.css('.homepage__reps__rep').first.css('img/@src').text
+              .must_include('250x250.jpeg')
+      representatives.css('.homepage__reps__rep').first.css('img/@src').text
+                     .must_include('250x250.jpeg')
+    end
+
+    it 'hides all but the first person of each type' do
+      governors.css('.homepage__reps__rep/@class')[2].text
+               .must_include('hidden')
+      governors.css('.homepage__reps__rep img/@src')[2]
+               .must_be_nil
+      senators.css('.homepage__reps__rep/@class')[4].text
+              .must_include('hidden')
+      senators.css('.homepage__reps__rep img/@src')[4]
+              .must_be_nil
+      representatives.css('.homepage__reps__rep/@class')[0].text
+                     .wont_include('hidden')
+      representatives.css('.homepage__reps__rep img/@src')[0]
+                     .wont_be_nil
     end
 
     it 'displays all types of people' do
-      subject.css('.homepage__reps__rep .btn-default').map(&:text).map(&:strip).uniq.sort
+      subject.css('.homepage__reps .btn-default').map(&:text).map(&:strip).uniq.sort
              .must_equal(%w[Governors Representatives Senators])
     end
 
-    it 'displays link to Governors' do
-      person.css('.btn-default/@href').text.must_equal('/position/executive-governor/')
+    it 'displays a link to Governors' do
+      governors.css('.btn-default/@href')[0].text
+               .must_equal('/position/executive-governor/')
+      governors.css('.btn-default')[0].text.strip
+               .must_equal('Governors')
     end
 
-    it 'displays the Governors label' do
-      person.css('.btn-default').text.strip.must_equal('Governors')
-    end
-
-    it 'displays link to Senators' do
-      subject.css('.homepage__reps__rep .btn-default/@href')[10].text
-             .must_equal('/position/senator/')
-    end
-
-    it 'displays the Senators label' do
-      subject.css('.homepage__reps__rep .btn-default')[10].text.strip
-             .must_equal('Senators')
+    it 'displays a link to Senators' do
+      senators.css('.btn-default/@href')[0].text
+              .must_equal('/position/senator/')
+      senators.css('.btn-default')[0].text.strip
+              .must_equal('Senators')
     end
 
     it 'displays link to Representatives' do
-      subject.css('.homepage__reps__rep .btn-default/@href')[20].text
-             .must_equal('/position/representative/')
-    end
-
-    it 'displays the Representatives label' do
-      subject.css('.homepage__reps__rep .btn-default')[20].text.strip
-             .must_equal('Representatives')
+      representatives.css('.btn-default/@href')[0].text
+                     .must_equal('/position/representative/')
+      representatives.css('.btn-default')[0].text.strip
+                     .must_equal('Representatives')
     end
   end
 

--- a/tests/web/homepage.rb
+++ b/tests/web/homepage.rb
@@ -7,7 +7,7 @@ describe 'Homepage' do
   subject { Nokogiri::HTML(last_response.body) }
 
   describe 'featured people' do
-    let(:person) { subject.css('.homepage__reps__rep').last }
+    let(:person) { subject.css('.homepage__reps__rep').first }
 
     it 'displays the person medium size image' do
       person.css('img/@src').text
@@ -17,6 +17,14 @@ describe 'Homepage' do
     it 'displays all types of people' do
       subject.css('.homepage__reps__rep .btn-default').map(&:text).map(&:strip).uniq.sort
              .must_equal(%w[Governors Representatives Senators])
+    end
+
+    it 'displays link to Governors' do
+      person.css('.btn-default/@href').text.must_equal('/position/executive-governor/')
+    end
+
+    it 'displays the Governors label' do
+      person.css('.btn-default').text.strip.must_equal('Governors')
     end
 
     it 'displays link to Senators' do
@@ -30,11 +38,13 @@ describe 'Homepage' do
     end
 
     it 'displays link to Representatives' do
-      person.css('.btn-default/@href').text.must_equal('/position/representative/')
+      subject.css('.homepage__reps__rep .btn-default/@href')[20].text
+             .must_equal('/position/representative/')
     end
 
     it 'displays the Representatives label' do
-      person.css('.btn-default').text.strip.must_equal('Representatives')
+      subject.css('.homepage__reps__rep .btn-default')[20].text.strip
+             .must_equal('Representatives')
     end
   end
 

--- a/tests/web/homepage.rb
+++ b/tests/web/homepage.rb
@@ -9,39 +9,23 @@ describe 'Homepage' do
   describe 'featured people' do
     let(:person) { subject.css('.homepage__reps__rep').last }
 
-    it 'links to the person page' do
-      person.css('a/@href').first.text
-            .must_equal('/person/abdukadir-rahis/')
-    end
-
     it 'displays the person medium size image' do
       person.css('img/@src').text
-            .must_include('/b2a7f72a-9ecf-4263-83f1-cb0f8783053c/250x250.jpeg')
-    end
-
-    it 'displays the person name' do
-      person.css('p strong').text.must_equal('ABDUKADIR RAHIS')
-    end
-
-    it 'displays the person party name' do
-      person.css('p').text.must_include('All Progressives Congress')
-    end
-
-    it 'displays the person area name' do
-      person.css('p').text.must_include('Maiduguri (Metropolitan)')
+            .must_include('250x250.jpeg')
     end
 
     it 'displays all types of people' do
-      subject.css('.homepage__reps__rep .btn-default').count.must_equal(3)
+      subject.css('.homepage__reps__rep .btn-default').map(&:text).map(&:strip).uniq.sort
+             .must_equal(%w[Governors Representatives Senators])
     end
 
     it 'displays link to Senators' do
-      subject.css('.homepage__reps__rep .btn-default/@href')[1].text
+      subject.css('.homepage__reps__rep .btn-default/@href')[10].text
              .must_equal('/position/senator/')
     end
 
     it 'displays the Senators label' do
-      subject.css('.homepage__reps__rep .btn-default')[1].text.strip
+      subject.css('.homepage__reps__rep .btn-default')[10].text.strip
              .must_equal('Senators')
     end
 

--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -29,11 +29,11 @@
     <h2>Find more information about your government representatives</h2>
     <div class="row">
       <% @page.government_representative_types.each do |type| %>
-        <div>
-          <% type.people.each do |person| %>
-            <div class="col-sm-4 homepage__reps__rep">
+        <div class="col-sm-4 js-show-random-child">
+          <% type.people.each_with_index do |person, i| %>
+            <div class="homepage__reps__rep <%= 'hidden' unless i == 0 %>">
               <a href="<%= person.url %>">
-                  <img src="<%= person.medium_image_url %>">
+                  <img <% if i == 0 %>src<% else %>data-src<% end %>="<%= person.medium_image_url %>">
               </a>
               <p>
                   <strong><%= person.name %></strong>,
@@ -82,3 +82,7 @@
     </div>
   </div>
 </div>
+
+<% content_for :footer_extra_js do %>
+  <script src="/javascripts/show-random-child.js"></script>
+<% end %>

--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -28,22 +28,24 @@
   <div class="container">
     <h2>Find more information about your government representatives</h2>
     <div class="row">
-      <% @page.featured_people.each do |page_fragment| %>
-        <% if page_fragment.featured_person %>
-        <div class="col-sm-4 homepage__reps__rep">
-            <a href="<%= page_fragment.featured_person.url %>">
-                <img src="<%= page_fragment.featured_person.medium_image_url %>">
-            </a>
-            <p>
-                <strong><%= page_fragment.featured_person.name %></strong>,
-                <%= page_fragment.featured_person.party_name %>,
-                <%= page_fragment.featured_person.area.name if page_fragment.featured_person.area %>
-            </p>
-            <a class="btn btn-default" href="<%= page_fragment.people_type_url %>">
-                <strong><%= page_fragment.people_type_display_text %></strong>
-            </a>
+      <% @page.government_representative_types.each do |type| %>
+        <div>
+          <% type.people.each do |person| %>
+            <div class="col-sm-4 homepage__reps__rep">
+              <a href="<%= person.url %>">
+                  <img src="<%= person.medium_image_url %>">
+              </a>
+              <p>
+                  <strong><%= person.name %></strong>,
+                  <%= person.party_name %>,
+                  <%= person.area.name if person.area %>
+              </p>
+              <a class="btn btn-default" href="<%= type.link_url %>">
+                  <strong><%= type.link_text %></strong>
+              </a>
+            </div>
+          <% end %>
         </div>
-        <% end %>
       <% end %>
     </div>
   </div>

--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -29,7 +29,8 @@
     <h2>Find more information about your government representatives</h2>
     <div class="row">
       <% @page.government_representative_types.each do |type| %>
-        <div class="col-sm-4 js-show-random-child">
+        <div class="col-sm-4">
+          <div class="js-show-random-child">
           <% type.people.each_with_index do |person, i| %>
             <div class="homepage__reps__rep <%= 'hidden' unless i == 0 %>">
               <a href="<%= person.url %>">
@@ -40,11 +41,12 @@
                   <%= person.party_name %>,
                   <%= person.area.name if person.area %>
               </p>
-              <a class="btn btn-default" href="<%= type.link_url %>">
-                  <strong><%= type.link_text %></strong>
-              </a>
             </div>
           <% end %>
+          </div>
+          <a class="btn btn-default" href="<%= type.link_url %>">
+              <strong><%= type.link_text %></strong>
+          </a>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
Each time the site is rebuilt, 10 representatives of each type are randomly selected for inclusion on the homepage.

The details of all 30 representatives are baked into the markup of the homepage, but only the first representative in each of these groups is actually made _visible_ to website visitors, by default.

We then use JavaScript to randomly select one representative from each group, to show.

The end result is that, in browsers with JavaScript support, each time the homepage is loaded, it will give the _effect_ of a random selection of representatives being shown. But in actuality, there are only 10 possible reps in each group.

We’re hoping 10 will be a good balance of "freshness" versus HTML markup bloat – but we can easily increase the number if Yemi / Seun feel the same few faces keep popping up too often.

Fixes #190